### PR TITLE
`processTransaction` and `processReceipt`

### DIFF
--- a/src/signer/index.ts
+++ b/src/signer/index.ts
@@ -100,6 +100,7 @@ export type RainSolverPrivateKeySigner = RainSolverSigner<PrivateKeyAccount>;
 export type RawTransaction = Prettify<
     Omit<TransactionRequestBase, "to"> & {
         to: `0x${string}`;
+        gasPrice?: bigint;
     }
 >;
 

--- a/src/solver/process/receipt.test.ts
+++ b/src/solver/process/receipt.test.ts
@@ -1,0 +1,383 @@
+import { BigNumber } from "ethers";
+import { Token } from "sushi/currency";
+import { TransactionReceipt } from "viem";
+import { handleRevert } from "../../error";
+import { RainSolverSigner } from "../../signer";
+import { OpStackTransactionReceipt } from "viem/chains";
+import { ProcessOrderHaltReason, ProcessOrderStatus } from "../types";
+import { describe, it, expect, vi, beforeEach, Mock, assert } from "vitest";
+import { sleep, getActualClearAmount, getIncome, getTotalIncome } from "../../utils";
+import { getL1Fee, tryGetReceipt, processReceipt, ProcessReceiptArgs } from "./receipt";
+
+vi.mock("../../error", () => ({
+    handleRevert: vi.fn(),
+}));
+
+vi.mock("../../utils", async (importOriginal) => ({
+    ...(await importOriginal()),
+    sleep: vi.fn(),
+    getIncome: vi.fn(),
+    getTotalIncome: vi.fn(),
+    getActualClearAmount: vi.fn(),
+}));
+
+describe("Test processReceipt", () => {
+    let mockSigner: RainSolverSigner;
+    let mockArgs: ProcessReceiptArgs;
+    let mockReceipt: TransactionReceipt;
+
+    beforeEach(() => {
+        vi.clearAllMocks();
+
+        // mock signer
+        mockSigner = {
+            account: {
+                address: "0xSignerAddress",
+            },
+            getSelfBalance: vi.fn().mockResolvedValue("1000000000000000000"),
+        } as any;
+
+        // mock receipt
+        mockReceipt = {
+            status: "success",
+            transactionHash: "0xTxHash123",
+            gasUsed: 21000n,
+            effectiveGasPrice: 20000000000n,
+        } as any as TransactionReceipt;
+
+        // mock arguments
+        mockArgs = {
+            receipt: mockReceipt,
+            signer: mockSigner,
+            rawtx: {
+                to: "0xContractAddress",
+                data: "0xTxData",
+            },
+            orderbook: "0xOrderbookAddress",
+            inputToEthPrice: "2000.0",
+            outputToEthPrice: "1.0",
+            baseResult: {
+                tokenPair: "ETH/USDC",
+                buyToken: "0xUSDC",
+                sellToken: "0xETH",
+                spanAttributes: {},
+                status: ProcessOrderStatus.FoundOpportunity,
+            },
+            txUrl: "https://etherscan.io/tx/0xTxHash123",
+            toToken: {
+                address: "0xUSDC",
+                decimals: 6,
+                symbol: "USDC",
+            } as any as Token,
+            fromToken: {
+                address: "0xETH",
+                decimals: 18,
+                symbol: "ETH",
+            } as any as Token,
+            txSendTime: Date.now(),
+        };
+    });
+
+    describe("successful receipt processing", () => {
+        it("should process successful receipt and return ok result", async () => {
+            const mockClearAmount = BigNumber.from("1000000");
+            const mockInputIncome = BigNumber.from("2000000000");
+            const mockOutputIncome = BigNumber.from("1000000000000000000");
+            const mockTotalIncome = BigNumber.from("4000000000000000000");
+            (getActualClearAmount as Mock).mockReturnValue(mockClearAmount);
+            (getIncome as Mock)
+                .mockReturnValueOnce(mockInputIncome) // input token income
+                .mockReturnValueOnce(mockOutputIncome); // output token income
+            (getTotalIncome as Mock).mockReturnValue(mockTotalIncome);
+            const result = await processReceipt(mockArgs);
+
+            assert(result.isOk());
+            expect(result.value.status).toBe(ProcessOrderStatus.FoundOpportunity);
+            expect(result.value.clearedAmount).toBe(mockClearAmount.toString());
+            expect(result.value.gasCost).toBe(420000000000000n); // gasUsed * effectiveGasPrice
+            expect(result.value.income).toBe(mockTotalIncome.toBigInt());
+            expect(result.value.inputTokenIncome).toBe("2000");
+            expect(result.value.outputTokenIncome).toBe("1");
+            expect(result.value.netProfit).toBeDefined();
+            expect(result.value.spanAttributes["didClear"]).toBe(true);
+            expect(result.value.spanAttributes["details.actualGasCost"]).toBeDefined();
+            expect(result.value.spanAttributes["details.actualGasCost"]).toBeTypeOf("number");
+            expect(result.value.spanAttributes["details.income"]).toBeDefined();
+            expect(result.value.spanAttributes["details.income"]).toBeTypeOf("number");
+            expect(result.value.spanAttributes["details.inputTokenIncome"]).toBeDefined();
+            expect(result.value.spanAttributes["details.inputTokenIncome"]).toBe("2000");
+            expect(result.value.spanAttributes["details.outputTokenIncome"]).toBeDefined();
+            expect(result.value.spanAttributes["details.outputTokenIncome"]).toBe("1");
+            expect(result.value.spanAttributes["details.netProfit"]).toBeDefined();
+            expect(result.value.spanAttributes["details.netProfit"]).toBeTypeOf("number");
+            expect(result.value.spanAttributes["details.gasCostL1"]).toBeUndefined();
+        });
+
+        it("should calculate gas cost correctly including L1 fee", async () => {
+            mockArgs.receipt = {
+                ...mockReceipt,
+                l1Fee: 50000000000000n,
+            } as any;
+            (getActualClearAmount as Mock).mockReturnValue(BigNumber.from("1000000"));
+            (getIncome as Mock).mockReturnValue(undefined);
+            (getTotalIncome as Mock).mockReturnValue(undefined);
+            const result = await processReceipt(mockArgs);
+
+            assert(result.isOk());
+            expect(result.value.gasCost).toBe(470000000000000n);
+            expect(mockArgs.baseResult.spanAttributes["details.gasCostL1"]).toBeDefined();
+        });
+
+        it("should handle case with no income", async () => {
+            (getActualClearAmount as Mock).mockReturnValue(BigNumber.from("1000000"));
+            (getIncome as Mock).mockReturnValue(undefined);
+            (getTotalIncome as Mock).mockReturnValue(undefined);
+
+            const result = await processReceipt(mockArgs);
+
+            assert(result.isOk());
+            expect(result.value.income).toBeUndefined();
+            expect(result.value.netProfit).toBeUndefined();
+            expect(result.value.inputTokenIncome).toBeUndefined();
+            expect(result.value.outputTokenIncome).toBeUndefined();
+        });
+    });
+
+    describe("failed receipt processing", () => {
+        beforeEach(() => {
+            mockArgs.receipt = {
+                ...mockReceipt,
+                status: "reverted",
+            } as TransactionReceipt;
+        });
+
+        it("should process reverted receipt and return error result", async () => {
+            const mockSimulation = {
+                snapshot: "Transaction reverted: insufficient balance",
+                nodeError: false,
+            };
+            (handleRevert as Mock).mockResolvedValue(mockSimulation);
+            const result = await processReceipt(mockArgs);
+
+            assert(result.isErr());
+            expect(result.error.reason).toBe(ProcessOrderHaltReason.TxReverted);
+            expect(result.error.error).toBe(mockSimulation);
+            expect(result.error.txUrl).toBe(mockArgs.txUrl);
+            expect(result.error.spanAttributes["txNoneNodeError"]).toBe(true);
+        });
+
+        it("should retry handleRevert when simulation fails to find revert reason", async () => {
+            const firstSimulation = {
+                snapshot: "simulation failed to find the revert reason",
+                nodeError: false,
+            };
+            const retrySimulation = {
+                snapshot: "Transaction reverted: gas limit exceeded",
+                nodeError: false,
+            };
+            (handleRevert as Mock)
+                .mockResolvedValueOnce(firstSimulation)
+                .mockResolvedValueOnce(retrySimulation);
+            const result = await processReceipt(mockArgs);
+
+            expect(sleep).toHaveBeenCalledWith(expect.any(Number));
+            expect(handleRevert as Mock).toHaveBeenCalledTimes(2);
+            assert(result.isErr());
+            expect(result.error.reason).toBe(ProcessOrderHaltReason.TxReverted);
+            expect(result.error.error).toBe(retrySimulation);
+        });
+
+        it("should handle node error correctly in span attributes", async () => {
+            const mockSimulation = {
+                snapshot: "Node connection failed",
+                nodeError: true,
+            };
+            (handleRevert as Mock).mockResolvedValue(mockSimulation);
+            const result = await processReceipt(mockArgs);
+
+            assert(result.isErr());
+            expect(result.error.spanAttributes["txNoneNodeError"]).toBe(false);
+        });
+
+        it("should call handleRevert with correct parameters", async () => {
+            const mockBalance = BigNumber.from("1000000000000000000");
+            (handleRevert as Mock).mockResolvedValue({ snapshot: "test", nodeError: false });
+            await processReceipt(mockArgs);
+
+            expect(handleRevert as Mock).toHaveBeenCalledWith(
+                mockSigner,
+                mockArgs.receipt.transactionHash,
+                mockArgs.receipt,
+                mockArgs.rawtx,
+                mockBalance,
+                mockArgs.orderbook,
+            );
+        });
+    });
+});
+
+describe("Test getL1Fee", () => {
+    let mockStandardReceipt: TransactionReceipt;
+
+    beforeEach(() => {
+        mockStandardReceipt = {
+            transactionHash: "0xHash123",
+            blockNumber: 12345n,
+            gasUsed: 21000n,
+            effectiveGasPrice: 20000000000n,
+            status: "success",
+        } as any as TransactionReceipt;
+    });
+
+    describe("receipts with no L1 fees", () => {
+        it("should return 0n when when receipt does not contains l1 fees", () => {
+            const result = getL1Fee(mockStandardReceipt);
+            expect(result).toBe(0n);
+        });
+    });
+
+    describe("receipts with L1 fees", () => {
+        it("should return l1Fee when receipt has l1Fee property", () => {
+            const l1Fee = 75000000000000n;
+            const receiptWithL1Fee = {
+                ...mockStandardReceipt,
+                l1Fee,
+            } as OpStackTransactionReceipt;
+            const result = getL1Fee(receiptWithL1Fee);
+
+            expect(result).toBe(l1Fee);
+        });
+    });
+
+    describe("receipts with L1 gas properties", () => {
+        it("should calculate and return l1GasPrice * l1GasUsed", () => {
+            const l1GasPrice = 15000000000n;
+            const l1GasUsed = 2100n;
+            const expectedFee = l1GasPrice * l1GasUsed;
+            const receiptWithL1Gas = {
+                ...mockStandardReceipt,
+                l1GasPrice,
+                l1GasUsed,
+            } as OpStackTransactionReceipt;
+
+            const result = getL1Fee(receiptWithL1Gas);
+
+            expect(result).toBe(expectedFee);
+            expect(result).toBe(31500000000000n);
+        });
+    });
+});
+
+describe("Test tryGetReceipt", () => {
+    let mockSigner: RainSolverSigner;
+    let mockClient: any;
+    const mockTxHash =
+        "0x1234567890123456789012345678901234567890123456789012345678901234" as `0x${string}`;
+
+    beforeEach(() => {
+        vi.clearAllMocks();
+
+        // mock client with receipt methods
+        mockClient = {
+            waitForTransactionReceipt: vi.fn(),
+            getTransactionReceipt: vi.fn(),
+        };
+
+        // mock signer
+        mockSigner = {
+            state: {
+                client: mockClient,
+            },
+        } as RainSolverSigner;
+    });
+
+    describe("successful waitForTransactionReceipt", () => {
+        it("should return receipt when waitForTransactionReceipt succeeds", async () => {
+            const mockReceipt: TransactionReceipt = {
+                transactionHash: mockTxHash,
+                blockNumber: 12345n,
+                gasUsed: 21000n,
+                effectiveGasPrice: 20000000000n,
+                status: "success",
+            } as TransactionReceipt;
+            mockClient.waitForTransactionReceipt.mockResolvedValueOnce(mockReceipt);
+            const result = await tryGetReceipt(mockSigner, mockTxHash, Date.now());
+
+            expect(result).toBe(mockReceipt);
+            expect(mockClient.waitForTransactionReceipt).toHaveBeenCalledWith({
+                hash: mockTxHash,
+                confirmations: 1,
+                timeout: 120_000,
+            });
+            expect(mockClient.waitForTransactionReceipt).toHaveBeenCalledTimes(1);
+            expect(mockClient.getTransactionReceipt).not.toHaveBeenCalled();
+        });
+
+        it("should call waitForTransactionReceipt with correct parameters", async () => {
+            const mockReceipt: TransactionReceipt = {
+                transactionHash: mockTxHash,
+                status: "success",
+            } as TransactionReceipt;
+            mockClient.waitForTransactionReceipt.mockResolvedValueOnce(mockReceipt);
+            await tryGetReceipt(mockSigner, mockTxHash, Date.now());
+
+            expect(mockClient.waitForTransactionReceipt).toHaveBeenCalledWith({
+                hash: mockTxHash,
+                confirmations: 1,
+                timeout: 120_000,
+            });
+        });
+    });
+
+    describe("waitForTransactionReceipt failure fallback", () => {
+        it("should fallback to getTransactionReceipt when waitForTransactionReceipt fails", async () => {
+            const mockReceipt: TransactionReceipt = {
+                transactionHash: mockTxHash,
+                blockNumber: 12345n,
+                status: "success",
+            } as TransactionReceipt;
+            mockClient.waitForTransactionReceipt.mockRejectedValueOnce(new Error("Timeout"));
+            mockClient.getTransactionReceipt.mockResolvedValueOnce(mockReceipt);
+            const result = await tryGetReceipt(mockSigner, mockTxHash, Date.now());
+
+            expect(result).toBe(mockReceipt);
+            expect(mockClient.waitForTransactionReceipt).toHaveBeenCalledTimes(1);
+            expect(sleep as Mock).toHaveBeenCalledTimes(1);
+            expect(mockClient.getTransactionReceipt).toHaveBeenCalledWith({
+                hash: mockTxHash,
+            });
+            expect(mockClient.getTransactionReceipt).toHaveBeenCalledTimes(1);
+        });
+
+        it("should call getTransactionReceipt with correct parameters", async () => {
+            const mockReceipt: TransactionReceipt = {
+                transactionHash: mockTxHash,
+                status: "success",
+            } as TransactionReceipt;
+            mockClient.waitForTransactionReceipt.mockRejectedValueOnce(new Error("Network error"));
+            mockClient.getTransactionReceipt.mockResolvedValueOnce(mockReceipt);
+            await tryGetReceipt(mockSigner, mockTxHash, Date.now());
+
+            expect(mockClient.getTransactionReceipt).toHaveBeenCalledWith({
+                hash: mockTxHash,
+            });
+        });
+    });
+
+    describe("error propagation", () => {
+        it("should propagate error when getTransactionReceipt also fails", async () => {
+            const waitError = new Error("Wait timeout");
+            const getError = new Error("Receipt not found");
+
+            mockClient.waitForTransactionReceipt.mockRejectedValueOnce(waitError);
+            mockClient.getTransactionReceipt.mockRejectedValueOnce(getError);
+
+            await expect(tryGetReceipt(mockSigner, mockTxHash, Date.now())).rejects.toThrow(
+                "Receipt not found",
+            );
+
+            expect(mockClient.waitForTransactionReceipt).toHaveBeenCalledTimes(1);
+            expect(mockClient.getTransactionReceipt).toHaveBeenCalledTimes(1);
+        });
+    });
+});

