### PR TITLE
inter-ob mode

### DIFF
--- a/src/abis.ts
+++ b/src/abis.ts
@@ -102,6 +102,7 @@ export const DeployerAbi = parseAbi(deployerAbi);
 export const MulticallAbi = parseAbi(multicall3Abi);
 export const Deposit2Abi = parseAbi([orderbookAbi[4]]);
 export const ArbAbi = parseAbi(arbAbis);
+export const TakeOrdersV2Abi = parseAbi([orderbookAbi[11]]);
 
 /**
  * Arbitrum node interface address, used to get L1 gas limit.

--- a/src/order/index.test.ts
+++ b/src/order/index.test.ts
@@ -541,7 +541,7 @@ describe("Test OrderManager", () => {
         const roundOrders = orderManager.getNextRoundOrders(false);
 
         // should find orderB as opposing order for orderA in the same orderbook
-        const opposing = orderManager.getOpposingOrders(roundOrders[0][0], true);
+        const opposing = orderManager.getCounterpartyOrders(roundOrders[0][0], true);
         expect(Array.isArray(opposing)).toBe(true);
         expect(opposing.length).toBe(1);
         expect(opposing[0].buyToken).toBe("0xoutput");
@@ -582,11 +582,13 @@ describe("Test OrderManager", () => {
         const roundOrders = orderManager.getNextRoundOrders(false);
 
         // should find orderB as opposing order for orderA across orderbooks
-        const opposing = orderManager.getOpposingOrders(roundOrders[0][0], false);
-        expect(Array.isArray(opposing)).toBe(true);
-        expect(opposing.length).toBe(1);
-        expect(opposing[0].buyToken).toBe("0xoutput");
-        expect(opposing[0].sellToken).toBe("0xinput");
-        expect(opposing[0].takeOrder.id).toBe("0xhashb");
+        const opposing = orderManager.getCounterpartyOrders(roundOrders[0][0], false);
+        for (const counteryparties of opposing) {
+            expect(Array.isArray(counteryparties)).toBe(true);
+            expect(counteryparties.length).toBe(1);
+            expect(counteryparties[0].buyToken).toBe("0xoutput");
+            expect(counteryparties[0].sellToken).toBe("0xinput");
+            expect(counteryparties[0].takeOrder.id).toBe("0xhashb");
+        }
     });
 });

--- a/src/solver/modes/inter/index.test.ts
+++ b/src/solver/modes/inter/index.test.ts
@@ -1,0 +1,320 @@
+import { RainSolver } from "../..";
+import { Result } from "../../../result";
+import { trySimulateTrade } from "./simulate";
+import { SimulationResult } from "../../types";
+import { BundledOrders } from "../../../order";
+import { RainSolverSigner } from "../../../signer";
+import { findBestInterOrderbookTrade } from "./index";
+import { extendObjectWithHeader } from "../../../logger";
+import { describe, it, expect, vi, beforeEach, Mock, assert } from "vitest";
+
+vi.mock("./simulate", () => ({
+    trySimulateTrade: vi.fn(),
+}));
+
+vi.mock("../../../logger", () => ({
+    extendObjectWithHeader: vi.fn(),
+}));
+
+describe("Test findBestInterOrderbookTrade", () => {
+    let mockRainSolver: RainSolver;
+    let orderDetails: BundledOrders;
+    let signer: RainSolverSigner;
+    let inputToEthPrice: string;
+    let outputToEthPrice: string;
+
+    beforeEach(() => {
+        vi.clearAllMocks();
+
+        mockRainSolver = {
+            state: {
+                client: {
+                    getBlockNumber: vi.fn().mockResolvedValue(123n),
+                },
+            },
+            orderManager: {
+                getCounterpartyOrders: vi.fn(),
+            },
+        } as any;
+
+        orderDetails = {
+            takeOrders: [{ quote: { maxOutput: 1000n } }, { quote: { maxOutput: 2000n } }],
+        } as any;
+
+        signer = { account: { address: "0xsigner" } } as any;
+        inputToEthPrice = "0.5";
+        outputToEthPrice = "2.0";
+    });
+
+    it("should return success result with highest profit when simulations succeed", async () => {
+        const mockCounterpartyOrders = [
+            [
+                { orderbook: "0xorderbook1", id: "order1" },
+                { orderbook: "0xorderbook1", id: "order2" },
+            ],
+            [{ orderbook: "0xorderbook2", id: "order3" }],
+        ];
+        (mockRainSolver.orderManager.getCounterpartyOrders as Mock).mockReturnValue(
+            mockCounterpartyOrders,
+        );
+
+        const mockResults = [
+            Result.ok({
+                spanAttributes: { foundOpp: true },
+                estimatedProfit: 100n,
+                oppBlockNumber: 123,
+            }),
+            Result.ok({
+                spanAttributes: { foundOpp: true },
+                estimatedProfit: 200n, // highest profit
+                oppBlockNumber: 123,
+            }),
+            Result.ok({
+                spanAttributes: { foundOpp: true },
+                estimatedProfit: 150n,
+                oppBlockNumber: 123,
+            }),
+        ];
+        (trySimulateTrade as Mock)
+            .mockResolvedValueOnce(mockResults[0])
+            .mockResolvedValueOnce(mockResults[1])
+            .mockResolvedValueOnce(mockResults[2]);
+
+        const result: SimulationResult = await findBestInterOrderbookTrade.call(
+            mockRainSolver,
+            orderDetails,
+            signer,
+            inputToEthPrice,
+            outputToEthPrice,
+        );
+
+        assert(result.isOk());
+        expect(result.value.spanAttributes.foundOpp).toBe(true);
+        expect(result.value.estimatedProfit).toBe(200n); // highest profit
+        expect(result.value.oppBlockNumber).toBe(123);
+        expect(mockRainSolver.orderManager.getCounterpartyOrders as Mock).toHaveBeenCalledWith(
+            orderDetails,
+            false,
+        );
+        expect(trySimulateTrade).toHaveBeenCalledTimes(3);
+    });
+
+    it("should return success result when only some simulations succeed", async () => {
+        const mockCounterpartyOrders = [
+            [
+                { orderbook: "0xorderbook1", id: "order1" },
+                { orderbook: "0xorderbook1", id: "order2" },
+            ],
+        ];
+        (mockRainSolver.orderManager.getCounterpartyOrders as Mock).mockReturnValue(
+            mockCounterpartyOrders,
+        );
+
+        const mockResults = [
+            Result.err({
+                spanAttributes: { error: "failed" },
+                noneNodeError: "simulation failed",
+            }),
+            Result.ok({
+                spanAttributes: { foundOpp: true },
+                estimatedProfit: 300n,
+                oppBlockNumber: 123,
+            }),
+        ];
+        (trySimulateTrade as Mock)
+            .mockResolvedValueOnce(mockResults[0])
+            .mockResolvedValueOnce(mockResults[1]);
+
+        const result: SimulationResult = await findBestInterOrderbookTrade.call(
+            mockRainSolver,
+            orderDetails,
+            signer,
+            inputToEthPrice,
+            outputToEthPrice,
+        );
+
+        assert(result.isOk());
+        expect(result.value.spanAttributes.foundOpp).toBe(true);
+        expect(result.value.estimatedProfit).toBe(300n);
+        expect(result.value.oppBlockNumber).toBe(123);
+        expect(trySimulateTrade).toHaveBeenCalledTimes(2);
+    });
+
+    it("should return error when all simulations fail", async () => {
+        const mockCounterpartyOrders = [
+            [{ orderbook: "0xorderbook1", id: "order1" }],
+            [{ orderbook: "0xorderbook2", id: "order2" }],
+        ];
+        (mockRainSolver.orderManager.getCounterpartyOrders as Mock).mockReturnValue(
+            mockCounterpartyOrders,
+        );
+
+        const mockResults = [
+            Result.err({
+                spanAttributes: { error: "failed1" },
+                noneNodeError: "simulation failed 1",
+            }),
+            Result.err({
+                spanAttributes: { error: "failed2" },
+                noneNodeError: "simulation failed 2",
+            }),
+        ];
+        (trySimulateTrade as Mock)
+            .mockResolvedValueOnce(mockResults[0])
+            .mockResolvedValueOnce(mockResults[1]);
+
+        const result: SimulationResult = await findBestInterOrderbookTrade.call(
+            mockRainSolver,
+            orderDetails,
+            signer,
+            inputToEthPrice,
+            outputToEthPrice,
+        );
+
+        assert(result.isErr());
+        expect(result.error.noneNodeError).toBe("simulation failed 1"); // first error
+        expect(extendObjectWithHeader).toHaveBeenCalledWith(
+            expect.any(Object),
+            { error: "failed1" },
+            "againstOrderbooks.0xorderbook1",
+        );
+        expect(extendObjectWithHeader).toHaveBeenCalledWith(
+            expect.any(Object),
+            { error: "failed2" },
+            "againstOrderbooks.0xorderbook2",
+        );
+    });
+
+    it("should handle empty counterparty orders", async () => {
+        const mockCounterpartyOrders = [];
+        (mockRainSolver.orderManager.getCounterpartyOrders as Mock).mockReturnValue(
+            mockCounterpartyOrders,
+        );
+
+        const result: SimulationResult = await findBestInterOrderbookTrade.call(
+            mockRainSolver,
+            orderDetails,
+            signer,
+            inputToEthPrice,
+            outputToEthPrice,
+        );
+
+        assert(result.isErr());
+        expect(result.error.noneNodeError).toBeUndefined();
+        expect(trySimulateTrade).not.toHaveBeenCalled();
+    });
+
+    it("should limit to top 3 counterparty orders per orderbook", async () => {
+        const mockCounterpartyOrders = [
+            [
+                { orderbook: "0xorderbook1", id: "order1" },
+                { orderbook: "0xorderbook1", id: "order2" },
+                { orderbook: "0xorderbook1", id: "order3" },
+                { orderbook: "0xorderbook1", id: "order4" }, // should be ignored
+                { orderbook: "0xorderbook1", id: "order5" }, // should be ignored
+            ],
+        ];
+        (mockRainSolver.orderManager.getCounterpartyOrders as Mock).mockReturnValue(
+            mockCounterpartyOrders,
+        );
+
+        const mockResults = [
+            Result.err({ spanAttributes: {}, noneNodeError: "error1" }),
+            Result.err({ spanAttributes: {}, noneNodeError: "error2" }),
+            Result.err({ spanAttributes: {}, noneNodeError: "error3" }),
+        ];
+        (trySimulateTrade as Mock)
+            .mockResolvedValueOnce(mockResults[0])
+            .mockResolvedValueOnce(mockResults[1])
+            .mockResolvedValueOnce(mockResults[2]);
+
+        await findBestInterOrderbookTrade.call(
+            mockRainSolver,
+            orderDetails,
+            signer,
+            inputToEthPrice,
+            outputToEthPrice,
+        );
+
+        // Should only call trySimulateTrade 3 times (top 3 orders)
+        expect(trySimulateTrade).toHaveBeenCalledTimes(3);
+    });
+
+    it("should call trySimulateTrade with correct parameters", async () => {
+        const mockCounterpartyOrders = [[{ orderbook: "0xorderbook1", id: "order1" }]];
+        (mockRainSolver.orderManager.getCounterpartyOrders as Mock).mockReturnValue(
+            mockCounterpartyOrders,
+        );
+
+        (trySimulateTrade as Mock).mockResolvedValue(
+            Result.err({
+                spanAttributes: { error: "failed" },
+                noneNodeError: "simulation failed",
+            }),
+        );
+
+        await findBestInterOrderbookTrade.call(
+            mockRainSolver,
+            orderDetails,
+            signer,
+            inputToEthPrice,
+            outputToEthPrice,
+        );
+
+        expect(trySimulateTrade).toHaveBeenCalledWith({
+            orderDetails,
+            counterpartyOrderDetails: { orderbook: "0xorderbook1", id: "order1" },
+            signer,
+            maximumInputFixed: 3000n, // 1000 + 2000
+            inputToEthPrice,
+            outputToEthPrice,
+            blockNumber: 123n,
+        });
+    });
+
+    it("should sort results by estimated profit in descending order", async () => {
+        const mockCounterpartyOrders = [
+            [
+                { orderbook: "0xorderbook1", id: "order1" },
+                { orderbook: "0xorderbook1", id: "order2" },
+                { orderbook: "0xorderbook1", id: "order3" },
+            ],
+        ];
+        (mockRainSolver.orderManager.getCounterpartyOrders as Mock).mockReturnValue(
+            mockCounterpartyOrders,
+        );
+
+        const mockResults = [
+            Result.ok({
+                spanAttributes: { foundOpp: true },
+                estimatedProfit: 50n, // lowest
+                oppBlockNumber: 123,
+            }),
+            Result.ok({
+                spanAttributes: { foundOpp: true },
+                estimatedProfit: 500n, // highest
+                oppBlockNumber: 123,
+            }),
+            Result.ok({
+                spanAttributes: { foundOpp: true },
+                estimatedProfit: 250n, // middle
+                oppBlockNumber: 123,
+            }),
+        ];
+        (trySimulateTrade as Mock)
+            .mockResolvedValueOnce(mockResults[0])
+            .mockResolvedValueOnce(mockResults[1])
+            .mockResolvedValueOnce(mockResults[2]);
+
+        const result: SimulationResult = await findBestInterOrderbookTrade.call(
+            mockRainSolver,
+            orderDetails,
+            signer,
+            inputToEthPrice,
+            outputToEthPrice,
+        );
+
+        assert(result.isOk());
+        expect(result.value.estimatedProfit).toBe(500n); // should return the highest profit
+    });
+});

--- a/src/solver/modes/inter/index.test.ts
+++ b/src/solver/modes/inter/index.test.ts
@@ -35,6 +35,9 @@ describe("Test findBestInterOrderbookTrade", () => {
             orderManager: {
                 getCounterpartyOrders: vi.fn(),
             },
+            appOptions: {
+                genericArbAddress: "0xarb",
+            },
         } as any;
 
         orderDetails = {

--- a/src/solver/modes/inter/index.ts
+++ b/src/solver/modes/inter/index.ts
@@ -25,6 +25,15 @@ export async function findBestInterOrderbookTrade(
     inputToEthPrice: string,
     outputToEthPrice: string,
 ): Promise<SimulationResult> {
+    // bail early if generic arb address is not set
+    if (!this.appOptions.genericArbAddress) {
+        return Result.err({
+            spanAttributes: {
+                error: "No generic arb address was set in config, cannot perform inter-orderbook trades",
+            },
+        });
+    }
+
     const spanAttributes: Attributes = {};
     const blockNumber = await this.state.client.getBlockNumber();
     const counterpartyOrders = this.orderManager.getCounterpartyOrders(orderDetails, false);

--- a/src/solver/modes/inter/index.ts
+++ b/src/solver/modes/inter/index.ts
@@ -1,0 +1,81 @@
+import assert from "assert";
+import { RainSolver } from "../..";
+import { Result } from "../../../result";
+import { trySimulateTrade } from "./simulate";
+import { SimulationResult } from "../../types";
+import { Attributes } from "@opentelemetry/api";
+import { RainSolverSigner } from "../../../signer";
+import { BundledOrders, Pair } from "../../../order";
+import { extendObjectWithHeader } from "../../../logger";
+
+/**
+ * Tries to find the best trade against order orderbooks (inter-orderbook) for the given order,
+ * it will simultaneously try to find the best trade against top 3 orders (by ratio) of all
+ * orderbooks that have a counterparty order pair
+ * @param this - RainSolver instance
+ * @param orderDetails - The details of the order to be processed
+ * @param signer - The signer to be used for the trade
+ * @param inputToEthPrice - The current price of input token to ETH price
+ * @param outputToEthPrice - The current price of output token to ETH price
+ */
+export async function findBestInterOrderbookTrade(
+    this: RainSolver,
+    orderDetails: BundledOrders,
+    signer: RainSolverSigner,
+    inputToEthPrice: string,
+    outputToEthPrice: string,
+): Promise<SimulationResult> {
+    const spanAttributes: Attributes = {};
+    const blockNumber = await this.state.client.getBlockNumber();
+    const counterpartyOrders = this.orderManager.getCounterpartyOrders(orderDetails, false);
+    const maximumInputFixed = orderDetails.takeOrders.reduce((a, b) => a + b.quote!.maxOutput, 0n);
+    const counterparties: Pair[] = [];
+
+    // run simulations for top 3 counterparty orders of each orderbook
+    const promises = counterpartyOrders.flatMap((orderbookCounterparties) => {
+        const cps = orderbookCounterparties.slice(0, 3);
+        counterparties.push(...cps);
+        return cps.map((counterpartyOrderDetails) => {
+            return trySimulateTrade.call(this, {
+                orderDetails,
+                counterpartyOrderDetails,
+                signer,
+                maximumInputFixed,
+                inputToEthPrice,
+                outputToEthPrice,
+                blockNumber,
+            });
+        });
+    });
+
+    const results = await Promise.all(promises);
+    if (results.some((res) => res.isOk())) {
+        // pick the one with highest estimated profit
+        return results.sort((a, b) => {
+            if (a.isErr() && b.isErr()) return 0;
+            if (a.isErr()) return 1;
+            if (b.isErr()) return -1;
+            return a.value.estimatedProfit < b.value.estimatedProfit
+                ? 1
+                : a.value.estimatedProfit > b.value.estimatedProfit
+                  ? -1
+                  : 0;
+        })[0];
+    } else {
+        const allNoneNodeErrors: (string | undefined)[] = [];
+        for (let i = 0; i < results.length; i++) {
+            const res = results[i];
+            assert(res.isErr()); // for type check as we know all results are errors
+            extendObjectWithHeader(
+                spanAttributes,
+                res.error.spanAttributes,
+                "againstOrderbooks." + counterparties[i].orderbook,
+            );
+            allNoneNodeErrors.push(res.error.noneNodeError);
+        }
+        return Result.err({
+            spanAttributes,
+            noneNodeError: allNoneNodeErrors[0],
+        });
+    }
+}

