### PR TITLE
intra orderbook mode

### DIFF
--- a/src/abis.ts
+++ b/src/abis.ts
@@ -103,6 +103,9 @@ export const MulticallAbi = parseAbi(multicall3Abi);
 export const Deposit2Abi = parseAbi([orderbookAbi[4]]);
 export const ArbAbi = parseAbi(arbAbis);
 export const TakeOrdersV2Abi = parseAbi([orderbookAbi[11]]);
+export const Withdraw2Abi = parseAbi([orderbookAbi[7]]);
+export const Clear2Abi = parseAbi([orderbookAbi[12]]);
+export const OrderbookMulticallAbi = parseAbi([orderbookAbi[10]]);
 
 /**
  * Arbitrum node interface address, used to get L1 gas limit.

--- a/src/solver/modes/intra/index.test.ts
+++ b/src/solver/modes/intra/index.test.ts
@@ -1,0 +1,595 @@
+import { Result } from "../../../result";
+import { SimulationResult } from "../../types";
+import { trySimulateTrade } from "./simulation";
+import { findBestIntraOrderbookTrade } from "./index";
+import { extendObjectWithHeader } from "../../../logger";
+import { describe, it, expect, vi, beforeEach, Mock, assert } from "vitest";
+
+vi.mock("./simulation", () => ({
+    trySimulateTrade: vi.fn(),
+}));
+
+vi.mock("../../../logger", () => ({
+    extendObjectWithHeader: vi.fn(),
+}));
+
+vi.mock("viem", async (importOriginal) => ({
+    ...(await importOriginal()),
+    erc20Abi: [],
+}));
+
+describe("Test findBestIntraOrderbookTrade", () => {
+    let mockRainSolver: any;
+    let orderDetails: any;
+    let signer: any;
+    let inputToEthPrice: string;
+    let outputToEthPrice: string;
+
+    beforeEach(() => {
+        vi.clearAllMocks();
+
+        mockRainSolver = {
+            state: {
+                client: {
+                    getBlockNumber: vi.fn().mockResolvedValue(123n),
+                    readContract: vi
+                        .fn()
+                        .mockResolvedValueOnce(5000000000000000000n) // input balance
+                        .mockResolvedValueOnce(3000000000000000000n), // output balance
+                },
+            },
+            orderManager: {
+                getCounterpartyOrders: vi.fn(),
+            },
+        };
+
+        orderDetails = {
+            takeOrders: [
+                {
+                    id: "order1",
+                    takeOrder: {
+                        order: {
+                            owner: "0xowner1",
+                        },
+                    },
+                    quote: { ratio: 1000000000000000000n }, // 1.0
+                },
+            ],
+            buyToken: "0xbuytoken",
+            sellToken: "0xselltoken",
+            buyTokenDecimals: 18,
+            sellTokenDecimals: 18,
+        };
+
+        signer = { account: { address: "0xsigner" } };
+        inputToEthPrice = "0.5";
+        outputToEthPrice = "2.0";
+    });
+
+    it("should return success result with highest profit when simulations succeed", async () => {
+        const mockCounterpartyOrders = [
+            {
+                takeOrder: {
+                    id: "order2",
+                    takeOrder: {
+                        order: {
+                            owner: "0xowner2",
+                        },
+                    },
+                    quote: { ratio: 500000000000000000n }, // 0.5
+                },
+            },
+            {
+                takeOrder: {
+                    id: "order3",
+                    takeOrder: {
+                        order: {
+                            owner: "0xowner3",
+                        },
+                    },
+                    quote: { ratio: 800000000000000000n }, // 0.8
+                },
+            },
+            {
+                takeOrder: {
+                    id: "order4",
+                    takeOrder: {
+                        order: {
+                            owner: "0xowner4",
+                        },
+                    },
+                    quote: { ratio: 600000000000000000n }, // 0.6
+                },
+            },
+        ];
+        mockRainSolver.orderManager.getCounterpartyOrders.mockReturnValue(mockCounterpartyOrders);
+
+        const mockResults = [
+            Result.ok({
+                spanAttributes: { foundOpp: true },
+                estimatedProfit: 100n,
+                oppBlockNumber: 123,
+            }),
+            Result.ok({
+                spanAttributes: { foundOpp: true },
+                estimatedProfit: 250n, // highest profit
+                oppBlockNumber: 123,
+            }),
+            Result.ok({
+                spanAttributes: { foundOpp: true },
+                estimatedProfit: 150n,
+                oppBlockNumber: 123,
+            }),
+        ];
+        (trySimulateTrade as Mock)
+            .mockResolvedValueOnce(mockResults[0])
+            .mockResolvedValueOnce(mockResults[1])
+            .mockResolvedValueOnce(mockResults[2]);
+
+        const result: SimulationResult = await findBestIntraOrderbookTrade.call(
+            mockRainSolver,
+            orderDetails,
+            signer,
+            inputToEthPrice,
+            outputToEthPrice,
+        );
+
+        assert(result.isOk());
+        expect(result.value.spanAttributes.foundOpp).toBe(true);
+        expect(result.value.estimatedProfit).toBe(250n); // highest profit
+        expect(result.value.oppBlockNumber).toBe(123);
+        expect(mockRainSolver.orderManager.getCounterpartyOrders).toHaveBeenCalledWith(
+            orderDetails,
+            true,
+        );
+        expect(trySimulateTrade).toHaveBeenCalledTimes(3);
+    });
+
+    it("should return success result when only some simulations succeed", async () => {
+        const mockCounterpartyOrders = [
+            {
+                takeOrder: {
+                    id: "order2",
+                    takeOrder: {
+                        order: {
+                            owner: "0xowner2",
+                        },
+                    },
+                    quote: { ratio: 500000000000000000n },
+                },
+            },
+            {
+                takeOrder: {
+                    id: "order3",
+                    takeOrder: {
+                        order: {
+                            owner: "0xowner3",
+                        },
+                    },
+                    quote: { ratio: 600000000000000000n },
+                },
+            },
+        ];
+        mockRainSolver.orderManager.getCounterpartyOrders.mockReturnValue(mockCounterpartyOrders);
+
+        const mockResults = [
+            Result.err({
+                spanAttributes: { error: "failed" },
+                noneNodeError: "simulation failed",
+            }),
+            Result.ok({
+                spanAttributes: { foundOpp: true },
+                estimatedProfit: 300n,
+                oppBlockNumber: 123,
+            }),
+        ];
+        (trySimulateTrade as Mock)
+            .mockResolvedValueOnce(mockResults[0])
+            .mockResolvedValueOnce(mockResults[1]);
+
+        const result: SimulationResult = await findBestIntraOrderbookTrade.call(
+            mockRainSolver,
+            orderDetails,
+            signer,
+            inputToEthPrice,
+            outputToEthPrice,
+        );
+
+        assert(result.isOk());
+        expect(result.value.spanAttributes.foundOpp).toBe(true);
+        expect(result.value.estimatedProfit).toBe(300n);
+        expect(result.value.oppBlockNumber).toBe(123);
+        expect(trySimulateTrade).toHaveBeenCalledTimes(2);
+    });
+
+    it("should return error when all simulations fail", async () => {
+        const mockCounterpartyOrders = [
+            {
+                takeOrder: {
+                    id: "order2",
+                    takeOrder: {
+                        order: {
+                            owner: "0xowner2",
+                        },
+                    },
+                    quote: { ratio: 500000000000000000n },
+                },
+            },
+            {
+                takeOrder: {
+                    id: "order3",
+                    takeOrder: {
+                        order: {
+                            owner: "0xowner3",
+                        },
+                    },
+                    quote: { ratio: 600000000000000000n },
+                },
+            },
+        ];
+        mockRainSolver.orderManager.getCounterpartyOrders.mockReturnValue(mockCounterpartyOrders);
+
+        const mockResults = [
+            Result.err({
+                spanAttributes: { error: "failed1" },
+                noneNodeError: "simulation failed 1",
+            }),
+            Result.err({
+                spanAttributes: { error: "failed2" },
+                noneNodeError: "simulation failed 2",
+            }),
+        ];
+        (trySimulateTrade as Mock)
+            .mockResolvedValueOnce(mockResults[0])
+            .mockResolvedValueOnce(mockResults[1]);
+
+        const result: SimulationResult = await findBestIntraOrderbookTrade.call(
+            mockRainSolver,
+            orderDetails,
+            signer,
+            inputToEthPrice,
+            outputToEthPrice,
+        );
+
+        assert(result.isErr());
+        expect(result.error.noneNodeError).toBe("simulation failed 1"); // first error
+        expect(extendObjectWithHeader).toHaveBeenCalledWith(
+            expect.any(Object),
+            { error: "failed1" },
+            "intraOrderbook.0",
+        );
+        expect(extendObjectWithHeader).toHaveBeenCalledWith(
+            expect.any(Object),
+            { error: "failed2" },
+            "intraOrderbook.1",
+        );
+    });
+
+    it("should filter out orders with same ID", async () => {
+        const mockCounterpartyOrders = [
+            {
+                takeOrder: {
+                    id: "order1", // same as main order
+                    takeOrder: {
+                        order: {
+                            owner: "0xowner2",
+                        },
+                    },
+                    quote: { ratio: 500000000000000000n },
+                },
+            },
+            {
+                takeOrder: {
+                    id: "order3",
+                    takeOrder: {
+                        order: {
+                            owner: "0xowner3",
+                        },
+                    },
+                    quote: { ratio: 600000000000000000n },
+                },
+            },
+        ];
+        mockRainSolver.orderManager.getCounterpartyOrders.mockReturnValue(mockCounterpartyOrders);
+
+        (trySimulateTrade as Mock).mockResolvedValue(
+            Result.ok({
+                spanAttributes: { foundOpp: true },
+                estimatedProfit: 200n,
+                oppBlockNumber: 123,
+            }),
+        );
+
+        await findBestIntraOrderbookTrade.call(
+            mockRainSolver,
+            orderDetails,
+            signer,
+            inputToEthPrice,
+            outputToEthPrice,
+        );
+
+        // should only call trySimulateTrade once (filtered out same ID order)
+        expect(trySimulateTrade).toHaveBeenCalledTimes(1);
+    });
+
+    it("should filter out orders with same owner", async () => {
+        const mockCounterpartyOrders = [
+            {
+                takeOrder: {
+                    id: "order2",
+                    takeOrder: {
+                        order: {
+                            owner: "0xowner1", // same as main order owner
+                        },
+                    },
+                    quote: { ratio: 500000000000000000n },
+                },
+            },
+            {
+                takeOrder: {
+                    id: "order3",
+                    takeOrder: {
+                        order: {
+                            owner: "0xowner3",
+                        },
+                    },
+                    quote: { ratio: 600000000000000000n },
+                },
+            },
+        ];
+        mockRainSolver.orderManager.getCounterpartyOrders.mockReturnValue(mockCounterpartyOrders);
+
+        (trySimulateTrade as Mock).mockResolvedValue(
+            Result.ok({
+                spanAttributes: { foundOpp: true },
+                estimatedProfit: 200n,
+                oppBlockNumber: 123,
+            }),
+        );
+
+        await findBestIntraOrderbookTrade.call(
+            mockRainSolver,
+            orderDetails,
+            signer,
+            inputToEthPrice,
+            outputToEthPrice,
+        );
+
+        // should only call trySimulateTrade once (filtered out same owner order)
+        expect(trySimulateTrade).toHaveBeenCalledTimes(1);
+    });
+
+    it("should filter out orders where price multiplication >= 1", async () => {
+        const mockCounterpartyOrders = [
+            {
+                takeOrder: {
+                    id: "order2",
+                    takeOrder: {
+                        order: {
+                            owner: "0xowner2",
+                        },
+                    },
+                    quote: { ratio: 1200000000000000000n }, // 1.2 * 1.0 = 1.2 >= 1, should be filtered
+                },
+            },
+            {
+                takeOrder: {
+                    id: "order3",
+                    takeOrder: {
+                        order: {
+                            owner: "0xowner3",
+                        },
+                    },
+                    quote: { ratio: 800000000000000000n }, // 0.8 * 1.0 = 0.8 < 1, should pass
+                },
+            },
+        ];
+        mockRainSolver.orderManager.getCounterpartyOrders.mockReturnValue(mockCounterpartyOrders);
+
+        (trySimulateTrade as Mock).mockResolvedValue(
+            Result.ok({
+                spanAttributes: { foundOpp: true },
+                estimatedProfit: 200n,
+                oppBlockNumber: 123,
+            }),
+        );
+
+        await findBestIntraOrderbookTrade.call(
+            mockRainSolver,
+            orderDetails,
+            signer,
+            inputToEthPrice,
+            outputToEthPrice,
+        );
+
+        // should only call trySimulateTrade once (filtered out high ratio order)
+        expect(trySimulateTrade).toHaveBeenCalledTimes(1);
+    });
+
+    it("should filter out orders without quote", async () => {
+        const mockCounterpartyOrders = [
+            {
+                takeOrder: {
+                    id: "order2",
+                    takeOrder: {
+                        order: {
+                            owner: "0xowner2",
+                        },
+                    },
+                    quote: null, // no quote, should be filtered
+                },
+            },
+            {
+                takeOrder: {
+                    id: "order3",
+                    takeOrder: {
+                        order: {
+                            owner: "0xowner3",
+                        },
+                    },
+                    quote: { ratio: 800000000000000000n },
+                },
+            },
+        ];
+        mockRainSolver.orderManager.getCounterpartyOrders.mockReturnValue(mockCounterpartyOrders);
+
+        (trySimulateTrade as Mock).mockResolvedValue(
+            Result.ok({
+                spanAttributes: { foundOpp: true },
+                estimatedProfit: 200n,
+                oppBlockNumber: 123,
+            }),
+        );
+
+        await findBestIntraOrderbookTrade.call(
+            mockRainSolver,
+            orderDetails,
+            signer,
+            inputToEthPrice,
+            outputToEthPrice,
+        );
+
+        // should only call trySimulateTrade once (filtered out order without quote)
+        expect(trySimulateTrade).toHaveBeenCalledTimes(1);
+    });
+
+    it("should limit to top 3 counterparty orders", async () => {
+        const mockCounterpartyOrders = [
+            {
+                takeOrder: {
+                    id: "order2",
+                    takeOrder: {
+                        order: {
+                            owner: "0xowner2",
+                        },
+                    },
+                    quote: { ratio: 500000000000000000n },
+                },
+            },
+            {
+                takeOrder: {
+                    id: "order3",
+                    takeOrder: {
+                        order: {
+                            owner: "0xowner3",
+                        },
+                    },
+                    quote: { ratio: 600000000000000000n },
+                },
+            },
+            {
+                takeOrder: {
+                    id: "order4",
+                    takeOrder: {
+                        order: {
+                            owner: "0xowner4",
+                        },
+                    },
+                    quote: { ratio: 700000000000000000n },
+                },
+            },
+            {
+                takeOrder: {
+                    id: "order5", // should be ignored
+                    takeOrder: {
+                        order: {
+                            owner: "0xowner5",
+                        },
+                    },
+                    quote: { ratio: 800000000000000000n },
+                },
+            },
+        ];
+        mockRainSolver.orderManager.getCounterpartyOrders.mockReturnValue(mockCounterpartyOrders);
+
+        (trySimulateTrade as Mock).mockResolvedValue(
+            Result.err({
+                spanAttributes: { error: "failed" },
+                noneNodeError: "simulation failed",
+            }),
+        );
+
+        await findBestIntraOrderbookTrade.call(
+            mockRainSolver,
+            orderDetails,
+            signer,
+            inputToEthPrice,
+            outputToEthPrice,
+        );
+
+        // should only call trySimulateTrade 3 times (top 3 orders)
+        expect(trySimulateTrade).toHaveBeenCalledTimes(3);
+    });
+
+    it("should call trySimulateTrade with correct parameters", async () => {
+        const mockCounterpartyOrders = [
+            {
+                takeOrder: {
+                    id: "order2",
+                    takeOrder: {
+                        order: {
+                            owner: "0xowner2",
+                        },
+                    },
+                    quote: { ratio: 500000000000000000n },
+                },
+            },
+        ];
+        mockRainSolver.orderManager.getCounterpartyOrders.mockReturnValue(mockCounterpartyOrders);
+
+        (trySimulateTrade as Mock).mockResolvedValue(
+            Result.err({
+                spanAttributes: { error: "failed" },
+                noneNodeError: "simulation failed",
+            }),
+        );
+
+        await findBestIntraOrderbookTrade.call(
+            mockRainSolver,
+            orderDetails,
+            signer,
+            inputToEthPrice,
+            outputToEthPrice,
+        );
+
+        expect(trySimulateTrade).toHaveBeenCalledWith({
+            orderDetails,
+            counterpartyOrderDetails: mockCounterpartyOrders[0].takeOrder,
+            signer,
+            inputToEthPrice,
+            outputToEthPrice,
+            blockNumber: 123n,
+            inputBalance: 5000000000000000000n,
+            outputBalance: 3000000000000000000n,
+        });
+    });
+
+    it("should handle empty counterparty orders after filtering", async () => {
+        const mockCounterpartyOrders = [
+            {
+                takeOrder: {
+                    id: "order1", // same ID as main order
+                    takeOrder: {
+                        order: {
+                            owner: "0xowner2",
+                        },
+                    },
+                    quote: { ratio: 500000000000000000n },
+                },
+            },
+        ];
+        mockRainSolver.orderManager.getCounterpartyOrders.mockReturnValue(mockCounterpartyOrders);
+
+        const result: SimulationResult = await findBestIntraOrderbookTrade.call(
+            mockRainSolver,
+            orderDetails,
+            signer,
+            inputToEthPrice,
+            outputToEthPrice,
+        );
+
+        assert(result.isErr());
+        expect(result.error.noneNodeError).toBeUndefined();
+        expect(trySimulateTrade).not.toHaveBeenCalled();
+    });
+});

--- a/src/solver/modes/intra/index.ts
+++ b/src/solver/modes/intra/index.ts
@@ -1,0 +1,104 @@
+import assert from "assert";
+import { erc20Abi } from "viem";
+import { RainSolver } from "../..";
+import { Result } from "../../../result";
+import { BundledOrders } from "../../../order";
+import { ONE18, scale18 } from "../../../math";
+import { SimulationResult } from "../../types";
+import { Attributes } from "@opentelemetry/api";
+import { trySimulateTrade } from "./simulation";
+import { RainSolverSigner } from "../../../signer";
+import { extendObjectWithHeader } from "../../../logger";
+
+/**
+ * Tries to find the best trade against opposite orders of the same orderbook (intra-orderbook) for
+ * the given order, it will simultaneously try to find the best trade against top 3 orders (by ratio)
+ * @param this - RainSolver instance
+ * @param orderDetails - The details of the order to be processed
+ * @param signer - The signer to be used for the trade
+ * @param inputToEthPrice - The current price of input token to ETH price
+ * @param outputToEthPrice - The current price of output token to ETH price
+ */
+export async function findBestIntraOrderbookTrade(
+    this: RainSolver,
+    orderDetails: BundledOrders,
+    signer: RainSolverSigner,
+    inputToEthPrice: string,
+    outputToEthPrice: string,
+): Promise<SimulationResult> {
+    const spanAttributes: Attributes = {};
+
+    // get counterparties and perform a general filter on them
+    const counterpartyOrders = this.orderManager.getCounterpartyOrders(orderDetails, true).filter(
+        (v) =>
+            v.takeOrder.quote &&
+            // not same order
+            v.takeOrder.id !== orderDetails.takeOrders[0].id &&
+            // not same owner
+            v.takeOrder.takeOrder.order.owner.toLowerCase() !==
+                orderDetails.takeOrders[0].takeOrder.order.owner.toLowerCase() &&
+            // only orders that (priceA x priceB < 1) can be profitbale
+            (v.takeOrder.quote.ratio * orderDetails.takeOrders[0].quote!.ratio) / ONE18 < ONE18,
+    );
+
+    const blockNumber = await this.state.client.getBlockNumber();
+    const inputBalance = scale18(
+        await this.state.client.readContract({
+            address: orderDetails.buyToken as `0x${string}`,
+            abi: erc20Abi,
+            functionName: "balanceOf",
+            args: [signer.account.address],
+        }),
+        orderDetails.buyTokenDecimals,
+    );
+    const outputBalance = scale18(
+        await this.state.client.readContract({
+            address: orderDetails.sellToken as `0x${string}`,
+            abi: erc20Abi,
+            functionName: "balanceOf",
+            args: [signer.account.address],
+        }),
+        orderDetails.sellTokenDecimals,
+    );
+
+    // run simulations for top 3 counterparty orders
+    const promises = counterpartyOrders.slice(0, 3).map((counterparty) => {
+        return trySimulateTrade.call(this, {
+            orderDetails,
+            counterpartyOrderDetails: counterparty.takeOrder,
+            signer,
+            inputToEthPrice,
+            outputToEthPrice,
+            blockNumber,
+            inputBalance,
+            outputBalance,
+        });
+    });
+
+    const results = await Promise.all(promises);
+    if (results.some((res) => res.isOk())) {
+        // pick the one with highest estimated profit
+        return results.sort((a, b) => {
+            if (a.isErr() && b.isErr()) return 0;
+            if (a.isErr()) return 1;
+            if (b.isErr()) return -1;
+            return a.value.estimatedProfit < b.value.estimatedProfit
+                ? 1
+                : a.value.estimatedProfit > b.value.estimatedProfit
+                  ? -1
+                  : 0;
+        })[0];
+    } else {
+        const allNoneNodeErrors: (string | undefined)[] = [];
+        for (let i = 0; i < results.length; i++) {
+            const res = results[i];
+            assert(res.isErr()); // for type check as we know all results are errors
+            extendObjectWithHeader(spanAttributes, res.error.spanAttributes, "intraOrderbook." + i);
+            allNoneNodeErrors.push(res.error.noneNodeError);
+        }
+        return Result.err({
+            spanAttributes,
+            noneNodeError: allNoneNodeErrors[0],
+        });
+    }
+}