--- a/src/solver/process/receipt.ts
+++ b/src/solver/process/receipt.ts
@@ -1,0 +1,191 @@
+import { BigNumber } from "ethers";
+import { Result } from "../../result";
+import { Token } from "sushi/currency";
+import { handleRevert } from "../../error";
+import { formatUnits, TransactionReceipt } from "viem";
+import { OpStackTransactionReceipt } from "viem/chains";
+import { RainSolverSigner, RawTransaction } from "../../signer";
+import { sleep, toNumber, getIncome, getTotalIncome, getActualClearAmount } from "../../utils";
+import {
+    ProcessOrderFailure,
+    ProcessOrderSuccess,
+    ProcessOrderHaltReason,
+    ProcessOrderResultBase,
+} from "../types";
+
+/** Arguments for processing a transaction receipt */
+export type ProcessReceiptArgs = {
+    signer: RainSolverSigner;
+    rawtx: RawTransaction;
+    orderbook: `0x${string}`;
+    inputToEthPrice: string;
+    outputToEthPrice: string;
+    baseResult: ProcessOrderResultBase;
+    toToken: Token;
+    fromToken: Token;
+    receipt: TransactionReceipt;
+    txUrl: string;
+    txSendTime: number;
+};
+
+/**
+ * Processes the transaction receipt after the transaction has been sent
+ * @param args - The arguments for processing the receipt
+ * @returns A promise that resolves to the result of processing the receipt
+ */
+export async function processReceipt({
+    rawtx,
+    txUrl,
+    signer,
+    receipt,
+    toToken,
+    fromToken,
+    orderbook,
+    txSendTime,
+    baseResult,
+    inputToEthPrice,
+    outputToEthPrice,
+}: ProcessReceiptArgs): Promise<Result<ProcessOrderSuccess, ProcessOrderFailure>> {
+    const l1Fee = getL1Fee(receipt);
+    const gasCost = receipt.effectiveGasPrice * receipt.gasUsed + l1Fee;
+
+    // keep track of gas consumption of the account and bounty token
+    baseResult.gasCost = gasCost;
+
+    if (receipt.status === "success") {
+        baseResult.spanAttributes["didClear"] = true;
+
+        const clearActualAmount = getActualClearAmount(rawtx.to, orderbook, receipt);
+        const inputTokenIncome = getIncome(signer.account.address, receipt, toToken.address);
+        const outputTokenIncome = getIncome(signer.account.address, receipt, fromToken.address);
+        const income = getTotalIncome(
+            inputTokenIncome,
+            outputTokenIncome,
+            inputToEthPrice,
+            outputToEthPrice,
+            toToken.decimals,
+            fromToken.decimals,
+        );
+        const netProfit = income ? income.sub(gasCost) : undefined;
+
+        baseResult.spanAttributes["details.actualGasCost"] = toNumber(gasCost);
+        if (l1Fee) {
+            baseResult.spanAttributes["details.gasCostL1"] = toNumber(l1Fee);
+        }
+        if (income) {
+            baseResult.spanAttributes["details.income"] = toNumber(income);
+            baseResult.spanAttributes["details.netProfit"] = toNumber(netProfit!);
+        }
+        if (inputTokenIncome) {
+            baseResult.spanAttributes["details.inputTokenIncome"] = formatUnits(
+                inputTokenIncome.toBigInt(),
+                toToken.decimals,
+            );
+        }
+        if (outputTokenIncome) {
+            baseResult.spanAttributes["details.outputTokenIncome"] = formatUnits(
+                outputTokenIncome.toBigInt(),
+                fromToken.decimals,
+            );
+        }
+
+        const success: ProcessOrderSuccess = {
+            ...baseResult,
+            clearedAmount: clearActualAmount?.toString(),
+            gasCost: gasCost,
+            income: income?.toBigInt(),
+            inputTokenIncome: baseResult.spanAttributes["details.inputTokenIncome"] as any,
+            outputTokenIncome: baseResult.spanAttributes["details.outputTokenIncome"] as any,
+            netProfit: netProfit?.toBigInt(),
+        };
+
+        return Result.ok({
+            ...baseResult,
+            ...success,
+        });
+    } else {
+        const simulation = await (async () => {
+            const signerBalance = BigNumber.from(await signer.getSelfBalance());
+            const result = await handleRevert(
+                signer,
+                receipt.transactionHash,
+                receipt,
+                rawtx,
+                signerBalance,
+                orderbook,
+            );
+            if (result.snapshot.includes("simulation failed to find the revert reason")) {
+                // wait at least 90s before simulating the revert tx
+                // in order for rpcs to catch up, this is concurrent to
+                // whole bot operation, so ideally all of it or at least
+                // partially will overlap with when bot is processing other
+                // orders
+                await sleep(Math.max(90_000 + txSendTime - Date.now(), 0));
+                return await handleRevert(
+                    signer,
+                    receipt.transactionHash,
+                    receipt,
+                    rawtx,
+                    signerBalance,
+                    orderbook,
+                );
+            } else {
+                return result;
+            }
+        })();
+        if (simulation) {
+            baseResult.spanAttributes["txNoneNodeError"] = !simulation.nodeError;
+        }
+        const failure: ProcessOrderFailure = {
+            ...baseResult,
+            txUrl,
+            error: simulation,
+            reason: ProcessOrderHaltReason.TxReverted,
+        };
+        return Result.err(failure);
+    }
+}
+
+/**
+ * Tries to get the transaction receipt for a given transaction hash
+ * @param signer - The RainSolverSigner instance
+ * @param hash - The transaction hash
+ * @param txSendTime - The time the transaction was sent
+ */
+export async function tryGetReceipt(
+    signer: RainSolverSigner,
+    hash: `0x${string}`,
+    txSendTime: number,
+): Promise<TransactionReceipt> {
+    try {
+        return await signer.state.client.waitForTransactionReceipt({
+            hash,
+            confirmations: 1,
+            timeout: 120_000,
+        });
+    } catch {
+        // in case waiting for tx receipt was unsuccessful, try getting the receipt directly
+        await sleep(Math.max(90_000 + txSendTime - Date.now(), 0));
+        return await signer.state.client.getTransactionReceipt({ hash });
+    }
+}
+
+/**
+ * Returns the L1 gas cost of a transaction
+ * @param receipt - The transaction receipt
+ * @returns The L1 fee as a bigint, or 0n if not applicable
+ */
+export function getL1Fee(receipt: OpStackTransactionReceipt | TransactionReceipt): bigint {
+    if ("l1Fee" in receipt && typeof receipt.l1Fee === "bigint") {
+        return receipt.l1Fee;
+    } else if (
+        "l1GasPrice" in receipt &&
+        "l1GasUsed" in receipt &&
+        typeof receipt.l1GasPrice === "bigint" &&
+        typeof receipt.l1GasUsed === "bigint"
+    ) {
+        return (receipt.l1GasPrice as bigint) * (receipt.l1GasUsed as bigint);
+    } else {
+        return 0n;
+    }
+}