--- a/src/solver/modes/inter/simulate.test.ts
+++ b/src/solver/modes/inter/simulate.test.ts
@@ -64,7 +64,7 @@ describe("Test trySimulateTrade", () => {
                 client: {},
             },
             appOptions: {
-                arbAddress: "0xarb",
+                genericArbAddress: "0xarb",
                 gasCoveragePercentage: "0",
                 gasLimitMultiplier: 120,
             },

--- a/src/solver/modes/inter/simulate.test.ts
+++ b/src/solver/modes/inter/simulate.test.ts
@@ -1,0 +1,287 @@
+import { dryrun } from "../dryrun";
+import { RainSolver } from "../..";
+import { ONE18 } from "../../../math";
+import { Result } from "../../../result";
+import { BundledOrders, Pair } from "../../../order";
+import { encodeFunctionData, encodeAbiParameters } from "viem";
+import { describe, it, expect, vi, beforeEach, Mock, assert } from "vitest";
+import { trySimulateTrade, SimulateInterOrderbookTradeArgs } from "./simulate";
+import { SimulationResult } from "../../types";
+
+vi.mock("viem", async (importOriginal) => ({
+    ...(await importOriginal()),
+    encodeFunctionData: vi.fn().mockReturnValue("0xdata"),
+    encodeAbiParameters: vi.fn().mockReturnValue("0xparams"),
+}));
+
+vi.mock("./utils", () => ({
+    estimateProfit: vi.fn().mockReturnValue(150n),
+}));
+
+vi.mock("../../../task", () => ({
+    parseRainlang: vi.fn().mockResolvedValue("0xbytecode"),
+    getBountyEnsureRainlang: vi.fn().mockResolvedValue("rainlang"),
+}));
+
+vi.mock("../dryrun", () => ({
+    dryrun: vi.fn(),
+}));
+
+function makeOrderDetails(ratio = 1n * ONE18): BundledOrders {
+    return {
+        orderbook: "0xorderbook",
+        sellToken: "0xselltoken",
+        buyToken: "0xbuytoken",
+        sellTokenDecimals: 18,
+        buyTokenDecimals: 18,
+        takeOrders: [{ takeOrder: {}, quote: { ratio } }],
+    } as BundledOrders;
+}
+
+function makeCounterpartyOrder(): Pair {
+    return {
+        orderbook: "0xcounterpartyorderbook",
+        takeOrder: {},
+    } as Pair;
+}
+
+describe("Test trySimulateTrade", () => {
+    let solver: RainSolver;
+    let args: SimulateInterOrderbookTradeArgs;
+
+    beforeEach(() => {
+        vi.clearAllMocks();
+        solver = {
+            state: {
+                gasPrice: 1n,
+                chainConfig: {
+                    isSpecialL2: false,
+                },
+                dispair: {
+                    interpreter: "0xint",
+                    store: "0xstore",
+                },
+                client: {},
+            },
+            appOptions: {
+                arbAddress: "0xarb",
+                gasCoveragePercentage: "0",
+                gasLimitMultiplier: 120,
+            },
+        } as any;
+        args = {
+            orderDetails: makeOrderDetails(),
+            counterpartyOrderDetails: makeCounterpartyOrder(),
+            signer: { account: { address: "0xsigner" } },
+            inputToEthPrice: "0.5",
+            outputToEthPrice: "2.0",
+            maximumInputFixed: 10n * ONE18,
+            blockNumber: 123n,
+        } as any;
+    });
+
+    it("should return error if initial dryrun fails", async () => {
+        (dryrun as Mock).mockResolvedValueOnce(
+            Result.err({
+                spanAttributes: { stage: 1 },
+                reason: "NoOpportunity",
+            }),
+        );
+
+        const result: SimulationResult = await trySimulateTrade.call(solver, args);
+
+        assert(result.isErr());
+        expect(result.error).toHaveProperty("spanAttributes");
+        expect(result.error.spanAttributes.stage).toBe(1);
+        expect(result.error.spanAttributes.oppBlockNumber).toBe(123);
+        expect(result.error.spanAttributes.maxInput).toBe("10000000000000000000");
+    });
+
+    it("should return ok result if all steps succeed with gasCoveragePercentage 0", async () => {
+        (dryrun as Mock).mockResolvedValueOnce(
+            Result.ok({
+                estimation: { gas: 100n, totalGasCost: 200n, gasPrice: 1n },
+                estimatedGasCost: 200n,
+                spanAttributes: {},
+            }),
+        );
+        args.orderDetails = makeOrderDetails(1n * ONE18);
+        solver.appOptions.gasCoveragePercentage = "0";
+
+        const result: SimulationResult = await trySimulateTrade.call(solver, args);
+
+        assert(result.isOk());
+        expect(result.value).toHaveProperty("spanAttributes");
+        expect(result.value).toHaveProperty("rawtx");
+        expect(result.value).toHaveProperty("estimatedGasCost");
+        expect(result.value).toHaveProperty("oppBlockNumber");
+        expect(result.value).toHaveProperty("estimatedProfit");
+        expect(result.value.estimatedProfit).toBe(150n);
+        expect(result.value.oppBlockNumber).toBe(Number(args.blockNumber));
+        expect(result.value.spanAttributes.foundOpp).toBe(true);
+        expect(result.value.estimatedGasCost).toBe(200n);
+        expect(result.value.rawtx).toHaveProperty("data", "0xdata");
+        expect(result.value.rawtx).toHaveProperty("to", "0xarb");
+        expect(result.value.rawtx).toHaveProperty("gasPrice", 1n);
+
+        // Assert encodeFunctionData was called correctly
+        expect(encodeFunctionData).toHaveBeenCalledWith({
+            abi: expect.any(Array), // ArbAbi
+            functionName: "arb3",
+            args: [
+                "0xorderbook",
+                {
+                    data: "0xparams",
+                    maximumIORatio: expect.any(BigInt),
+                    maximumInput: expect.any(BigInt),
+                    minimumInput: 1n,
+                    orders: [{}],
+                },
+                {
+                    evaluable: {
+                        bytecode: "0x",
+                        interpreter: "0xint",
+                        store: "0xstore",
+                    },
+                    signedContext: [],
+                },
+            ],
+        });
+
+        // Assert encodeAbiParameters was called correctly for takeOrders2
+        expect(encodeAbiParameters).toHaveBeenCalledWith(
+            expect.arrayContaining([
+                expect.objectContaining({ type: "address" }),
+                expect.objectContaining({ type: "address" }),
+                expect.objectContaining({ type: "bytes" }),
+            ]),
+            ["0xcounterpartyorderbook", "0xcounterpartyorderbook", expect.any(String)],
+        );
+    });
+
+    it("should return ok result if all steps succeed with gasCoveragePercentage not 0", async () => {
+        (dryrun as Mock)
+            .mockResolvedValueOnce(
+                Result.ok({
+                    estimation: { gas: 100n, totalGasCost: 200n, gasPrice: 1n },
+                    estimatedGasCost: 200n,
+                    spanAttributes: { initial: "data" },
+                }),
+            )
+            .mockResolvedValueOnce(
+                Result.ok({
+                    estimation: { gas: 150n, totalGasCost: 300n, gasPrice: 1n },
+                    estimatedGasCost: 300n,
+                    spanAttributes: { final: "data" },
+                }),
+            );
+        args.orderDetails = makeOrderDetails(1n * ONE18);
+        solver.appOptions.gasCoveragePercentage = "100";
+
+        const result: SimulationResult = await trySimulateTrade.call(solver, args);
+
+        assert(result.isOk());
+        expect(result.value).toHaveProperty("spanAttributes");
+        expect(result.value).toHaveProperty("rawtx");
+        expect(result.value).toHaveProperty("estimatedGasCost");
+        expect(result.value).toHaveProperty("oppBlockNumber");
+        expect(result.value).toHaveProperty("estimatedProfit");
+        expect(result.value.estimatedProfit).toBe(150n);
+        expect(result.value.oppBlockNumber).toBe(Number(args.blockNumber));
+        expect(result.value.spanAttributes.foundOpp).toBe(true);
+        expect(result.value.estimatedGasCost).toBe(300n);
+        expect(result.value.spanAttributes.initial).toBe("data");
+        expect(result.value.spanAttributes.final).toBe("data");
+        expect(result.value.rawtx).toHaveProperty("data", "0xdata");
+        expect(result.value.rawtx).toHaveProperty("to", "0xarb");
+        expect(result.value.rawtx).toHaveProperty("gasPrice", 1n);
+
+        // Verify encodeFunctionData called 3 times (initial, final, and last)
+        expect(encodeFunctionData).toHaveBeenCalledTimes(4);
+        expect(encodeAbiParameters).toHaveBeenCalledTimes(1);
+    });
+
+    it("should handle zero ratio in opposing order calculations", async () => {
+        (dryrun as Mock).mockResolvedValue(
+            Result.ok({
+                estimation: { gas: 100n, totalGasCost: 200n, gasPrice: 1n },
+                estimatedGasCost: 200n,
+                spanAttributes: {},
+            }),
+        );
+        args.orderDetails = makeOrderDetails(0n); // zero ratio
+
+        const result: SimulationResult = await trySimulateTrade.call(solver, args);
+
+        assert(result.isOk());
+        expect(result.value.spanAttributes.foundOpp).toBe(true);
+
+        // Verify that maxUint256 is used for zero ratio
+        expect(encodeFunctionData).toHaveBeenCalledWith({
+            abi: expect.any(Array),
+            functionName: "arb3",
+            args: [
+                "0xorderbook",
+                expect.objectContaining({
+                    maximumInput: expect.any(BigInt),
+                    maximumIORatio: expect.any(BigInt),
+                }),
+                expect.any(Object),
+            ],
+        });
+    });
+
+    it("should return error if final dryrun fails when gasCoveragePercentage is not 0", async () => {
+        (dryrun as Mock)
+            .mockResolvedValueOnce(
+                Result.ok({
+                    estimation: { gas: 100n, totalGasCost: 200n, gasPrice: 1n },
+                    estimatedGasCost: 200n,
+                    spanAttributes: {},
+                }),
+            )
+            .mockResolvedValueOnce(
+                Result.err({
+                    spanAttributes: { stage: 2 },
+                    reason: "NoOpportunity",
+                }),
+            );
+        args.orderDetails = makeOrderDetails(1n * ONE18);
+        solver.appOptions.gasCoveragePercentage = "100";
+
+        const result: SimulationResult = await trySimulateTrade.call(solver, args);
+
+        assert(result.isErr());
+        expect(result.error).toHaveProperty("spanAttributes");
+        expect(result.error.spanAttributes.stage).toBe(2);
+        expect(result.error.spanAttributes["gasEst.initial.gasLimit"]).toBe("100");
+        expect(result.error.spanAttributes["gasEst.initial.totalCost"]).toBe("200");
+        expect(result.error.spanAttributes["gasEst.initial.gasPrice"]).toBe("1");
+        expect(result.error.spanAttributes["gasEst.initial.minBountyExpected"]).toBe("206");
+
+        // Verify encodeFunctionData was called twice (for both dryruns)
+        expect(encodeFunctionData).toHaveBeenCalledTimes(3);
+        expect(encodeAbiParameters).toHaveBeenCalledTimes(1);
+    });
+
+    it("should handle different token decimals correctly", async () => {
+        (dryrun as Mock).mockResolvedValue(
+            Result.ok({
+                estimation: { gas: 100n, totalGasCost: 200n, gasPrice: 1n },
+                estimatedGasCost: 200n,
+                spanAttributes: {},
+            }),
+        );
+        args.orderDetails = {
+            ...makeOrderDetails(1n * ONE18),
+            sellTokenDecimals: 6,
+            buyTokenDecimals: 8,
+        };
+
+        const result: SimulationResult = await trySimulateTrade.call(solver, args);
+
+        assert(result.isOk());
+        expect(result.value.spanAttributes.foundOpp).toBe(true);
+        expect(result.value.spanAttributes.maxInput).toBe("10000000"); // scaled to 6 decimals
+    });
+});

--- a/src/solver/modes/inter/simulate.ts
+++ b/src/solver/modes/inter/simulate.ts
@@ -76,7 +76,7 @@ export async function trySimulateTrade(
                 minimumInput: 1n,
                 maximumInput: opposingMaxInput, // main maxout * main ratio
                 maximumIORatio: opposingMaxIORatio, // inverse of main ratio (1 / ratio)
-                orders: [counterpartyOrderDetails.takeOrder], // opposing orders
+                orders: [counterpartyOrderDetails.takeOrder.takeOrder], // opposing orders
                 data: "0x",
             },
         ],