--- a/src/solver/modes/intra/simulation.test.ts
+++ b/src/solver/modes/intra/simulation.test.ts
@@ -1,0 +1,291 @@
+import { dryrun } from "../dryrun";
+import { RainSolver } from "../..";
+import { ONE18 } from "../../../math";
+import { Result } from "../../../result";
+import { encodeFunctionData } from "viem";
+import { BundledOrders, TakeOrderDetails } from "../../../order";
+import { describe, it, expect, vi, beforeEach, Mock, assert } from "vitest";
+import { trySimulateTrade, SimulateIntraOrderbookTradeArgs } from "./simulation";
+
+vi.mock("viem", async (importOriginal) => ({
+    ...(await importOriginal()),
+    encodeFunctionData: vi.fn().mockReturnValue("0xdata"),
+}));
+
+vi.mock("./utils", () => ({
+    estimateProfit: vi.fn().mockReturnValue(200n),
+}));
+
+vi.mock("../../../task", () => ({
+    parseRainlang: vi.fn().mockResolvedValue("0xbytecode"),
+    getWithdrawEnsureRainlang: vi.fn().mockResolvedValue("rainlang"),
+}));
+
+vi.mock("../dryrun", () => ({
+    dryrun: vi.fn(),
+}));
+
+function makeOrderDetails(ratio = 1n * ONE18): BundledOrders {
+    return {
+        orderbook: "0xorderbook",
+        sellToken: "0xselltoken",
+        buyToken: "0xbuytoken",
+        sellTokenDecimals: 18,
+        buyTokenDecimals: 18,
+        takeOrders: [
+            {
+                takeOrder: {
+                    order: {},
+                    inputIOIndex: 0,
+                    outputIOIndex: 1,
+                },
+                quote: { ratio },
+            },
+        ],
+    } as BundledOrders;
+}
+
+function makeCounterpartyOrder(): TakeOrderDetails {
+    return {
+        takeOrder: {
+            order: {},
+            inputIOIndex: 1,
+            outputIOIndex: 0,
+        },
+    } as TakeOrderDetails;
+}
+
+describe("Test trySimulateTrade", () => {
+    let solver: RainSolver;
+    let args: SimulateIntraOrderbookTradeArgs;
+
+    beforeEach(() => {
+        vi.clearAllMocks();
+        solver = {
+            state: {
+                gasPrice: 1n,
+                chainConfig: {
+                    isSpecialL2: false,
+                },
+                dispair: {
+                    interpreter: "0xint",
+                    store: "0xstore",
+                },
+                client: {},
+            },
+            appOptions: {
+                arbAddress: "0xarb",
+                gasCoveragePercentage: "0",
+                gasLimitMultiplier: 120,
+            },
+        } as any;
+        args = {
+            orderDetails: makeOrderDetails(),
+            counterpartyOrderDetails: makeCounterpartyOrder(),
+            signer: { account: { address: "0xsigner" } },
+            inputToEthPrice: "0.5",
+            outputToEthPrice: "2.0",
+            inputBalance: 5n * ONE18,
+            outputBalance: 3n * ONE18,
+            blockNumber: 123n,
+        } as any;
+    });
+
+    it("should return error if initial dryrun fails", async () => {
+        (dryrun as Mock).mockResolvedValueOnce(
+            Result.err({
+                spanAttributes: { stage: 1 },
+                reason: "NoOpportunity",
+            }),
+        );
+
+        const result = await trySimulateTrade.call(solver, args);
+
+        assert(result.isErr());
+        expect(result.error).toHaveProperty("spanAttributes");
+        expect(result.error.spanAttributes.stage).toBe(1);
+        expect(result.error.spanAttributes.oppBlockNumber).toBe(123);
+    });
+
+    it("should return ok result if all steps succeed with gasCoveragePercentage 0", async () => {
+        (dryrun as Mock).mockResolvedValueOnce(
+            Result.ok({
+                estimation: { gas: 100n, totalGasCost: 200n, gasPrice: 1n },
+                estimatedGasCost: 200n,
+                spanAttributes: {},
+            }),
+        );
+        args.orderDetails = makeOrderDetails(1n * ONE18);
+        solver.appOptions.gasCoveragePercentage = "0";
+
+        const result = await trySimulateTrade.call(solver, args);
+
+        assert(result.isOk());
+        expect(result.value).toHaveProperty("spanAttributes");
+        expect(result.value).toHaveProperty("rawtx");
+        expect(result.value).toHaveProperty("estimatedGasCost");
+        expect(result.value).toHaveProperty("oppBlockNumber");
+        expect(result.value).toHaveProperty("estimatedProfit");
+        expect(result.value.estimatedProfit).toBe(200n);
+        expect(result.value.oppBlockNumber).toBe(Number(args.blockNumber));
+        expect(result.value.spanAttributes.foundOpp).toBe(true);
+        expect(result.value.estimatedGasCost).toBe(200n);
+        expect(result.value.rawtx).toHaveProperty("data", "0xdata");
+        expect(result.value.rawtx).toHaveProperty("to", "0xorderbook");
+        expect(result.value.rawtx).toHaveProperty("gasPrice", 1n);
+
+        // assert encodeFunctionData was called correctly for multicall
+        expect(encodeFunctionData).toHaveBeenCalledWith({
+            abi: expect.any(Array), // OrderbookMulticallAbi
+            functionName: "multicall",
+            args: [expect.any(Array)],
+        });
+
+        // assert encodeFunctionData was called for clear2
+        expect(encodeFunctionData).toHaveBeenCalledWith({
+            abi: expect.any(Array), // Clear2Abi
+            functionName: "clear2",
+            args: [
+                {},
+                {},
+                {
+                    aliceInputIOIndex: 0n,
+                    aliceOutputIOIndex: 1n,
+                    bobInputIOIndex: 1n,
+                    bobOutputIOIndex: 0n,
+                    aliceBountyVaultId: 1n,
+                    bobBountyVaultId: 1n,
+                },
+                [],
+                [],
+            ],
+        });
+
+        // assert encodeFunctionData was called for withdraw2 (input)
+        expect(encodeFunctionData).toHaveBeenCalledWith({
+            abi: expect.any(Array), // Withdraw2Abi
+            functionName: "withdraw2",
+            args: ["0xbuytoken", 1n, expect.any(BigInt), []],
+        });
+
+        // assert encodeFunctionData was called for withdraw2 (output)
+        expect(encodeFunctionData).toHaveBeenCalledWith({
+            abi: expect.any(Array), // Withdraw2Abi
+            functionName: "withdraw2",
+            args: ["0xselltoken", 1n, expect.any(BigInt), []],
+        });
+    });
+
+    it("should return ok result if all steps succeed with gasCoveragePercentage not 0", async () => {
+        (dryrun as Mock)
+            .mockResolvedValueOnce(
+                Result.ok({
+                    estimation: { gas: 100n, totalGasCost: 200n, gasPrice: 1n },
+                    estimatedGasCost: 200n,
+                    spanAttributes: { initial: "data" },
+                }),
+            )
+            .mockResolvedValueOnce(
+                Result.ok({
+                    estimation: { gas: 150n, totalGasCost: 300n, gasPrice: 1n },
+                    estimatedGasCost: 300n,
+                    spanAttributes: { final: "data" },
+                }),
+            );
+        args.orderDetails = makeOrderDetails(1n * ONE18);
+        solver.appOptions.gasCoveragePercentage = "100";
+
+        const result = await trySimulateTrade.call(solver, args);
+
+        assert(result.isOk());
+        expect(result.value).toHaveProperty("spanAttributes");
+        expect(result.value).toHaveProperty("rawtx");
+        expect(result.value).toHaveProperty("estimatedGasCost");
+        expect(result.value).toHaveProperty("oppBlockNumber");
+        expect(result.value).toHaveProperty("estimatedProfit");
+        expect(result.value.estimatedProfit).toBe(200n);
+        expect(result.value.oppBlockNumber).toBe(Number(args.blockNumber));
+        expect(result.value.spanAttributes.foundOpp).toBe(true);
+        expect(result.value.estimatedGasCost).toBe(300n);
+        expect(result.value.spanAttributes.initial).toBe("data");
+        expect(result.value.spanAttributes.final).toBe("data");
+        expect(result.value.rawtx).toHaveProperty("data", "0xdata");
+        expect(result.value.rawtx).toHaveProperty("to", "0xorderbook");
+        expect(result.value.rawtx).toHaveProperty("gasPrice", 1n);
+
+        // verify encodeFunctionData called multiple times (initial, final, and last)
+        expect(encodeFunctionData).toHaveBeenCalledTimes(8); // 4 calls * 2 dryruns
+    });
+
+    it("should return error if final dryrun fails when gasCoveragePercentage is not 0", async () => {
+        (dryrun as Mock)
+            .mockResolvedValueOnce(
+                Result.ok({
+                    estimation: { gas: 100n, totalGasCost: 200n, gasPrice: 1n },
+                    estimatedGasCost: 200n,
+                    spanAttributes: {},
+                }),
+            )
+            .mockResolvedValueOnce(
+                Result.err({
+                    spanAttributes: { stage: 2 },
+                    reason: "NoOpportunity",
+                }),
+            );
+        args.orderDetails = makeOrderDetails(1n * ONE18);
+        solver.appOptions.gasCoveragePercentage = "100";
+
+        const result = await trySimulateTrade.call(solver, args);
+
+        assert(result.isErr());
+        expect(result.error).toHaveProperty("spanAttributes");
+        expect(result.error.spanAttributes.stage).toBe(2);
+        expect(result.error.spanAttributes["gasEst.initial.gasLimit"]).toBe("100");
+        expect(result.error.spanAttributes["gasEst.initial.totalCost"]).toBe("200");
+        expect(result.error.spanAttributes["gasEst.initial.gasPrice"]).toBe("1");
+        expect(result.error.spanAttributes["gasEst.initial.minBountyExpected"]).toBe("206");
+
+        // verify encodeFunctionData was called for both dryruns
+        expect(encodeFunctionData).toHaveBeenCalledTimes(6); // 3 calls * 2 dryruns
+    });
+
+    it("should handle different input/output IO indices correctly", async () => {
+        (dryrun as Mock).mockResolvedValue(
+            Result.ok({
+                estimation: { gas: 100n, totalGasCost: 200n, gasPrice: 1n },
+                estimatedGasCost: 200n,
+                spanAttributes: {},
+            }),
+        );
+        args.orderDetails = makeOrderDetails(1n * ONE18);
+        args.orderDetails.takeOrders[0].takeOrder.inputIOIndex = 2;
+        args.orderDetails.takeOrders[0].takeOrder.outputIOIndex = 3;
+        args.counterpartyOrderDetails.takeOrder.inputIOIndex = 4;
+        args.counterpartyOrderDetails.takeOrder.outputIOIndex = 5;
+
+        const result = await trySimulateTrade.call(solver, args);
+
+        assert(result.isOk());
+        expect(result.value.spanAttributes.foundOpp).toBe(true);
+
+        // verify clear2 was called with correct IO indices
+        expect(encodeFunctionData).toHaveBeenCalledWith({
+            abi: expect.any(Array),
+            functionName: "clear2",
+            args: [
+                {},
+                {},
+                {
+                    aliceInputIOIndex: 2n,
+                    aliceOutputIOIndex: 3n,
+                    bobInputIOIndex: 4n,
+                    bobOutputIOIndex: 5n,
+                    aliceBountyVaultId: 1n,
+                    bobBountyVaultId: 1n,
+                },
+                [],
+                [],
+            ],
+        });
+    });
+});