--- a/src/solver/process/transaction.test.ts
+++ b/src/solver/process/transaction.test.ts
@@ -1,0 +1,280 @@
+import { BaseError } from "viem";
+import { Result } from "../../result";
+import { Token } from "sushi/currency";
+import { processReceipt } from "./receipt";
+import { containsNodeError } from "../../error";
+import { sleep, withBigintSerializer } from "../../utils";
+import { RainSolverSigner, RawTransaction } from "../../signer";
+import { processTransaction, ProcessTransactionArgs } from "./transaction";
+import { describe, it, expect, vi, beforeEach, Mock, assert } from "vitest";
+import {
+    ProcessOrderFailure,
+    ProcessOrderHaltReason,
+    ProcessOrderStatus,
+    ProcessOrderSuccess,
+} from "../types";
+
+// mock dependencies
+vi.mock("../../error", () => ({
+    containsNodeError: vi.fn(),
+}));
+
+vi.mock("./receipt", async (importOriginal) => ({
+    ...(await importOriginal()),
+    processReceipt: vi.fn(),
+}));
+
+vi.mock("../../utils", async (importOriginal) => {
+    const org: any = await importOriginal();
+    return {
+        ...org,
+        sleep: vi.fn(),
+        withBigintSerializer: vi.spyOn(org, "withBigintSerializer"),
+    };
+});
+
+describe("Test processTransaction", () => {
+    let mockSigner: RainSolverSigner;
+    let mockRawTx: RawTransaction;
+    let mockArgs: ProcessTransactionArgs;
+    let mockWriteSigner: any;
+
+    beforeEach(() => {
+        vi.clearAllMocks();
+
+        // mock write signer
+        mockWriteSigner = {
+            sendTx: vi.fn(),
+        };
+
+        // mock RainSolverSigner
+        mockSigner = {
+            account: {
+                address: "0xSignerAddress",
+            },
+            state: {
+                client: {
+                    waitForTransactionReceipt: vi.fn(),
+                    getTransactionReceipt: vi.fn(),
+                },
+                chainConfig: {
+                    isSpecialL2: false,
+                    blockExplorers: {
+                        default: {
+                            url: "https://etherscan.io",
+                        },
+                    },
+                },
+            },
+            asWriteSigner: vi.fn().mockReturnValue(mockWriteSigner),
+        } as any;
+
+        // mock raw transaction
+        mockRawTx = {
+            to: "0xContractAddress",
+            data: "0xTransactionData",
+            value: 0n,
+            gas: 21000n,
+            gasPrice: 20000000000n,
+        };
+
+        // mock arguments
+        mockArgs = {
+            signer: mockSigner,
+            rawtx: mockRawTx,
+            orderbook: "0xOrderbookAddress",
+            inputToEthPrice: "2000.0",
+            outputToEthPrice: "1.0",
+            baseResult: {
+                tokenPair: "ETH/USDC",
+                buyToken: "0xUSDC",
+                sellToken: "0xETH",
+                spanAttributes: {},
+                status: ProcessOrderStatus.FoundOpportunity,
+            },
+            toToken: {
+                address: "0xUSDC",
+                decimals: 6,
+                symbol: "USDC",
+            } as any as Token,
+            fromToken: {
+                address: "0xETH",
+                decimals: 18,
+                symbol: "ETH",
+            } as any as Token,
+        };
+    });
+
+    describe("successful transaction sending", () => {
+        it("should send transaction successfully on first attempt", async () => {
+            const mockTxHash = "0xTransactionHash123";
+            mockWriteSigner.sendTx.mockResolvedValueOnce(mockTxHash);
+            const mockReceipt = {
+                status: "success",
+                transactionHash: mockTxHash,
+                gasUsed: 21000n,
+                effectiveGasPrice: 20000000000n,
+            };
+            (mockSigner.state.client.waitForTransactionReceipt as Mock).mockResolvedValueOnce(
+                mockReceipt,
+            );
+            const mockHandleReceiptResult = Result.ok<ProcessOrderSuccess, ProcessOrderFailure>({
+                ...mockArgs.baseResult,
+                clearedAmount: "100",
+                gasCost: 420000000000000n,
+            });
+            (processReceipt as Mock).mockResolvedValueOnce(mockHandleReceiptResult);
+            const settlerFn = await processTransaction(mockArgs);
+            const result = await settlerFn();
+
+            // verify transaction was sent with correct parameters
+            expect(mockWriteSigner.sendTx).toHaveBeenCalledWith({
+                ...mockRawTx,
+                type: "legacy",
+            });
+            expect(mockWriteSigner.sendTx).toHaveBeenCalledTimes(1);
+
+            // verify span attributes were set
+            expect(mockArgs.baseResult.spanAttributes["details.txUrl"]).toBe(
+                "https://etherscan.io/tx/0xTransactionHash123",
+            );
+
+            // verify processReceipt was called with correct parameters
+            expect(processReceipt as Mock).toHaveBeenCalledWith({
+                receipt: mockReceipt,
+                signer: mockSigner,
+                rawtx: mockRawTx,
+                orderbook: mockArgs.orderbook,
+                inputToEthPrice: mockArgs.inputToEthPrice,
+                outputToEthPrice: mockArgs.outputToEthPrice,
+                baseResult: mockArgs.baseResult,
+                txUrl: "https://etherscan.io/tx/0xTransactionHash123",
+                toToken: mockArgs.toToken,
+                fromToken: mockArgs.fromToken,
+                txSendTime: expect.any(Number),
+            });
+
+            // verify result is passed through from processReceipt
+            expect(result).toBe(mockHandleReceiptResult);
+        });
+
+        it("should retry transaction sending after first failure", async () => {
+            const mockTxHash = "0xRetryTxHash456";
+            const mockError = new Error("Network error");
+            mockWriteSigner.sendTx
+                .mockRejectedValueOnce(mockError) // First attempt fails
+                .mockResolvedValueOnce(mockTxHash); // Second attempt succeeds
+            const mockReceipt = {
+                status: "success",
+                transactionHash: mockTxHash,
+                gasUsed: 21000n,
+                effectiveGasPrice: 20000000000n,
+            };
+            (mockSigner.state.client.waitForTransactionReceipt as Mock).mockResolvedValueOnce(
+                mockReceipt,
+            );
+            (processReceipt as Mock).mockResolvedValueOnce(Result.ok(mockArgs.baseResult));
+            const settlerFn = await processTransaction(mockArgs);
+            await settlerFn();
+
+            // verify sleep was called for retry delay
+            expect(sleep).toHaveBeenCalledWith(5000);
+
+            // verify transaction was attempted twice
+            expect(mockWriteSigner.sendTx).toHaveBeenCalledTimes(2);
+
+            // verify final success with retry hash
+            expect(mockArgs.baseResult.spanAttributes["details.txUrl"]).toBe(
+                "https://etherscan.io/tx/0xRetryTxHash456",
+            );
+        });
+    });
+
+    describe("transaction sending failures", () => {
+        it("should return error result when both send attempts fail", async () => {
+            const mockError = new Error("Persistent network error");
+            mockWriteSigner.sendTx.mockRejectedValue(mockError);
+            (containsNodeError as Mock).mockReturnValue(false);
+            const settlerFn = await processTransaction(mockArgs);
+            const result = await settlerFn();
+
+            // verify error result structure
+            assert(result.isErr());
+            expect(result.error).toEqual({
+                ...mockArgs.baseResult,
+                error: mockError,
+                reason: ProcessOrderHaltReason.TxFailed,
+            });
+
+            // verify raw transaction was logged
+            expect(mockArgs.baseResult.spanAttributes["details.rawTx"]).toBeDefined();
+            expect(mockArgs.baseResult.spanAttributes["txNoneNodeError"]).toBe(true);
+            expect(withBigintSerializer).toHaveBeenCalledTimes(7);
+        });
+
+        it("should correctly identify node errors in transaction failures", async () => {
+            const mockNodeError = new BaseError("Node connection failed");
+            mockWriteSigner.sendTx.mockRejectedValue(mockNodeError);
+            (containsNodeError as Mock).mockReturnValue(true);
+            const settlerFn = await processTransaction(mockArgs);
+            const result = await settlerFn();
+
+            assert(result.isErr());
+            expect(mockArgs.baseResult.spanAttributes["txNoneNodeError"]).toBe(false);
+            expect(containsNodeError).toHaveBeenCalledWith(mockNodeError);
+        });
+    });
+
+    describe("receipt processing failures", () => {
+        it("should return error result when receipt retrieval fails completely", async () => {
+            const mockTxHash = "0xFailedReceiptHash";
+            const receiptError = new Error("Receipt retrieval failed");
+            mockWriteSigner.sendTx.mockResolvedValueOnce(mockTxHash);
+            (mockSigner.state.client.waitForTransactionReceipt as Mock).mockRejectedValueOnce(
+                receiptError,
+            );
+            (mockSigner.state.client.getTransactionReceipt as Mock).mockRejectedValue(receiptError);
+            (containsNodeError as Mock).mockReturnValue(true);
+            const settlerFn = await processTransaction(mockArgs);
+            const result = await settlerFn();
+
+            assert(result.isErr());
+            expect(result.error).toEqual({
+                ...mockArgs.baseResult,
+                txUrl: "https://etherscan.io/tx/0xFailedReceiptHash",
+                reason: ProcessOrderHaltReason.TxMineFailed,
+                error: receiptError,
+            });
+            expect(result.error.spanAttributes["details.rawTx"]).toBeDefined();
+            expect(result.error.spanAttributes["txNoneNodeError"]).toBe(false);
+        });
+
+        it("should return error result when processReceipt throws", async () => {
+            const mockTxHash = "0xHandleReceiptFailHash";
+            const mockReceipt = {
+                status: "success",
+                transactionHash: mockTxHash,
+                gasUsed: 21000n,
+                effectiveGasPrice: 20000000000n,
+            };
+            const handleReceiptError = new Error("Handle receipt failed");
+            mockWriteSigner.sendTx.mockResolvedValueOnce(mockTxHash);
+            (mockSigner.state.client.waitForTransactionReceipt as Mock).mockResolvedValueOnce(
+                mockReceipt,
+            );
+            (processReceipt as Mock).mockRejectedValueOnce(handleReceiptError);
+            (containsNodeError as Mock).mockReturnValue(false);
+            const settlerFn = await processTransaction(mockArgs);
+            const result = await settlerFn();
+
+            assert(result.isErr());
+            expect(result.error).toEqual({
+                ...mockArgs.baseResult,
+                txUrl: "https://etherscan.io/tx/0xHandleReceiptFailHash",
+                reason: ProcessOrderHaltReason.TxMineFailed,
+                error: handleReceiptError,
+            });
+            expect(result.error.spanAttributes["txNoneNodeError"]).toBe(true);
+        });
+    });
+});

