### PR TITLE
fallback eth price (for refactored version)

### DIFF
--- a/src/core/modes/inter/index.ts
+++ b/src/core/modes/inter/index.ts
@@ -3,6 +3,7 @@ import { RainSolver } from "../..";
 import { Result } from "../../../common";
 import { trySimulateTrade } from "./simulate";
 import { Attributes } from "@opentelemetry/api";
+import { fallbackEthPrice } from "../../../router";
 import { RainSolverSigner } from "../../../signer";
 import { BundledOrders, Pair } from "../../../order";
 import { extendObjectWithHeader } from "../../../logger";
@@ -51,8 +52,20 @@ export async function findBestInterOrderbookTrade(
                 counterpartyOrderDetails,
                 signer,
                 maximumInputFixed,
-                inputToEthPrice,
-                outputToEthPrice,
+                inputToEthPrice:
+                    inputToEthPrice ||
+                    fallbackEthPrice(
+                        orderDetails.takeOrders[0].quote!.ratio,
+                        counterpartyOrderDetails.takeOrder.quote!.ratio,
+                        outputToEthPrice,
+                    ),
+                outputToEthPrice:
+                    outputToEthPrice ||
+                    fallbackEthPrice(
+                        counterpartyOrderDetails.takeOrder.quote!.ratio,
+                        orderDetails.takeOrders[0].quote!.ratio,
+                        inputToEthPrice,
+                    ),
                 blockNumber,
             });
         });