--- a/src/solver/modes/intra/simulation.ts
+++ b/src/solver/modes/intra/simulation.ts
@@ -1,0 +1,272 @@
+import { RainSolver } from "../..";
+import { dryrun } from "../dryrun";
+import { Result } from "../../../result";
+import { estimateProfit } from "./utils";
+import { Attributes } from "@opentelemetry/api";
+import { RainSolverSigner } from "../../../signer";
+import { extendObjectWithHeader } from "../../../logger";
+import { SimulationResult, TaskType } from "../../types";
+import { BundledOrders, TakeOrderDetails } from "../../../order";
+import { encodeFunctionData, maxUint256, parseUnits } from "viem";
+import { getWithdrawEnsureRainlang, parseRainlang } from "../../../task";
+import { Clear2Abi, OrderbookMulticallAbi, Withdraw2Abi } from "../../../abis";
+
+/** Arguments for simulating inter-orderbook trade */
+export type SimulateIntraOrderbookTradeArgs = {
+    /** The bundled order details including tokens, decimals, and take orders */
+    orderDetails: BundledOrders;
+    /** The counterparty order to trade against */
+    counterpartyOrderDetails: TakeOrderDetails;
+    /** The RainSolverSigner instance used for signing transactions */
+    signer: RainSolverSigner;
+    /** The input token to ETH price (in 18 decimals) */
+    inputToEthPrice: string;
+    /** The output token to ETH price (in 18 decimals) */
+    outputToEthPrice: string;
+    /** The current input token balance of signer (in 18 decimals) */
+    inputBalance: bigint;
+    /** The current output token balance of signer (in 18 decimals) */
+    outputBalance: bigint;
+    /** The current block number for context */
+    blockNumber: bigint;
+};
+
+/**
+ * Attempts to simulate a intra-orderbook trade against the given counterparty order
+ * @param this - The RainSolver instance context
+ * @param args - The arguments for simulating the trade
+ */
+export async function trySimulateTrade(
+    this: RainSolver,
+    args: SimulateIntraOrderbookTradeArgs,
+): Promise<SimulationResult> {
+    const {
+        orderDetails,
+        counterpartyOrderDetails,
+        signer,
+        inputToEthPrice,
+        outputToEthPrice,
+        inputBalance,
+        outputBalance,
+        blockNumber,
+    } = args;
+    const gasPrice = this.state.gasPrice;
+    const spanAttributes: Attributes = {};
+    const inputBountyVaultId = 1n;
+    const outputBountyVaultId = 1n;
+
+    // build clear2 function call data and withdraw tasks
+    const task: TaskType = {
+        evaluable: {
+            interpreter: this.state.dispair.interpreter as `0x${string}`,
+            store: this.state.dispair.store as `0x${string}`,
+            bytecode: (await parseRainlang(
+                await getWithdrawEnsureRainlang(
+                    signer.account.address,
+                    orderDetails.buyToken,
+                    orderDetails.sellToken,
+                    inputBalance,
+                    outputBalance,
+                    parseUnits(inputToEthPrice, 18),
+                    parseUnits(outputToEthPrice, 18),
+                    0n,
+                    signer.account.address,
+                ),
+                this.state.client,
+                this.state.dispair,
+            )) as `0x${string}`,
+        },
+        signedContext: [],
+    };
+    const withdrawInputCalldata = encodeFunctionData({
+        abi: Withdraw2Abi,
+        functionName: "withdraw2",
+        args: [orderDetails.buyToken, inputBountyVaultId, maxUint256, []],
+    });
+    let withdrawOutputCalldata = encodeFunctionData({
+        abi: Withdraw2Abi,
+        functionName: "withdraw2",
+        args: [
+            orderDetails.sellToken,
+            outputBountyVaultId,
+            maxUint256,
+            this.appOptions.gasCoveragePercentage === "0" ? [] : [task],
+        ],
+    });
+    const clear2Calldata = encodeFunctionData({
+        abi: Clear2Abi,
+        functionName: "clear2",
+        args: [
+            orderDetails.takeOrders[0].takeOrder.order,
+            counterpartyOrderDetails.takeOrder.order,
+            {
+                aliceInputIOIndex: BigInt(orderDetails.takeOrders[0].takeOrder.inputIOIndex),
+                aliceOutputIOIndex: BigInt(orderDetails.takeOrders[0].takeOrder.outputIOIndex),
+                bobInputIOIndex: BigInt(counterpartyOrderDetails.takeOrder.inputIOIndex),
+                bobOutputIOIndex: BigInt(counterpartyOrderDetails.takeOrder.outputIOIndex),
+                aliceBountyVaultId: inputBountyVaultId,
+                bobBountyVaultId: outputBountyVaultId,
+            },
+            [],
+            [],
+        ],
+    });
+    const rawtx: any = {
+        data: encodeFunctionData({
+            abi: OrderbookMulticallAbi,
+            functionName: "multicall",
+            args: [[clear2Calldata, withdrawInputCalldata, withdrawOutputCalldata]],
+        }),
+        to: orderDetails.orderbook,
+        gasPrice,
+    };
+    spanAttributes["oppBlockNumber"] = Number(blockNumber);
+
+    // initial dryrun with 0 minimum sender output to get initial
+    // pass and tx gas cost to calc minimum sender output
+    spanAttributes["oppBlockNumber"] = Number(blockNumber);
+    const initDryrunResult = await dryrun(
+        signer,
+        rawtx,
+        gasPrice,
+        this.appOptions.gasLimitMultiplier,
+    );
+    if (initDryrunResult.isErr()) {
+        spanAttributes["stage"] = 1;
+        Object.assign(initDryrunResult.error.spanAttributes, spanAttributes);
+        return Result.err(initDryrunResult.error);
+    }
+
+    let { estimation, estimatedGasCost } = initDryrunResult.value;
+    // include dryrun initial gas estimation in logs
+    Object.assign(spanAttributes, initDryrunResult.value.spanAttributes);
+    // include dryrun headroom gas estimation in otel logs
+    extendObjectWithHeader(
+        spanAttributes,
+        {
+            gasLimit: estimation.gas.toString(),
+            totalCost: estimation.totalGasCost.toString(),
+            gasPrice: estimation.gasPrice.toString(),
+            ...(this.state.chainConfig.isSpecialL2
+                ? {
+                      l1Cost: estimation.l1Cost.toString(),
+                      l1GasPrice: estimation.l1GasPrice.toString(),
+                  }
+                : {}),
+        },
+        "gasEst.initial",
+    );
+
+    // repeat the same process with heaedroom if gas
+    // coverage is not 0, 0 gas coverage means 0 minimum
+    // sender output which is already called above
+    if (this.appOptions.gasCoveragePercentage !== "0") {
+        const headroom = BigInt((Number(this.appOptions.gasCoveragePercentage) * 1.03).toFixed());
+        spanAttributes["gasEst.initial.minBountyExpected"] = (
+            (estimatedGasCost * headroom) /
+            100n
+        ).toString();
+        task.evaluable.bytecode = (await parseRainlang(
+            await getWithdrawEnsureRainlang(
+                signer.account.address,
+                orderDetails.buyToken,
+                orderDetails.sellToken,
+                inputBalance,
+                outputBalance,
+                parseUnits(inputToEthPrice, 18),
+                parseUnits(outputToEthPrice, 18),
+                (estimatedGasCost * headroom) / 100n,
+                signer.account.address,
+            ),
+            this.state.client,
+            this.state.dispair,
+        )) as `0x${string}`;
+        withdrawOutputCalldata = encodeFunctionData({
+            abi: Withdraw2Abi,
+            functionName: "withdraw2",
+            args: [orderDetails.sellToken, outputBountyVaultId, maxUint256, [task]],
+        });
+        rawtx.data = encodeFunctionData({
+            abi: OrderbookMulticallAbi,
+            functionName: "multicall",
+            args: [[clear2Calldata, withdrawInputCalldata, withdrawOutputCalldata]],
+        });
+
+        const finalDryrunResult = await dryrun(
+            signer,
+            rawtx,
+            gasPrice,
+            this.appOptions.gasLimitMultiplier,
+        );
+        if (finalDryrunResult.isErr()) {
+            spanAttributes["stage"] = 2;
+            Object.assign(finalDryrunResult.error.spanAttributes, spanAttributes);
+            return Result.err(finalDryrunResult.error);
+        }
+
+        ({ estimation, estimatedGasCost } = finalDryrunResult.value);
+        // include dryrun final gas estimation in otel logs
+        Object.assign(spanAttributes, finalDryrunResult.value.spanAttributes);
+        extendObjectWithHeader(
+            spanAttributes,
+            {
+                gasLimit: estimation.gas.toString(),
+                totalCost: estimation.totalGasCost.toString(),
+                gasPrice: estimation.gasPrice.toString(),
+                ...(this.state.chainConfig.isSpecialL2
+                    ? {
+                          l1Cost: estimation.l1Cost.toString(),
+                          l1GasPrice: estimation.l1GasPrice.toString(),
+                      }
+                    : {}),
+            },
+            "gasEst.final",
+        );
+
+        task.evaluable.bytecode = (await parseRainlang(
+            await getWithdrawEnsureRainlang(
+                signer.account.address,
+                orderDetails.buyToken,
+                orderDetails.sellToken,
+                inputBalance,
+                outputBalance,
+                parseUnits(inputToEthPrice, 18),
+                parseUnits(outputToEthPrice, 18),
+                (estimatedGasCost * BigInt(this.appOptions.gasCoveragePercentage)) / 100n,
+                signer.account.address,
+            ),
+            this.state.client,
+            this.state.dispair,
+        )) as `0x${string}`;
+        withdrawOutputCalldata = encodeFunctionData({
+            abi: Withdraw2Abi,
+            functionName: "withdraw2",
+            args: [orderDetails.sellToken, outputBountyVaultId, maxUint256, [task]],
+        });
+        rawtx.data = encodeFunctionData({
+            abi: OrderbookMulticallAbi,
+            functionName: "multicall",
+            args: [[clear2Calldata, withdrawInputCalldata, withdrawOutputCalldata]],
+        });
+        spanAttributes["gasEst.final.minBountyExpected"] = (
+            (estimatedGasCost * BigInt(this.appOptions.gasCoveragePercentage)) /
+            100n
+        ).toString();
+    }
+
+    // if reached here, it means there was a success and found opp
+    spanAttributes["foundOpp"] = true;
+    const result = {
+        spanAttributes,
+        rawtx,
+        estimatedGasCost,
+        oppBlockNumber: Number(blockNumber),
+        estimatedProfit: estimateProfit(
+            orderDetails,
+            parseUnits(inputToEthPrice, 18),
+            parseUnits(outputToEthPrice, 18),
+            counterpartyOrderDetails,
+        ),
+    };
+    return Result.ok(result);
+}