--- a/src/solver/process/transaction.ts
+++ b/src/solver/process/transaction.ts
@@ -1,0 +1,122 @@
+import { BaseError } from "viem";
+import { Result } from "../../result";
+import { Token } from "sushi/currency";
+import { containsNodeError } from "../../error";
+import { sleep, withBigintSerializer } from "../../utils";
+import { processReceipt, tryGetReceipt } from "./receipt";
+import { RainSolverSigner, RawTransaction } from "../../signer";
+import {
+    ProcessOrderSuccess,
+    ProcessOrderFailure,
+    ProcessOrderHaltReason,
+    ProcessOrderResultBase,
+} from "../types";
+
+/** Arguments for processing a transaction */
+export type ProcessTransactionArgs = {
+    signer: RainSolverSigner;
+    rawtx: RawTransaction;
+    orderbook: `0x${string}`;
+    inputToEthPrice: string;
+    outputToEthPrice: string;
+    baseResult: ProcessOrderResultBase;
+    toToken: Token;
+    fromToken: Token;
+};
+
+/**
+ * Handles the given transaction, starts by sending the transaction and
+ * then tries to get the receipt and process that in async manner, returns
+ * a function that resolves with the ProcessOrderResult type when called
+ * @param args - The arguments for processing the transaction
+ * @returns A function that returns a promise resolving to the ProcessOrderResult
+ */
+export async function processTransaction({
+    rawtx,
+    signer,
+    toToken,
+    fromToken,
+    orderbook,
+    baseResult,
+    inputToEthPrice,
+    outputToEthPrice,
+}: ProcessTransactionArgs): Promise<
+    () => Promise<Result<ProcessOrderSuccess, ProcessOrderFailure>>
+> {
+    // submit the tx
+    let txhash: `0x${string}`, txUrl: string;
+    let txSendTime = 0;
+    const sendTx = async () => {
+        txhash = await signer.asWriteSigner().sendTx({
+            ...rawtx,
+            type: "legacy",
+        });
+        txUrl = signer.state.chainConfig.blockExplorers?.default.url + "/tx/" + txhash;
+        txSendTime = Date.now();
+        // eslint-disable-next-line no-console
+        console.log("\x1b[33m%s\x1b[0m", txUrl, "\n");
+        baseResult.spanAttributes["details.txUrl"] = txUrl;
+    };
+    try {
+        await sendTx();
+    } catch (e) {
+        try {
+            // retry again after 5 seconds if first attempt failed
+            await sleep(5000);
+            await sendTx();
+        } catch {
+            // record rawtx in logs
+            baseResult.spanAttributes["details.rawTx"] = JSON.stringify(
+                {
+                    ...rawtx,
+                    from: signer.account.address,
+                },
+                withBigintSerializer,
+            );
+            baseResult.spanAttributes["txNoneNodeError"] = !containsNodeError(e as BaseError);
+            return async () =>
+                Result.err({
+                    ...baseResult,
+                    error: e,
+                    reason: ProcessOrderHaltReason.TxFailed,
+                });
+        }
+    }
+
+    // start getting tx receipt in background and return the settler fn
+    const receiptPromise = tryGetReceipt(signer, txhash!, txSendTime);
+
+    return async () => {
+        try {
+            const receipt = await receiptPromise;
+            return await processReceipt({
+                receipt,
+                signer,
+                rawtx,
+                orderbook,
+                inputToEthPrice,
+                outputToEthPrice,
+                baseResult,
+                txUrl,
+                toToken,
+                fromToken,
+                txSendTime,
+            });
+        } catch (e: any) {
+            baseResult.spanAttributes["details.rawTx"] = JSON.stringify(
+                {
+                    ...rawtx,
+                    from: signer.account.address,
+                },
+                withBigintSerializer,
+            );
+            baseResult.spanAttributes["txNoneNodeError"] = !containsNodeError(e);
+            return Result.err({
+                ...baseResult,
+                txUrl,
+                reason: ProcessOrderHaltReason.TxMineFailed,
+                error: e,
+            });
+        }
+    };
+}