--- a/src/solver/modes/inter/simulate.ts
+++ b/src/solver/modes/inter/simulate.ts
@@ -31,7 +31,7 @@ export type SimulateInterOrderbookTradeArgs = {
 };
 
 /**
- * Attempts to simulate a trade against the given counterparty order
+ * Attempts to simulate a inter-orderbook trade against the given counterparty order
  * @param this - The RainSolver instance context
  * @param args - The arguments for simulating the trade
  */
@@ -121,7 +121,7 @@ export async function trySimulateTrade(
             functionName: "arb3",
             args: [orderDetails.orderbook as `0x${string}`, takeOrdersConfigStruct, task],
         }),
-        to: this.appOptions.arbAddress as `0x${string}`,
+        to: this.appOptions.genericArbAddress as `0x${string}`,
         gasPrice,
     };
 

--- a/src/solver/modes/inter/simulate.ts
+++ b/src/solver/modes/inter/simulate.ts
@@ -1,0 +1,255 @@
+import { RainSolver } from "../..";
+import { dryrun } from "../dryrun";
+import { Result } from "../../../result";
+import { estimateProfit } from "./utils";
+import { Attributes } from "@opentelemetry/api";
+import { ONE18, scale18To } from "../../../math";
+import { BundledOrders, Pair } from "../../../order";
+import { extendObjectWithHeader } from "../../../logger";
+import { ArbAbi, TakeOrdersV2Abi } from "../../../abis";
+import { RainSolverSigner, RawTransaction } from "../../../signer";
+import { getBountyEnsureRainlang, parseRainlang } from "../../../task";
+import { SimulationResult, TakeOrdersConfigType, TaskType } from "../../types";
+import { encodeAbiParameters, encodeFunctionData, maxUint256, parseUnits } from "viem";
+
+/** Arguments for simulating inter-orderbook trade */
+export type SimulateInterOrderbookTradeArgs = {
+    /** The bundled order details including tokens, decimals, and take orders */
+    orderDetails: BundledOrders;
+    /** The counterparty order to trade against */
+    counterpartyOrderDetails: Pair;
+    /** The RainSolverSigner instance used for signing transactions */
+    signer: RainSolverSigner;
+    /** The input token to ETH price (in 18 decimals) */
+    inputToEthPrice: string;
+    /** The output token to ETH price (in 18 decimals) */
+    outputToEthPrice: string;
+    /** The maximum input amount (in 18 decimals) */
+    maximumInputFixed: bigint;
+    /** The current block number for context */
+    blockNumber: bigint;
+};
+
+/**
+ * Attempts to simulate a trade against the given counterparty order
+ * @param this - The RainSolver instance context
+ * @param args - The arguments for simulating the trade
+ */
+export async function trySimulateTrade(
+    this: RainSolver,
+    args: SimulateInterOrderbookTradeArgs,
+): Promise<SimulationResult> {
+    const {
+        orderDetails,
+        counterpartyOrderDetails,
+        signer,
+        maximumInputFixed,
+        blockNumber,
+        inputToEthPrice,
+        outputToEthPrice,
+    } = args;
+    const spanAttributes: Attributes = {};
+    const gasPrice = this.state.gasPrice;
+
+    const maximumInput = scale18To(maximumInputFixed, orderDetails.sellTokenDecimals);
+    spanAttributes["maxInput"] = maximumInput.toString();
+
+    const opposingMaxInput =
+        orderDetails.takeOrders[0].quote!.ratio === 0n
+            ? maxUint256
+            : scale18To(
+                  (maximumInputFixed * orderDetails.takeOrders[0].quote!.ratio) / ONE18,
+                  orderDetails.buyTokenDecimals,
+              );
+
+    const opposingMaxIORatio =
+        orderDetails.takeOrders[0].quote!.ratio === 0n
+            ? maxUint256
+            : ONE18 ** 2n / orderDetails.takeOrders[0].quote!.ratio;
+
+    // encode takeOrders2() and build tx fields
+    const encodedFN = encodeFunctionData({
+        abi: TakeOrdersV2Abi,
+        functionName: "takeOrders2",
+        args: [
+            {
+                minimumInput: 1n,
+                maximumInput: opposingMaxInput, // main maxout * main ratio
+                maximumIORatio: opposingMaxIORatio, // inverse of main ratio (1 / ratio)
+                orders: [counterpartyOrderDetails.takeOrder], // opposing orders
+                data: "0x",
+            },
+        ],
+    });
+    const takeOrdersConfigStruct: TakeOrdersConfigType = {
+        minimumInput: 1n,
+        maximumInput: maxUint256,
+        maximumIORatio: maxUint256,
+        orders: [orderDetails.takeOrders[0].takeOrder],
+        data: encodeAbiParameters(
+            [{ type: "address" }, { type: "address" }, { type: "bytes" }],
+            [
+                counterpartyOrderDetails.orderbook as `0x${string}`,
+                counterpartyOrderDetails.orderbook as `0x${string}`,
+                encodedFN,
+            ],
+        ),
+    };
+    const task: TaskType = {
+        evaluable: {
+            interpreter: this.state.dispair.interpreter as `0x${string}`,
+            store: this.state.dispair.store as `0x${string}`,
+            bytecode:
+                this.appOptions.gasCoveragePercentage === "0"
+                    ? "0x"
+                    : ((await parseRainlang(
+                          await getBountyEnsureRainlang(
+                              parseUnits(inputToEthPrice, 18),
+                              parseUnits(outputToEthPrice, 18),
+                              0n,
+                              signer.account.address,
+                          ),
+                          this.state.client,
+                          this.state.dispair,
+                      )) as `0x${string}`),
+        },
+        signedContext: [],
+    };
+    const rawtx: RawTransaction = {
+        data: encodeFunctionData({
+            abi: ArbAbi,
+            functionName: "arb3",
+            args: [orderDetails.orderbook as `0x${string}`, takeOrdersConfigStruct, task],
+        }),
+        to: this.appOptions.arbAddress as `0x${string}`,
+        gasPrice,
+    };
+
+    // initial dryrun with 0 minimum sender output to get initial
+    // pass and tx gas cost to calc minimum sender output
+    spanAttributes["oppBlockNumber"] = Number(blockNumber);
+    const initDryrunResult = await dryrun(
+        signer,
+        rawtx,
+        gasPrice,
+        this.appOptions.gasLimitMultiplier,
+    );
+    if (initDryrunResult.isErr()) {
+        spanAttributes["stage"] = 1;
+        Object.assign(initDryrunResult.error.spanAttributes, spanAttributes);
+        return Result.err(initDryrunResult.error);
+    }
+
+    let { estimation, estimatedGasCost } = initDryrunResult.value;
+    // include dryrun initial gas estimation in logs
+    Object.assign(spanAttributes, initDryrunResult.value.spanAttributes);
+    extendObjectWithHeader(
+        spanAttributes,
+        {
+            gasLimit: estimation.gas.toString(),
+            totalCost: estimation.totalGasCost.toString(),
+            gasPrice: estimation.gasPrice.toString(),
+            ...(this.state.chainConfig.isSpecialL2
+                ? {
+                      l1Cost: estimation.l1Cost.toString(),
+                      l1GasPrice: estimation.l1GasPrice.toString(),
+                  }
+                : {}),
+        },
+        "gasEst.initial",
+    );
+
+    // repeat the same process with heaedroom if gas
+    // coverage is not 0, 0 gas coverage means 0 minimum
+    // sender output which is already called above
+    if (this.appOptions.gasCoveragePercentage !== "0") {
+        const headroom = BigInt((Number(this.appOptions.gasCoveragePercentage) * 1.03).toFixed());
+        spanAttributes["gasEst.initial.minBountyExpected"] = (
+            (estimatedGasCost * headroom) /
+            100n
+        ).toString();
+        task.evaluable.bytecode = (await parseRainlang(
+            await getBountyEnsureRainlang(
+                parseUnits(inputToEthPrice, 18),
+                parseUnits(outputToEthPrice, 18),
+                (estimatedGasCost * headroom) / 100n,
+                signer.account.address,
+            ),
+            this.state.client,
+            this.state.dispair,
+        )) as `0x${string}`;
+        rawtx.data = encodeFunctionData({
+            abi: ArbAbi,
+            functionName: "arb3",
+            args: [orderDetails.orderbook as `0x${string}`, takeOrdersConfigStruct, task],
+        });
+
+        const finalDryrunResult = await dryrun(
+            signer,
+            rawtx,
+            gasPrice,
+            this.appOptions.gasLimitMultiplier,
+        );
+        if (finalDryrunResult.isErr()) {
+            spanAttributes["stage"] = 2;
+            Object.assign(finalDryrunResult.error.spanAttributes, spanAttributes);
+            return Result.err(finalDryrunResult.error);
+        }
+
+        ({ estimation, estimatedGasCost } = finalDryrunResult.value);
+        // include dryrun final gas estimation in otel logs
+        Object.assign(spanAttributes, finalDryrunResult.value.spanAttributes);
+        extendObjectWithHeader(
+            spanAttributes,
+            {
+                gasLimit: estimation.gas.toString(),
+                totalCost: estimation.totalGasCost.toString(),
+                gasPrice: estimation.gasPrice.toString(),
+                ...(this.state.chainConfig.isSpecialL2
+                    ? {
+                          l1Cost: estimation.l1Cost.toString(),
+                          l1GasPrice: estimation.l1GasPrice.toString(),
+                      }
+                    : {}),
+            },
+            "gasEst.final",
+        );
+
+        task.evaluable.bytecode = (await parseRainlang(
+            await getBountyEnsureRainlang(
+                parseUnits(inputToEthPrice, 18),
+                parseUnits(outputToEthPrice, 18),
+                (estimatedGasCost * BigInt(this.appOptions.gasCoveragePercentage)) / 100n,
+                signer.account.address,
+            ),
+            this.state.client,
+            this.state.dispair,
+        )) as `0x${string}`;
+        rawtx.data = encodeFunctionData({
+            abi: ArbAbi,
+            functionName: "arb3",
+            args: [orderDetails.orderbook as `0x${string}`, takeOrdersConfigStruct, task],
+        });
+        spanAttributes["gasEst.final.minBountyExpected"] = (
+            (estimatedGasCost * BigInt(this.appOptions.gasCoveragePercentage)) /
+            100n
+        ).toString();
+    }
+
+    // if reached here, it means there was a success and found opp
+    spanAttributes["foundOpp"] = true;
+    const result = {
+        spanAttributes,
+        rawtx,
+        estimatedGasCost,
+        oppBlockNumber: Number(blockNumber),
+        estimatedProfit: estimateProfit(
+            orderDetails,
+            parseUnits(inputToEthPrice, 18),
+            parseUnits(outputToEthPrice, 18),
+            counterpartyOrderDetails,
+            maximumInputFixed,
+        )!,
+    };
+    return Result.ok(result);
+}