--- a/src/solver/modes/intra/utils.test.ts
+++ b/src/solver/modes/intra/utils.test.ts
@@ -1,0 +1,266 @@
+import { ONE18 } from "../../../math";
+import { estimateProfit } from "./utils";
+import { describe, it, expect } from "vitest";
+import { BundledOrders, TakeOrderDetails } from "../../../order";
+
+const ONE17 = 10n ** 17n;
+function makeOrderPairObject(ratio: bigint, maxOutput: bigint): BundledOrders {
+    return {
+        takeOrders: [
+            {
+                quote: {
+                    ratio,
+                    maxOutput,
+                },
+            },
+        ],
+    } as BundledOrders;
+}
+function makeCounterpartyOrder(ratio: bigint, maxOutput: bigint): TakeOrderDetails {
+    return {
+        quote: {
+            ratio,
+            maxOutput,
+        },
+    } as TakeOrderDetails;
+}
+
+describe("Test estimateProfit", () => {
+    it("should calculate profit correctly when both orders can be filled completely", () => {
+        const orderPairObject = makeOrderPairObject(2n * ONE18, 10n * ONE18); // ratio = 2.0, maxOutput = 10
+        const inputToEthPrice = 1n * ONE18; // 1 ETH per input token
+        const outputToEthPrice = 3n * ONE18; // 3 ETH per output token
+        const counterpartyOrder = makeCounterpartyOrder(5n * ONE17, 20n * ONE18); // ratio = 0.5, maxOutput = 20
+
+        // orderMaxInput = (10 * 2) / 1 = 20
+        // opposingMaxInput = (20 * 0.5) / 1 = 10
+        // orderOutput = min(10, 10) = 10
+        // orderInput = (10 * 2) / 1 = 20
+        // opposingOutput = min(20, 20) = 20
+        // opposingInput = (20 * 0.5) / 1 = 10
+        // outputProfit = max(0, 10 - 10) = 0, in ETH = 0
+        // inputProfit = max(0, 20 - 20) = 0, in ETH = 0
+        // total = 0 + 0 = 0
+        const result = estimateProfit(
+            orderPairObject,
+            inputToEthPrice,
+            outputToEthPrice,
+            counterpartyOrder,
+        );
+        expect(result).toBe(0n);
+    });
+
+    it("should calculate profit when order output is limited by opposing max input", () => {
+        const orderPairObject = makeOrderPairObject(1n * ONE18, 15n * ONE18); // ratio = 1.0, maxOutput = 15
+        const inputToEthPrice = 2n * ONE18;
+        const outputToEthPrice = 3n * ONE18; // Changed from 1n to 3n
+        const counterpartyOrder = makeCounterpartyOrder(5n * ONE17, 20n * ONE18); // ratio 0.5
+
+        // orderMaxInput = (15 * 1) / 1 = 15
+        // opposingMaxInput = (20 * 0.5) / 1 = 10
+        // orderOutput = min(15, 10) = 10
+        // orderInput = (10 * 1) / 1 = 10
+        // opposingOutput = min(15, 20) = 15
+        // opposingInput = (15 * 0.5) / 1 = 7.5
+        // outputProfit = max(0, 10 - 7.5) = 2.5, in ETH = 2.5 * 3 = 7.5
+        // inputProfit = max(0, 15 - 10) = 5, in ETH = 5 * 2 = 10
+        // total = 7.5 + 10 = 17.5
+        const result = estimateProfit(
+            orderPairObject,
+            inputToEthPrice,
+            outputToEthPrice,
+            counterpartyOrder,
+        );
+        expect(result).toBe(175n * ONE17); // 17.5 * ONE18
+    });
+
+    it("should calculate profit when opposing output is limited by order max input", () => {
+        const orderPairObject = makeOrderPairObject(15n * ONE17, 8n * ONE18); // ratio 1.5, maxOutput = 8
+        const inputToEthPrice = 2n * ONE18; // Changed from 1n to 2n
+        const outputToEthPrice = 4n * ONE18;
+        const counterpartyOrder = makeCounterpartyOrder(5n * ONE17, 20n * ONE18); // ratio 0.5
+
+        // orderMaxInput = (8 * 1.5) / 1 = 12
+        // opposingMaxInput = (20 * 0.5) / 1 = 10
+        // orderOutput = min(8, 10) = 8
+        // orderInput = (8 * 1.5) / 1 = 12
+        // opposingOutput = min(12, 20) = 12
+        // opposingInput = (12 * 0.5) / 1 = 6
+        // outputProfit = max(0, 8 - 6) = 2, in ETH = 2 * 4 = 8
+        // inputProfit = max(0, 12 - 12) = 0
+        // total = 8 + 0 = 8
+        const result = estimateProfit(
+            orderPairObject,
+            inputToEthPrice,
+            outputToEthPrice,
+            counterpartyOrder,
+        );
+        expect(result).toBe(8n * ONE18);
+    });
+
+    it("should calculate profit when opposing output is limited by counterparty max output", () => {
+        const orderPairObject = makeOrderPairObject(1n * ONE18, 8n * ONE18); // ratio = 1.0, maxOutput = 8
+        const inputToEthPrice = 2n * ONE18;
+        const outputToEthPrice = 3n * ONE18;
+        const counterpartyOrder = makeCounterpartyOrder(5n * ONE17, 5n * ONE18); // ratio = 0.5, maxOutput = 5
+
+        // orderMaxInput = (8 * 1) / 1 = 8
+        // opposingMaxInput = (5 * 0.5) / 1 = 2.5
+        // orderOutput = min(8, 2.5) = 2.5
+        // orderInput = (2.5 * 1) / 1 = 2.5
+        // opposingOutput = min(8, 5) = 5
+        // opposingInput = (5 * 0.5) / 1 = 2.5
+        // outputProfit = max(0, 2.5 - 2.5) = 0
+        // inputProfit = max(0, 5 - 2.5) = 2.5, in ETH = 2.5 * 2 = 5
+        // total = 0 + 5 = 5
+        const result = estimateProfit(
+            orderPairObject,
+            inputToEthPrice,
+            outputToEthPrice,
+            counterpartyOrder,
+        );
+        expect(result).toBe(5n * ONE18);
+    });
+
+    it("should handle counterparty order with zero ratio", () => {
+        const orderPairObject = makeOrderPairObject(1n * ONE18, 10n * ONE18); // ratio = 1.0, maxOutput = 10
+        const inputToEthPrice = 1n * ONE18;
+        const outputToEthPrice = 2n * ONE18;
+        const counterpartyOrder = makeCounterpartyOrder(0n, 15n * ONE18); // ratio = 0, maxOutput = 15
+
+        // When counterparty ratio is 0:
+        // orderOutput = 10 (orderPairObject maxOutput)
+        // orderInput = (10 * 1) / 1 = 10
+        // opposingOutput = 15 (counterparty maxOutput)
+        // opposingInput = (15 * 0) / 1 = 0
+        // outputProfit = max(0, 10 - 0) = 10, in ETH = 10 * 2 = 20
+        // inputProfit = max(0, 15 - 10) = 5, in ETH = 5 * 1 = 5
+        // total = 20 + 5 = 25
+        const result = estimateProfit(
+            orderPairObject,
+            inputToEthPrice,
+            outputToEthPrice,
+            counterpartyOrder,
+        );
+        expect(result).toBe(25n * ONE18);
+    });
+
+    it("should handle order pair object with zero ratio", () => {
+        const orderPairObject = makeOrderPairObject(0n, 12n * ONE18); // ratio = 0, maxOutput = 12
+        const inputToEthPrice = 3n * ONE18;
+        const outputToEthPrice = 1n * ONE18;
+        const counterpartyOrder = makeCounterpartyOrder(1n * ONE18, 8n * ONE18); // ratio = 1.0, maxOutput = 8
+
+        // orderMaxInput = (12 * 0) / 1 = 0
+        // opposingMaxInput = (8 * 1) / 1 = 8
+        // orderOutput = min(12, 8) = 8
+        // orderInput = (8 * 0) / 1 = 0
+        // opposingOutput = min(0, 8) = 0
+        // opposingInput = (0 * 1) / 1 = 0
+        // outputProfit = max(0, 8 - 0) = 8, in ETH = 8 * 1 = 8
+        // inputProfit = max(0, 0 - 0) = 0
+        // total = 8 + 0 = 8
+        const result = estimateProfit(
+            orderPairObject,
+            inputToEthPrice,
+            outputToEthPrice,
+            counterpartyOrder,
+        );
+        expect(result).toBe(8n * ONE18);
+    });
+
+    it("should handle both orders with zero ratio", () => {
+        const orderPairObject = makeOrderPairObject(0n, 6n * ONE18); // ratio = 0, maxOutput = 6
+        const inputToEthPrice = 2n * ONE18;
+        const outputToEthPrice = 3n * ONE18;
+        const counterpartyOrder = makeCounterpartyOrder(0n, 4n * ONE18); // ratio = 0, maxOutput = 4
+
+        // When both ratios are 0:
+        // orderOutput = 6 (orderPairObject maxOutput)
+        // orderInput = (6 * 0) / 1 = 0
+        // opposingOutput = 4 (counterparty maxOutput)
+        // opposingInput = (4 * 0) / 1 = 0
+        // outputProfit = max(0, 6 - 0) = 6, in ETH = 6 * 3 = 18
+        // inputProfit = max(0, 4 - 0) = 4, in ETH = 4 * 2 = 8
+        // total = 18 + 8 = 26
+        const result = estimateProfit(
+            orderPairObject,
+            inputToEthPrice,
+            outputToEthPrice,
+            counterpartyOrder,
+        );
+        expect(result).toBe(26n * ONE18);
+    });
+
+    it("should handle edge case with zero max outputs", () => {
+        const orderPairObject = makeOrderPairObject(1n * ONE18, 0n); // maxOutput = 0
+        const inputToEthPrice = 1n * ONE18;
+        const outputToEthPrice = 1n * ONE18;
+        const counterpartyOrder = makeCounterpartyOrder(1n * ONE18, 0n); // maxOutput = 0
+
+        // orderMaxInput = (0 * 1) / 1 = 0
+        // opposingMaxInput = (0 * 1) / 1 = 0
+        // orderOutput = min(0, 0) = 0
+        // orderInput = (0 * 1) / 1 = 0
+        // opposingOutput = min(0, 0) = 0
+        // opposingInput = (0 * 1) / 1 = 0
+        // outputProfit = max(0, 0 - 0) = 0
+        // inputProfit = max(0, 0 - 0) = 0
+        // total = 0
+        const result = estimateProfit(
+            orderPairObject,
+            inputToEthPrice,
+            outputToEthPrice,
+            counterpartyOrder,
+        );
+        expect(result).toBe(0n);
+    });
+
+    it("should calculate profit when there is clear arbitrage opportunity", () => {
+        const orderPairObject = makeOrderPairObject(5n * ONE17, 20n * ONE18); // ratio = 0.5, maxOutput = 20
+        const inputToEthPrice = 2n * ONE18; // Changed from 1n to 2n
+        const outputToEthPrice = 3n * ONE18; // Changed from 1n to 3n
+        const counterpartyOrder = makeCounterpartyOrder(15n * ONE17, 8n * ONE18); // ratio 1.5, maxOutput 8
+
+        // orderMaxInput = (20 * 0.5) / 1 = 10
+        // opposingMaxInput = (8 * 1.5) / 1 = 12
+        // orderOutput = min(20, 12) = 12
+        // orderInput = (12 * 0.5) / 1 = 6
+        // opposingOutput = min(10, 8) = 8
+        // opposingInput = (8 * 1.5) / 1 = 12
+        // outputProfit = max(0, 12 - 12) = 0
+        // inputProfit = max(0, 8 - 6) = 2, in ETH = 2 * 2 = 4
+        // total = 0 + 4 = 4
+        const result = estimateProfit(
+            orderPairObject,
+            inputToEthPrice,
+            outputToEthPrice,
+            counterpartyOrder,
+        );
+        expect(result).toBe(4n * ONE18);
+    });
+
+    it("should handle asymmetric price ratios with profit", () => {
+        const orderPairObject = makeOrderPairObject(1n * ONE18, 10n * ONE18); // ratio = 1.0, maxOutput = 10
+        const inputToEthPrice = 1n * ONE18;
+        const outputToEthPrice = 2n * ONE18;
+        const counterpartyOrder = makeCounterpartyOrder(5n * ONE17, 15n * ONE18); // ratio = 0.5, maxOutput = 15
+
+        // orderMaxInput = (10 * 1) / 1 = 10
+        // opposingMaxInput = (15 * 0.5) / 1 = 7.5
+        // orderOutput = min(10, 7.5) = 7.5
+        // orderInput = (7.5 * 1) / 1 = 7.5
+        // opposingOutput = min(10, 15) = 10
+        // opposingInput = (10 * 0.5) / 1 = 5
+        // outputProfit = max(0, 7.5 - 5) = 2.5, in ETH = 2.5 * 2 = 5
+        // inputProfit = max(0, 10 - 7.5) = 2.5, in ETH = 2.5 * 1 = 2.5
+        // total = 5 + 2.5 = 7.5
+        const result = estimateProfit(
+            orderPairObject,
+            inputToEthPrice,
+            outputToEthPrice,
+            counterpartyOrder,
+        );
+        expect(result).toBe(75n * ONE17); // 7.5 * ONE18
+    });
+});