--- a/src/core/modes/inter/simulate.test.ts
+++ b/src/core/modes/inter/simulate.test.ts
@@ -41,7 +41,10 @@ function makeOrderDetails(ratio = 1n * ONE18): BundledOrders {
 function makeCounterpartyOrder(): Pair {
     return {
         orderbook: "0xcounterpartyorderbook",
-        takeOrder: {},
+        takeOrder: {
+            id: "0xid",
+            quote: { maxOutput: 1n, ratio: 2n },
+        },
     } as Pair;
 }
 

--- a/src/core/modes/inter/simulate.ts
+++ b/src/core/modes/inter/simulate.ts
@@ -8,7 +8,7 @@ import { extendObjectWithHeader } from "../../../logger";
 import { ArbAbi, TakeOrdersV2Abi, Result } from "../../../common";
 import { RainSolverSigner, RawTransaction } from "../../../signer";
 import { getBountyEnsureRainlang, parseRainlang } from "../../../task";
-import { encodeAbiParameters, encodeFunctionData, maxUint256, parseUnits } from "viem";
+import { encodeAbiParameters, encodeFunctionData, formatUnits, maxUint256, parseUnits } from "viem";
 import {
     TaskType,
     TradeType,
@@ -55,6 +55,14 @@ export async function trySimulateTrade(
     } = args;
     const spanAttributes: Attributes = {};
     const gasPrice = this.state.gasPrice;
+
+    spanAttributes["against"] = counterpartyOrderDetails.takeOrder.id;
+    spanAttributes["inputToEthPrice"] = inputToEthPrice;
+    spanAttributes["outputToEthPrice"] = outputToEthPrice;
+    spanAttributes["counterpartyOrderQuote"] = JSON.stringify({
+        maxOutput: formatUnits(counterpartyOrderDetails.takeOrder.quote!.maxOutput, 18),
+        ratio: formatUnits(counterpartyOrderDetails.takeOrder.quote!.ratio, 18),
+    });
 
     const maximumInput = scale18To(maximumInputFixed, orderDetails.sellTokenDecimals);
     spanAttributes["maxInput"] = maximumInput.toString();

--- a/src/core/modes/intra/index.ts
+++ b/src/core/modes/intra/index.ts
@@ -7,6 +7,7 @@ import { ONE18, scale18 } from "../../../math";
 import { Attributes } from "@opentelemetry/api";
 import { trySimulateTrade } from "./simulation";
 import { RainSolverSigner } from "../../../signer";
+import { fallbackEthPrice } from "../../../router";
 import { extendObjectWithHeader } from "../../../logger";
 import { SimulationResult, TradeType } from "../../types";
 
@@ -67,8 +68,20 @@ export async function findBestIntraOrderbookTrade(
             orderDetails,
             counterpartyOrderDetails: counterparty.takeOrder,
             signer,
-            inputToEthPrice,
-            outputToEthPrice,
+            inputToEthPrice:
+                inputToEthPrice ||
+                fallbackEthPrice(
+                    orderDetails.takeOrders[0].quote!.ratio,
+                    counterparty.takeOrder.quote!.ratio,
+                    outputToEthPrice,
+                ),
+            outputToEthPrice:
+                outputToEthPrice ||
+                fallbackEthPrice(
+                    counterparty.takeOrder.quote!.ratio,
+                    orderDetails.takeOrders[0].quote!.ratio,
+                    inputToEthPrice,
+                ),
             blockNumber,
             inputBalance,
             outputBalance,

--- a/src/core/modes/intra/simulation.test.ts
+++ b/src/core/modes/intra/simulation.test.ts
@@ -47,6 +47,8 @@ function makeOrderDetails(ratio = 1n * ONE18): BundledOrders {
 
 function makeCounterpartyOrder(): TakeOrderDetails {
     return {
+        id: "0xid",
+        quote: { maxOutput: 1n, ratio: 2n },
         takeOrder: {
             order: {},
             inputIOIndex: 1,

--- a/src/core/modes/intra/simulation.ts
+++ b/src/core/modes/intra/simulation.ts
@@ -5,8 +5,8 @@ import { Attributes } from "@opentelemetry/api";
 import { RainSolverSigner } from "../../../signer";
 import { extendObjectWithHeader } from "../../../logger";
 import { BundledOrders, TakeOrderDetails } from "../../../order";
-import { encodeFunctionData, maxUint256, parseUnits } from "viem";
 import { getWithdrawEnsureRainlang, parseRainlang } from "../../../task";
+import { encodeFunctionData, formatUnits, maxUint256, parseUnits } from "viem";
 import { FailedSimulation, SimulationResult, TaskType, TradeType } from "../../types";
 import { Clear2Abi, OrderbookMulticallAbi, Withdraw2Abi, Result } from "../../../common";
 
@@ -53,6 +53,14 @@ export async function trySimulateTrade(
     const spanAttributes: Attributes = {};
     const inputBountyVaultId = 1n;
     const outputBountyVaultId = 1n;
+
+    spanAttributes["against"] = counterpartyOrderDetails.id;
+    spanAttributes["inputToEthPrice"] = inputToEthPrice;
+    spanAttributes["outputToEthPrice"] = outputToEthPrice;
+    spanAttributes["counterpartyOrderQuote"] = JSON.stringify({
+        maxOutput: formatUnits(counterpartyOrderDetails.quote!.maxOutput, 18),
+        ratio: formatUnits(counterpartyOrderDetails.quote!.ratio, 18),
+    });
 
     // build clear2 function call data and withdraw tasks
     const task: TaskType = {

--- a/src/core/modes/rp/index.test.ts
+++ b/src/core/modes/rp/index.test.ts
@@ -291,4 +291,21 @@ describe("Test findBestRouteProcessorTrade", () => {
             "full",
         );
     });
+
+    it("should return early if ethPrice is unknown", async () => {
+        const result: SimulationResult = await findBestRouteProcessorTrade.call(
+            mockRainSolver,
+            orderDetails,
+            signer,
+            "",
+            toToken,
+            fromToken,
+        );
+
+        assert(result.isErr());
+        expect(result.error.type).toBe("routeProcessor");
+        expect(result.error.spanAttributes.error).toBe(
+            "no route to get price of input token to eth",
+        );
+    });
 });

--- a/src/core/modes/rp/index.ts
+++ b/src/core/modes/rp/index.ts
@@ -32,6 +32,16 @@ export async function findBestRouteProcessorTrade(
     fromToken: Token,
 ): Promise<SimulationResult> {
     const spanAttributes: Attributes = {};
+
+    // exit early if eth price is unknown
+    if (!ethPrice) {
+        spanAttributes["error"] = "no route to get price of input token to eth";
+        return Result.err({
+            type: TradeType.RouteProcessor,
+            spanAttributes,
+        });
+    }
+
     const maximumInput = orderDetails.takeOrders.reduce((a, b) => a + b.quote!.maxOutput, 0n);
     const blockNumber = await this.state.client.getBlockNumber();
 

--- a/src/order/quote.ts
+++ b/src/order/quote.ts
@@ -22,16 +22,21 @@ export async function quoteSingleOrder(
     blockNumber?: bigint,
     gas?: bigint,
 ) {
-    const { data } = await viemClient.call({
-        to: orderDetails.orderbook as `0x${string}`,
-        data: encodeFunctionData({
-            abi: OrderbookQuoteAbi,
-            functionName: "quote",
-            args: [TakeOrder.getQuoteConfig(orderDetails.takeOrders[0].takeOrder)],
-        }),
-        blockNumber,
-        gas,
-    });
+    const { data } = await viemClient
+        .call({
+            to: orderDetails.orderbook as `0x${string}`,
+            data: encodeFunctionData({
+                abi: OrderbookQuoteAbi,
+                functionName: "quote",
+                args: [TakeOrder.getQuoteConfig(orderDetails.takeOrders[0].takeOrder)],
+            }),
+            blockNumber,
+            gas,
+        })
+        .catch((error) => {
+            orderDetails.takeOrders[0].quote = undefined;
+            throw error;
+        });
     if (typeof data !== "undefined") {
         const quoteResult = decodeFunctionResult({
             abi: OrderbookQuoteAbi,

--- a/src/router/marketPrice.ts
+++ b/src/router/marketPrice.ts
@@ -1,9 +1,9 @@
-import { scale18 } from "../math";
 import { SharedState } from "../state";
 import { Token } from "sushi/currency";
 import { ChainId, Router } from "sushi";
-import { formatUnits, parseUnits } from "viem";
+import { scale18, ONE18 } from "../math";
 import { PoolBlackList, RPoolFilter } from ".";
+import { formatUnits, parseUnits, maxUint256 } from "viem";
 
 /**
  * Get market price for 1 unit of token for a token pair
@@ -53,4 +53,35 @@ export async function getMarketPrice(
     } catch (error) {
         return;
     }
+}
+
+/**
+ * Calculates the fallback price of a token pair input token to ETH from the order and counterparty order
+ * ratios and known output token to ETH price when there is no route in sushi router to get the output token
+ * to ETH price directly.
+ * Thi is done by assuming the min of the two order and counterparty order ratios as a price path to calculate
+ * the pair's input token to ETH price, for calculating a pair output token to ETH price, just pass the ratios
+ * in place of eachother.
+ *
+ * @example
+ * pair A/B, where A is the input token and B is the output token
+ * we already know the price of B to ETH (oEthPrice), and we want to calculate the price of A to ETH
+ * we have the following ratios from order and counterparty order:
+ * - oiRatio: ratio of the order, which is OI, output token to input token, ie A/B
+ * - ioRatio: ratio of the counterparty order, which is IO, input token to output token, ie B/A
+ * by inversing the oiRatio, and getting min of that and ioRatio, we now have a path from
+ * A to B to ETH, which we can use to calculate the price of A to ETH:
+ * - if B to ETH price is 0.5
+ * - oiRatio is 2 (2 A for 1 B) and inveresed is 0.5 (0.5 B for 1 A)
+ * - ioRatio is 1 (1 B for 1 A)
+ * - A to ETH is: min(0.5, 1) * 0.5 = 0.25 ie for 1 A, we get 0.25 ETH
+ *
+ * @param oiRatio - The ratio of the order, ie output token to input token - OI ratio
+ * @param ioRatio - The ratio of the counterparty order, ie input token to output token - IO ratio
+ * @param oEthPrice - The output token price to ETH
+ */
+export function fallbackEthPrice(oiRatio: bigint, ioRatio: bigint, oEthPrice: string): string {
+    const oiRatioInverese = oiRatio === 0n ? maxUint256 : ONE18 ** 2n / oiRatio;
+    const minRatio = oiRatioInverese < ioRatio ? oiRatioInverese : ioRatio;
+    return formatUnits((minRatio * parseUnits(oEthPrice, 18)) / ONE18, 18);
 }


### PR DESCRIPTION
<!-- Thanks for your Pull Request, please read the contributing guidelines before submitting. -->

## Motivation
## ⚠️ Do NOT merge before #374 

This PR adds `fallbackEthPrice` function that is used to derive a token price to eth when there is no direct price for that from sushi router, it also updates the solving modes to use it and adds test for it
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## Checks
<!-- It's important you've done these, or your PR will not be considered for review -->
By submitting this for review, I'm confirming I've done the following:
- [x] made this PR as small as possible
- [x] unit-tested any new functionality
- [x] linked any relevant issues or PRs
- [ ] ~~included screenshots (if this involves a front-end change)~~