--- a/src/solver/modes/inter/utils.test.ts
+++ b/src/solver/modes/inter/utils.test.ts
@@ -38,9 +38,9 @@ describe("Test estimateProfit", () => {
         // opposingMaxIORatio = 1^2 / 2 = 0.5
         // Since opposingMaxIORatio (0.5) < counterpartyOrder.ratio (1.5), counterparty conditions not met
         // counterpartyInput = 0, counterpartyOutput = 0
-        // outputProfit = 10 - (0 * 3) / 1 = 10
-        // inputProfit = 0 - (20 * 1) / 1 = -20
-        // total = 10 + (-20) = -10
+        // outputProfit = ((10 - 0) * 3) / 1 = 30
+        // inputProfit = ((0 - 20) * 1) / 1 = -20
+        // total = 30 + (-20) = 10
         const result = estimateProfit(
             orderDetails,
             inputToEthPrice,
@@ -48,7 +48,7 @@ describe("Test estimateProfit", () => {
             counterpartyOrder,
             maxInput,
         );
-        expect(result).toBe(-10n * ONE18);
+        expect(result).toBe(10n * ONE18);
     });
 
     it("should handle zero ratio in order (maxUint256 case)", () => {
@@ -66,9 +66,9 @@ describe("Test estimateProfit", () => {
         // maxOut = min(maxUint256, 5) = 5
         // counterpartyOutput = 5
         // counterpartyInput = (5 * 1) / 1 = 5
-        // outputProfit = 10 - (5 * 2) / 1 = 0
-        // inputProfit = 5 - (0 * 1) / 1 = 5
-        // total = 0 + 5 = 5
+        // outputProfit = ((10 - 5) * 2) / 1 = 10
+        // inputProfit = ((5 - 0) * 1) / 1 = 5
+        // total = 10 + 5 = 5
         const result = estimateProfit(
             orderDetails,
             inputToEthPrice,
@@ -76,7 +76,7 @@ describe("Test estimateProfit", () => {
             counterpartyOrder,
             maxInput,
         );
-        expect(result).toBe(5n * ONE18);
+        expect(result).toBe(15n * ONE18);
     });
 
     it("should handle counterparty trade when opposing max input is limiting factor", () => {
@@ -94,9 +94,9 @@ describe("Test estimateProfit", () => {
         // maxOut = min(10, 20) = 10 (opposingMaxInput is limiting)
         // counterpartyOutput = 10
         // counterpartyInput = (10 * 0.5) / 1 = 5
-        // outputProfit = 10 - (5 * 1) / 1 = 5
-        // inputProfit = 10 - (10 * 2) / 1 = -10
-        // total = 5 + (-10) = -5
+        // outputProfit = ((10 - 5) * 1) / 1 = 5
+        // inputProfit = ((10 - 10) * 2) / 1 = 0
+        // total = 5 + 0 = 5
         const result = estimateProfit(
             orderDetails,
             inputToEthPrice,
@@ -104,7 +104,7 @@ describe("Test estimateProfit", () => {
             counterpartyOrder,
             maxInput,
         );
-        expect(result).toBe(-5n * ONE18);
+        expect(result).toBe(5n * ONE18);
     });
 
     it("should handle counterparty trade when counterparty max output is limiting factor", () => {

--- a/src/solver/modes/inter/utils.test.ts
+++ b/src/solver/modes/inter/utils.test.ts
@@ -1,0 +1,190 @@
+import { ONE18 } from "../../../math";
+import { Pair } from "../../../order";
+import { estimateProfit } from "./utils";
+import { describe, it, expect } from "vitest";
+
+const ONE17 = 10n ** 17n;
+function makeOrderDetails(ratio: bigint) {
+    return {
+        takeOrders: [
+            {
+                quote: { ratio },
+            },
+        ],
+    };
+}
+function makeCounterpartyOrder(ratio: bigint, maxOutput: bigint): Pair {
+    return {
+        takeOrder: {
+            quote: {
+                ratio,
+                maxOutput,
+            },
+        },
+    } as Pair;
+}
+
+describe("Test estimateProfit", () => {
+    it("should calculate profit correctly for typical values", () => {
+        const orderDetails = makeOrderDetails(2n * ONE18); // ratio = 2.0
+        const inputToEthPrice = 1n * ONE18; // 1 ETH per input token
+        const outputToEthPrice = 3n * ONE18; // 3 ETH per output token
+        const counterpartyOrder = makeCounterpartyOrder(15n * ONE17, 5n * ONE18); // ratio = 1.5, maxOutput = 5
+        const maxInput = 10n * ONE18; // 10 units
+
+        // orderOutput = 10
+        // orderInput = (10 * 2) / 1 = 20
+        // opposingMaxInput = (10 * 2) / 1 = 20
+        // opposingMaxIORatio = 1^2 / 2 = 0.5
+        // Since opposingMaxIORatio (0.5) < counterpartyOrder.ratio (1.5), counterparty conditions not met
+        // counterpartyInput = 0, counterpartyOutput = 0
+        // outputProfit = 10 - (0 * 3) / 1 = 10
+        // inputProfit = 0 - (20 * 1) / 1 = -20
+        // total = 10 + (-20) = -10
+        const result = estimateProfit(
+            orderDetails,
+            inputToEthPrice,
+            outputToEthPrice,
+            counterpartyOrder,
+            maxInput,
+        );
+        expect(result).toBe(-10n * ONE18);
+    });
+
+    it("should handle zero ratio in order (maxUint256 case)", () => {
+        const orderDetails = makeOrderDetails(0n); // ratio = 0
+        const inputToEthPrice = 1n * ONE18;
+        const outputToEthPrice = 2n * ONE18;
+        const counterpartyOrder = makeCounterpartyOrder(1n * ONE18, 5n * ONE18); // ratio = 1.0, maxOutput = 5
+        const maxInput = 10n * ONE18;
+
+        // orderOutput = 10
+        // orderInput = (10 * 0) / 1 = 0
+        // opposingMaxInput = maxUint256 (since ratio is 0)
+        // opposingMaxIORatio = maxUint256 (since ratio is 0)
+        // Since opposingMaxIORatio (maxUint256) >= counterpartyOrder.ratio (1.0), counterparty conditions met
+        // maxOut = min(maxUint256, 5) = 5
+        // counterpartyOutput = 5
+        // counterpartyInput = (5 * 1) / 1 = 5
+        // outputProfit = 10 - (5 * 2) / 1 = 0
+        // inputProfit = 5 - (0 * 1) / 1 = 5
+        // total = 0 + 5 = 5
+        const result = estimateProfit(
+            orderDetails,
+            inputToEthPrice,
+            outputToEthPrice,
+            counterpartyOrder,
+            maxInput,
+        );
+        expect(result).toBe(5n * ONE18);
+    });
+
+    it("should handle counterparty trade when opposing max input is limiting factor", () => {
+        const orderDetails = makeOrderDetails(1n * ONE18); // ratio = 1.0
+        const inputToEthPrice = 2n * ONE18;
+        const outputToEthPrice = 1n * ONE18;
+        const counterpartyOrder = makeCounterpartyOrder(5n * ONE17, 20n * ONE18); // ratio = 0.5, maxOutput = 20
+        const maxInput = 10n * ONE18;
+
+        // orderOutput = 10
+        // orderInput = (10 * 1) / 1 = 10
+        // opposingMaxInput = (10 * 1) / 1 = 10
+        // opposingMaxIORatio = 1^2 / 1 = 1
+        // Since opposingMaxIORatio (1.0) >= counterpartyOrder.ratio (0.5), counterparty conditions met
+        // maxOut = min(10, 20) = 10 (opposingMaxInput is limiting)
+        // counterpartyOutput = 10
+        // counterpartyInput = (10 * 0.5) / 1 = 5
+        // outputProfit = 10 - (5 * 1) / 1 = 5
+        // inputProfit = 10 - (10 * 2) / 1 = -10
+        // total = 5 + (-10) = -5
+        const result = estimateProfit(
+            orderDetails,
+            inputToEthPrice,
+            outputToEthPrice,
+            counterpartyOrder,
+            maxInput,
+        );
+        expect(result).toBe(-5n * ONE18);
+    });
+
+    it("should handle counterparty trade when counterparty max output is limiting factor", () => {
+        const orderDetails = makeOrderDetails(1n * ONE18); // ratio = 1.0
+        const inputToEthPrice = 1n * ONE18;
+        const outputToEthPrice = 1n * ONE18;
+        const counterpartyOrder = makeCounterpartyOrder(5n * ONE17, 3n * ONE18); // ratio = 0.5, maxOutput = 3
+        const maxInput = 10n * ONE18;
+
+        // orderOutput = 10
+        // orderInput = (10 * 1) / 1 = 10
+        // opposingMaxInput = (10 * 1) / 1 = 10
+        // opposingMaxIORatio = 1^2 / 1 = 1
+        // Since opposingMaxIORatio (1.0) >= counterpartyOrder.ratio (0.5), counterparty conditions met
+        // maxOut = min(10, 3) = 3 (counterparty maxOutput is limiting)
+        // counterpartyOutput = 3
+        // counterpartyInput = (3 * 0.5) / 1 = 1.5
+        // outputProfit = 10 - (1.5 * 1) / 1 = 8.5
+        // inputProfit = 3 - (10 * 1) / 1 = -7
+        // total = 8.5 + (-7) = 1.5
+        const result = estimateProfit(
+            orderDetails,
+            inputToEthPrice,
+            outputToEthPrice,
+            counterpartyOrder,
+            maxInput,
+        );
+        expect(result).toBe(15n * ONE17); // 1.5 * ONE18
+    });
+
+    it("should handle case when opposing max IO ratio is less than counterparty ratio", () => {
+        const orderDetails = makeOrderDetails(4n * ONE18); // ratio = 4.0
+        const inputToEthPrice = 1n * ONE18;
+        const outputToEthPrice = 1n * ONE18;
+        const counterpartyOrder = makeCounterpartyOrder(1n * ONE18, 10n * ONE18); // ratio = 1.0, maxOutput = 10
+        const maxInput = 5n * ONE18;
+
+        // orderOutput = 5
+        // orderInput = (5 * 4) / 1 = 20
+        // opposingMaxInput = (5 * 4) / 1 = 20
+        // opposingMaxIORatio = 1^2 / 4 = 0.25
+        // Since opposingMaxIORatio (0.25) < counterpartyOrder.ratio (1.0), counterparty conditions NOT met
+        // counterpartyInput = 0, counterpartyOutput = 0
+        // outputProfit = 5 - (0 * 1) / 1 = 5
+        // inputProfit = 0 - (20 * 1) / 1 = -20
+        // total = 5 + (-20) = -15
+        const result = estimateProfit(
+            orderDetails,
+            inputToEthPrice,
+            outputToEthPrice,
+            counterpartyOrder,
+            maxInput,
+        );
+        expect(result).toBe(-15n * ONE18);
+    });
+
+    it("should handle edge case with zero max input", () => {
+        const orderDetails = makeOrderDetails(1n * ONE18);
+        const inputToEthPrice = 1n * ONE18;
+        const outputToEthPrice = 1n * ONE18;
+        const counterpartyOrder = makeCounterpartyOrder(1n * ONE18, 10n * ONE18);
+        const maxInput = 0n;
+
+        // orderOutput = 0
+        // orderInput = (0 * 1) / 1 = 0
+        // opposingMaxInput = (0 * 1) / 1 = 0
+        // opposingMaxIORatio = 1^2 / 1 = 1
+        // Since opposingMaxIORatio (1.0) >= counterpartyOrder.ratio (1.0), counterparty conditions met
+        // maxOut = min(0, 10) = 0
+        // counterpartyOutput = 0, counterpartyInput = 0
+        // outputProfit = 0 - (0 * 1) / 1 = 0
+        // inputProfit = 0 - (0 * 1) / 1 = 0
+        // total = 0
+        const result = estimateProfit(
+            orderDetails,
+            inputToEthPrice,
+            outputToEthPrice,
+            counterpartyOrder,
+            maxInput,
+        );
+        expect(result).toBe(0n);
+    });
+});

--- a/src/solver/modes/inter/utils.ts
+++ b/src/solver/modes/inter/utils.ts
@@ -31,7 +31,7 @@ export function estimateProfit(
         counterpartyInput += (maxOut * quote.ratio) / ONE18;
         opposingMaxInput -= maxOut;
     }
-    const outputProfit = orderOutput - (counterpartyInput * outputToEthPrice) / ONE18;
-    const inputProfit = counterpartyOutput - (orderInput * inputToEthPrice) / ONE18;
+    const outputProfit = ((orderOutput - counterpartyInput) * outputToEthPrice) / ONE18;
+    const inputProfit = ((counterpartyOutput - orderInput) * inputToEthPrice) / ONE18;
     return outputProfit + inputProfit;
 }

--- a/src/solver/modes/inter/utils.ts
+++ b/src/solver/modes/inter/utils.ts
@@ -1,0 +1,37 @@
+import { maxUint256 } from "viem";
+import { ONE18 } from "../../../math";
+import { Pair } from "../../../order";
+
+/** Estimates profit for a inter-orderbook trade */
+export function estimateProfit(
+    orderDetails: any,
+    inputToEthPrice: bigint,
+    outputToEthPrice: bigint,
+    counterpartyOrder: Pair,
+    maxInput: bigint,
+): bigint {
+    const orderOutput = maxInput;
+    const orderInput = (maxInput * orderDetails.takeOrders[0].quote.ratio) / ONE18;
+
+    let opposingMaxInput =
+        orderDetails.takeOrders[0].quote.ratio === 0n
+            ? maxUint256
+            : (maxInput * orderDetails.takeOrders[0].quote.ratio) / ONE18;
+    const opposingMaxIORatio =
+        orderDetails.takeOrders[0].quote.ratio === 0n
+            ? maxUint256
+            : ONE18 ** 2n / orderDetails.takeOrders[0].quote.ratio;
+
+    let counterpartyInput = 0n;
+    let counterpartyOutput = 0n;
+    const quote = counterpartyOrder.takeOrder.quote!;
+    if (opposingMaxIORatio >= quote.ratio) {
+        const maxOut = opposingMaxInput < quote.maxOutput ? opposingMaxInput : quote.maxOutput;
+        counterpartyOutput += maxOut;
+        counterpartyInput += (maxOut * quote.ratio) / ONE18;
+        opposingMaxInput -= maxOut;
+    }
+    const outputProfit = orderOutput - (counterpartyInput * outputToEthPrice) / ONE18;
+    const inputProfit = counterpartyOutput - (orderInput * inputToEthPrice) / ONE18;
+    return outputProfit + inputProfit;
+}


### PR DESCRIPTION
<!-- Thanks for your Pull Request, please read the contributing guidelines before submitting. -->

## Motivation
related to #341 
### ⚠️ Do NOT merge before #362 

- This PR implements the clearing mode for inter orderbook, that includes methods to simulate and find best inter-ob trade for the given order against counterparty orders of different orderbooks as well as functionalities for estimating the solver profit.
- also add extensive unit tests for newly added functionalities
- also rename `getOpposingOrders` to `getCounterpartyOrders` (for better and more consistent rain specific naming) and add sorting to them, this is because  throughout the runtime, orders get quoted when they are being processed, these quote results are cached for each order inside of its object, these quotes are used to sort the `pairMap` in place when `getCounterpartyOrders()` is called for inter and intra clearing modes, so this ensures at any given time, we have instant access to sorted list of counterparty orders by quote ratio, and we only simulate the processing order against top 3 counterparties.
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## Checks
<!-- It's important you've done these, or your PR will not be considered for review -->
By submitting this for review, I'm confirming I've done the following:
- [x] made this PR as small as possible
- [x] unit-tested any new functionality
- [x] linked any relevant issues or PRs
- [ ] ~~included screenshots (if this involves a front-end change)~~