--- a/src/solver/modes/intra/utils.ts
+++ b/src/solver/modes/intra/utils.ts
@@ -1,0 +1,51 @@
+import { ONE18 } from "../../../math";
+import { BundledOrders, TakeOrderDetails } from "../../../order";
+
+/**
+ * Estimates profit for a arb/clear2 tx
+ * @param orderPairObject
+ * @param inputToEthPrice
+ * @param outputToEthPrice
+ * @param counterpartyOrder
+ * @param marketPrice
+ * @param maxInput
+ */
+export function estimateProfit(
+    orderPairObject: BundledOrders,
+    inputToEthPrice: bigint,
+    outputToEthPrice: bigint,
+    counterpartyOrder: TakeOrderDetails,
+): bigint {
+    const orderMaxInput =
+        (orderPairObject.takeOrders[0].quote!.maxOutput *
+            orderPairObject.takeOrders[0].quote!.ratio) /
+        ONE18;
+    const opposingMaxInput =
+        (counterpartyOrder.quote!.maxOutput * counterpartyOrder.quote!.ratio) / ONE18;
+
+    const orderOutput =
+        counterpartyOrder.quote!.ratio === 0n
+            ? orderPairObject.takeOrders[0].quote!.maxOutput
+            : orderPairObject.takeOrders[0].quote!.maxOutput <= opposingMaxInput
+              ? orderPairObject.takeOrders[0].quote!.maxOutput
+              : opposingMaxInput;
+    const orderInput = (orderOutput * orderPairObject.takeOrders[0].quote!.ratio) / ONE18;
+
+    const opposingOutput =
+        counterpartyOrder.quote!.ratio === 0n
+            ? counterpartyOrder.quote!.maxOutput
+            : orderMaxInput <= counterpartyOrder.quote!.maxOutput
+              ? orderMaxInput
+              : counterpartyOrder.quote!.maxOutput;
+    const opposingInput = (opposingOutput * counterpartyOrder.quote!.ratio) / ONE18;
+
+    let outputProfit = orderOutput - opposingInput;
+    if (outputProfit < 0n) outputProfit = 0n;
+    outputProfit = (outputProfit * outputToEthPrice) / ONE18;
+
+    let inputProfit = opposingOutput - orderInput;
+    if (inputProfit < 0n) inputProfit = 0n;
+    inputProfit = (inputProfit * inputToEthPrice) / ONE18;
+
+    return outputProfit + inputProfit;
+}

