### PR TITLE
pair map for order manager

### DIFF
--- a/src/order/types.ts
+++ b/src/order/types.ts
@@ -86,6 +86,7 @@ export type BundledOrders = {
 };
 
 export type Pair = {
+    orderbook: string;
     buyToken: string;
     buyTokenDecimals: number;
     buyTokenSymbol: string;
@@ -112,3 +113,7 @@ export type OrdersProfileMap = Map<string, OrderProfile>;
 export type OwnersProfileMap = Map<string, OwnerProfile>;
 
 export type OrderbooksOwnersProfileMap = Map<string, OwnersProfileMap>;
+
+export type OrderbooksPairMap = Map<string, PairMap>;
+
+export type PairMap = Map<string, Pair[]>;


### PR DESCRIPTION
<!-- Thanks for your Pull Request, please read the contributing guidelines before submitting. -->

## Motivation
### ⚠️ Do NOT merge before #358 

Related to #341 

This PR adds `pairMap` and `getOpposingOrders()` to `OrderManager` class, which is used to store references of cached order details as pairs for easy and instant access to counterparty order used in intra-ob and inter-ob clear modes
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## Checks
<!-- It's important you've done these, or your PR will not be considered for review -->
By submitting this for review, I'm confirming I've done the following:
- [x] made this PR as small as possible
- [x] unit-tested any new functionality
- [x] linked any relevant issues or PRs
- [ ] ~~included screenshots (if this involves a front-end change)~~