--- a/src/solver/types.ts
+++ b/src/solver/types.ts
@@ -1,3 +1,5 @@
+import { Attributes } from "@opentelemetry/api";
+
 /** Specifies reason that order process halted with failure */
 export enum ProcessOrderHaltReason {
     FailedToQuote = 1,
@@ -16,3 +18,33 @@ export enum ProcessOrderStatus {
     NoOpportunity = 2,
     FoundOpportunity = 3,
 }
+
+/** Base type for process order results containing shared fields */
+export type ProcessOrderResultBase = {
+    status: ProcessOrderStatus;
+    tokenPair: string;
+    buyToken: string;
+    sellToken: string;
+    spanAttributes: Attributes;
+    txUrl?: string;
+    gasCost?: bigint;
+};
+
+/** Successful process order result */
+export type ProcessOrderSuccess = ProcessOrderResultBase & {
+    txUrl?: string;
+    clearedAmount?: string;
+    inputTokenIncome?: string;
+    outputTokenIncome?: string;
+    income?: bigint;
+    netProfit?: bigint;
+    estimatedProfit?: bigint;
+    message?: string;
+};
+
+/** Failed process order result */
+export type ProcessOrderFailure = ProcessOrderResultBase & {
+    reason: ProcessOrderHaltReason;
+    error?: any;
+    txUrl?: string;
+};


### PR DESCRIPTION
<!-- Thanks for your Pull Request, please read the contributing guidelines before submitting. -->

## Motivation
### ⚠️ Do NOT merge before #355 

Related to #341 

This PR adds:
- `processTransaction` function, responsible for submitting the given transaction to onchain and handling/reporting its result
- `processReceipt` function, responsible for handling the transaction receipt, this is called by the `processTransaction` function when the submitted transaction gets mined onchain
- extensive tests for mentioned functions
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## Checks
<!-- It's important you've done these, or your PR will not be considered for review -->
By submitting this for review, I'm confirming I've done the following:
- [x] made this PR as small as possible
- [x] unit-tested any new functionality
- [x] linked any relevant issues or PRs
- [ ] ~~included screenshots (if this involves a front-end change)~~