--- a/src/solver/types.ts
+++ b/src/solver/types.ts
@@ -1,7 +1,7 @@
-import { Attributes } from "@opentelemetry/api";
-import { EstimateGasCostResult, RawTransaction } from "../signer";
 import { Result } from "../result";
 import { Evaluable, TakeOrder } from "../order";
+import { Attributes } from "@opentelemetry/api";
+import { EstimateGasCostResult, RawTransaction } from "../signer";
 
 /** Specifies reason that order process halted with failure */
 export enum ProcessOrderHaltReason {
@@ -29,7 +29,6 @@ export type ProcessOrderResultBase = {
     buyToken: string;
     sellToken: string;
     spanAttributes: Attributes;
-    txUrl?: string;
     gasCost?: bigint;
 };
 
@@ -65,10 +64,10 @@ export type TaskType = {
     signedContext: any[];
 };
 
+// dryrun result types
 export type DryrunResultBase = {
     spanAttributes: Attributes;
 };
-
 export type DryrunSuccess = DryrunResultBase & {
     estimatedGasCost: bigint;
     estimation: EstimateGasCostResult;
@@ -79,6 +78,7 @@ export type DryrunFailure = DryrunResultBase & {
 };
 export type DryrunResult = Result<DryrunSuccess, DryrunFailure>;
 
+// simulation result types
 export type SuccessSimulation = {
     spanAttributes: Attributes;
     estimatedGasCost: bigint;


### PR DESCRIPTION
<!-- Thanks for your Pull Request, please read the contributing guidelines before submitting. -->

## Motivation
related to #341 
### ⚠️ Do NOT merge before #363 

This PR implements the clearing mode for intra orderbook, that includes methods to simulate and find best intra-ob trade for the given order against counterparty orders of same orderbook as well as functionalities for estimating the solver profit.
also add extensive unit tests for newly added functionalities
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## Checks
<!-- It's important you've done these, or your PR will not be considered for review -->
By submitting this for review, I'm confirming I've done the following:
- [x] made this PR as small as possible
- [x] unit-tested any new functionality
- [x] linked any relevant issues or PRs
- [ ] ~~included screenshots (if this involves a front-end change)~~
