### PR TITLE
`pairMap` update

### DIFF
--- a/src/core/modes/index.ts
+++ b/src/core/modes/index.ts
@@ -1,8 +1,8 @@
 import assert from "assert";
 import { RainSolver } from "..";
+import { Pair } from "../../order";
 import { Result } from "../../common";
 import { Token } from "sushi/currency";
-import { BundledOrders } from "../../order";
 import { FindBestTradeResult } from "../types";
 import { RainSolverSigner } from "../../signer";
 import { Attributes } from "@opentelemetry/api";
@@ -14,7 +14,7 @@ import { extendObjectWithHeader } from "../../logger";
 /** Arguments for finding the best trade */
 export type FindBestTradeArgs = {
     /** The order details to find the best trade for */
-    orderDetails: BundledOrders;
+    orderDetails: Pair;
     /** The signer that performs the trade simulation */
     signer: RainSolverSigner;
     /** The input token price to ETH */

--- a/src/core/modes/inter/index.test.ts
+++ b/src/core/modes/inter/index.test.ts
@@ -2,7 +2,7 @@ import { RainSolver } from "../..";
 import { Result } from "../../../common";
 import { trySimulateTrade } from "./simulate";
 import { SimulationResult } from "../../types";
-import { BundledOrders } from "../../../order";
+import { BundledOrders, CounterpartySource } from "../../../order";
 import { fallbackEthPrice } from "../../../router";
 import { RainSolverSigner } from "../../../signer";
 import { findBestInterOrderbookTrade } from "./index";
@@ -105,7 +105,7 @@ describe("Test findBestInterOrderbookTrade", () => {
         expect(result.value.oppBlockNumber).toBe(123);
         expect(mockRainSolver.orderManager.getCounterpartyOrders as Mock).toHaveBeenCalledWith(
             orderDetails,
-            false,
+            CounterpartySource.InterOrderbook,
         );
         expect(trySimulateTrade).toHaveBeenCalledTimes(3);
         expect(result.value.type).toBe("interOrderbook");

--- a/src/core/modes/inter/index.test.ts
+++ b/src/core/modes/inter/index.test.ts
@@ -46,10 +46,7 @@ describe("Test findBestInterOrderbookTrade", () => {
         } as any;
 
         orderDetails = {
-            takeOrders: [
-                { quote: { maxOutput: 1000n, ratio: 5n } },
-                { quote: { maxOutput: 2000n, ratio: 6n } },
-            ],
+            takeOrder: { quote: { maxOutput: 1000n, ratio: 5n } },
         } as any;
 
         signer = { account: { address: "0xsigner" } } as any;
@@ -285,7 +282,7 @@ describe("Test findBestInterOrderbookTrade", () => {
             orderDetails,
             counterpartyOrderDetails: { orderbook: "0xorderbook1", id: "order1" },
             signer,
-            maximumInputFixed: 3000n, // 1000 + 2000
+            maximumInputFixed: 1000n,
             inputToEthPrice,
             outputToEthPrice,
             blockNumber: 123n,
@@ -369,7 +366,7 @@ describe("Test findBestInterOrderbookTrade", () => {
             orderDetails,
             counterpartyOrderDetails: mockCounterpartyOrders[0][0],
             signer,
-            maximumInputFixed: 3000n, // 1000 + 2000
+            maximumInputFixed: 1000n,
             inputToEthPrice: "1",
             outputToEthPrice: "2",
             blockNumber: 123n,

--- a/src/core/modes/inter/index.ts
+++ b/src/core/modes/inter/index.ts
@@ -1,11 +1,11 @@
 import assert from "assert";
 import { RainSolver } from "../..";
+import { Pair } from "../../../order";
 import { Result } from "../../../common";
 import { trySimulateTrade } from "./simulate";
 import { Attributes } from "@opentelemetry/api";
 import { fallbackEthPrice } from "../../../router";
 import { RainSolverSigner } from "../../../signer";
-import { BundledOrders, Pair } from "../../../order";
 import { extendObjectWithHeader } from "../../../logger";
 import { SimulationResult, TradeType } from "../../types";
 
@@ -21,7 +21,7 @@ import { SimulationResult, TradeType } from "../../types";
  */
 export async function findBestInterOrderbookTrade(
     this: RainSolver,
-    orderDetails: BundledOrders,
+    orderDetails: Pair,
     signer: RainSolverSigner,
     inputToEthPrice: string,
     outputToEthPrice: string,
@@ -39,7 +39,7 @@ export async function findBestInterOrderbookTrade(
     const spanAttributes: Attributes = {};
     const blockNumber = await this.state.client.getBlockNumber();
     const counterpartyOrders = this.orderManager.getCounterpartyOrders(orderDetails, false);
-    const maximumInputFixed = orderDetails.takeOrders.reduce((a, b) => a + b.quote!.maxOutput, 0n);
+    const maximumInputFixed = orderDetails.takeOrder.quote!.maxOutput;
     const counterparties: Pair[] = [];
 
     // run simulations for top 3 counterparty orders of each orderbook
@@ -55,7 +55,7 @@ export async function findBestInterOrderbookTrade(
                 inputToEthPrice:
                     inputToEthPrice ||
                     fallbackEthPrice(
-                        orderDetails.takeOrders[0].quote!.ratio,
+                        orderDetails.takeOrder.quote!.ratio,
                         counterpartyOrderDetails.takeOrder.quote!.ratio,
                         outputToEthPrice,
                     ),
@@ -63,7 +63,7 @@ export async function findBestInterOrderbookTrade(
                     outputToEthPrice ||
                     fallbackEthPrice(
                         counterpartyOrderDetails.takeOrder.quote!.ratio,
-                        orderDetails.takeOrders[0].quote!.ratio,
+                        orderDetails.takeOrder.quote!.ratio,
                         inputToEthPrice,
                     ),
                 blockNumber,

--- a/src/core/modes/inter/index.ts
+++ b/src/core/modes/inter/index.ts
@@ -1,11 +1,11 @@
 import assert from "assert";
 import { RainSolver } from "../..";
-import { Pair } from "../../../order";
 import { Result } from "../../../common";
 import { trySimulateTrade } from "./simulate";
 import { Attributes } from "@opentelemetry/api";
 import { fallbackEthPrice } from "../../../router";
 import { RainSolverSigner } from "../../../signer";
+import { CounterpartySource, Pair } from "../../../order";
 import { extendObjectWithHeader } from "../../../logger";
 import { SimulationResult, TradeType } from "../../types";
 
@@ -38,7 +38,10 @@ export async function findBestInterOrderbookTrade(
 
     const spanAttributes: Attributes = {};
     const blockNumber = await this.state.client.getBlockNumber();
-    const counterpartyOrders = this.orderManager.getCounterpartyOrders(orderDetails, false);
+    const counterpartyOrders = this.orderManager.getCounterpartyOrders(
+        orderDetails,
+        CounterpartySource.InterOrderbook,
+    );
     const maximumInputFixed = orderDetails.takeOrder.quote!.maxOutput;
     const counterparties: Pair[] = [];
 

--- a/src/core/modes/inter/simulate.test.ts
+++ b/src/core/modes/inter/simulate.test.ts
@@ -1,9 +1,9 @@
 import { dryrun } from "../dryrun";
 import { RainSolver } from "../..";
 import { ONE18 } from "../../../math";
+import { Pair } from "../../../order";
 import { Result } from "../../../common";
 import { SimulationResult } from "../../types";
-import { BundledOrders, Pair } from "../../../order";
 import { encodeFunctionData, encodeAbiParameters } from "viem";
 import { describe, it, expect, vi, beforeEach, Mock, assert } from "vitest";
 import { trySimulateTrade, SimulateInterOrderbookTradeArgs } from "./simulate";
@@ -27,15 +27,15 @@ vi.mock("../dryrun", () => ({
     dryrun: vi.fn(),
 }));
 
-function makeOrderDetails(ratio = 1n * ONE18): BundledOrders {
+function makeOrderDetails(ratio = 1n * ONE18): Pair {
     return {
         orderbook: "0xorderbook",
         sellToken: "0xselltoken",
         buyToken: "0xbuytoken",
         sellTokenDecimals: 18,
         buyTokenDecimals: 18,
-        takeOrders: [{ takeOrder: {}, quote: { ratio } }],
-    } as BundledOrders;
+        takeOrder: { takeOrder: {}, quote: { ratio } },
+    } as Pair;
 }
 
 function makeCounterpartyOrder(): Pair {

--- a/src/core/modes/inter/utils.test.ts
+++ b/src/core/modes/inter/utils.test.ts
@@ -6,12 +6,10 @@ import { describe, it, expect } from "vitest";
 const ONE17 = 10n ** 17n;
 function makeOrderDetails(ratio: bigint) {
     return {
-        takeOrders: [
-            {
-                quote: { ratio },
-            },
-        ],
-    };
+        takeOrder: {
+            quote: { ratio },
+        },
+    } as Pair;
 }
 function makeCounterpartyOrder(ratio: bigint, maxOutput: bigint): Pair {
     return {

--- a/src/core/modes/inter/utils.ts
+++ b/src/core/modes/inter/utils.ts
@@ -4,23 +4,23 @@ import { Pair } from "../../../order";
 
 /** Estimates profit for a inter-orderbook trade */
 export function estimateProfit(
-    orderDetails: any,
+    orderDetails: Pair,
     inputToEthPrice: bigint,
     outputToEthPrice: bigint,
     counterpartyOrder: Pair,
     maxInput: bigint,
 ): bigint {
     const orderOutput = maxInput;
-    const orderInput = (maxInput * orderDetails.takeOrders[0].quote.ratio) / ONE18;
+    const orderInput = (maxInput * orderDetails.takeOrder.quote!.ratio) / ONE18;
 
     let opposingMaxInput =
-        orderDetails.takeOrders[0].quote.ratio === 0n
+        orderDetails.takeOrder.quote!.ratio === 0n
             ? maxUint256
-            : (maxInput * orderDetails.takeOrders[0].quote.ratio) / ONE18;
+            : (maxInput * orderDetails.takeOrder.quote!.ratio) / ONE18;
     const opposingMaxIORatio =
-        orderDetails.takeOrders[0].quote.ratio === 0n
+        orderDetails.takeOrder.quote!.ratio === 0n
             ? maxUint256
-            : ONE18 ** 2n / orderDetails.takeOrders[0].quote.ratio;
+            : ONE18 ** 2n / orderDetails.takeOrder.quote!.ratio;
 
     let counterpartyInput = 0n;
     let counterpartyOutput = 0n;

--- a/src/core/modes/intra/index.test.ts
+++ b/src/core/modes/intra/index.test.ts
@@ -49,17 +49,15 @@ describe("Test findBestIntraOrderbookTrade", () => {
         };
 
         orderDetails = {
-            takeOrders: [
-                {
-                    id: "order1",
-                    takeOrder: {
-                        order: {
-                            owner: "0xowner1",
-                        },
+            takeOrder: {
+                id: "order1",
+                takeOrder: {
+                    order: {
+                        owner: "0xowner1",
                     },
-                    quote: { ratio: 1000000000000000000n }, // 1.0
                 },
-            ],
+                quote: { ratio: 1000000000000000000n }, // 1.0
+            },
             buyToken: "0xbuytoken",
             sellToken: "0xselltoken",
             buyTokenDecimals: 18,

--- a/src/core/modes/intra/index.test.ts
+++ b/src/core/modes/intra/index.test.ts
@@ -5,6 +5,7 @@ import { fallbackEthPrice } from "../../../router";
 import { findBestIntraOrderbookTrade } from "./index";
 import { extendObjectWithHeader } from "../../../logger";
 import { describe, it, expect, vi, beforeEach, Mock, assert } from "vitest";
+import { CounterpartySource } from "../../../order";
 
 vi.mock("../../../router", () => ({
     fallbackEthPrice: vi.fn(),
@@ -146,7 +147,7 @@ describe("Test findBestIntraOrderbookTrade", () => {
         expect(result.value.oppBlockNumber).toBe(123);
         expect(mockRainSolver.orderManager.getCounterpartyOrders).toHaveBeenCalledWith(
             orderDetails,
-            true,
+            CounterpartySource.IntraOrderbook,
         );
         expect(trySimulateTrade).toHaveBeenCalledTimes(3);
         expect(result.value.type).toBe("intraOrderbook");

--- a/src/core/modes/intra/index.ts
+++ b/src/core/modes/intra/index.ts
@@ -1,9 +1,9 @@
 import assert from "assert";
 import { erc20Abi } from "viem";
 import { RainSolver } from "../..";
+import { Pair } from "../../../order";
 import { Result } from "../../../common";
-import { BundledOrders } from "../../../order";
-import { ONE18, scale18 } from "../../../math";
+import { ONE18, scaleTo18 } from "../../../math";
 import { Attributes } from "@opentelemetry/api";
 import { trySimulateTrade } from "./simulation";
 import { RainSolverSigner } from "../../../signer";
@@ -22,7 +22,7 @@ import { SimulationResult, TradeType } from "../../types";
  */
 export async function findBestIntraOrderbookTrade(
     this: RainSolver,
-    orderDetails: BundledOrders,
+    orderDetails: Pair,
     signer: RainSolverSigner,
     inputToEthPrice: string,
     outputToEthPrice: string,
@@ -34,16 +34,16 @@ export async function findBestIntraOrderbookTrade(
         (v) =>
             v.takeOrder.quote &&
             // not same order
-            v.takeOrder.id !== orderDetails.takeOrders[0].id &&
+            v.takeOrder.id !== orderDetails.takeOrder.id &&
             // not same owner
             v.takeOrder.takeOrder.order.owner.toLowerCase() !==
-                orderDetails.takeOrders[0].takeOrder.order.owner.toLowerCase() &&
+                orderDetails.takeOrder.takeOrder.order.owner.toLowerCase() &&
             // only orders that (priceA x priceB < 1) can be profitbale
-            (v.takeOrder.quote.ratio * orderDetails.takeOrders[0].quote!.ratio) / ONE18 < ONE18,
+            (v.takeOrder.quote.ratio * orderDetails.takeOrder.quote!.ratio) / ONE18 < ONE18,
     );
 
     const blockNumber = await this.state.client.getBlockNumber();
-    const inputBalance = scale18(
+    const inputBalance = scaleTo18(
         await this.state.client.readContract({
             address: orderDetails.buyToken as `0x${string}`,
             abi: erc20Abi,
@@ -52,7 +52,7 @@ export async function findBestIntraOrderbookTrade(
         }),
         orderDetails.buyTokenDecimals,
     );
-    const outputBalance = scale18(
+    const outputBalance = scaleTo18(
         await this.state.client.readContract({
             address: orderDetails.sellToken as `0x${string}`,
             abi: erc20Abi,
@@ -71,7 +71,7 @@ export async function findBestIntraOrderbookTrade(
             inputToEthPrice:
                 inputToEthPrice ||
                 fallbackEthPrice(
-                    orderDetails.takeOrders[0].quote!.ratio,
+                    orderDetails.takeOrder.quote!.ratio,
                     counterparty.takeOrder.quote!.ratio,
                     outputToEthPrice,
                 ),
@@ -79,7 +79,7 @@ export async function findBestIntraOrderbookTrade(
                 outputToEthPrice ||
                 fallbackEthPrice(
                     counterparty.takeOrder.quote!.ratio,
-                    orderDetails.takeOrders[0].quote!.ratio,
+                    orderDetails.takeOrder.quote!.ratio,
                     inputToEthPrice,
                 ),
             blockNumber,

--- a/src/core/modes/intra/simulation.test.ts
+++ b/src/core/modes/intra/simulation.test.ts
@@ -3,7 +3,7 @@ import { RainSolver } from "../..";
 import { ONE18 } from "../../../math";
 import { Result } from "../../../common";
 import { encodeFunctionData } from "viem";
-import { BundledOrders, TakeOrderDetails } from "../../../order";
+import { Pair, TakeOrderDetails } from "../../../order";
 import { describe, it, expect, vi, beforeEach, Mock, assert } from "vitest";
 import { trySimulateTrade, SimulateIntraOrderbookTradeArgs } from "./simulation";
 
@@ -25,24 +25,22 @@ vi.mock("../dryrun", () => ({
     dryrun: vi.fn(),
 }));
 
-function makeOrderDetails(ratio = 1n * ONE18): BundledOrders {
+function makeOrderDetails(ratio = 1n * ONE18): Pair {
     return {
         orderbook: "0xorderbook",
         sellToken: "0xselltoken",
         buyToken: "0xbuytoken",
         sellTokenDecimals: 18,
         buyTokenDecimals: 18,
-        takeOrders: [
-            {
-                takeOrder: {
-                    order: {},
-                    inputIOIndex: 0,
-                    outputIOIndex: 1,
-                },
-                quote: { ratio },
+        takeOrder: {
+            takeOrder: {
+                order: {},
+                inputIOIndex: 0,
+                outputIOIndex: 1,
             },
-        ],
-    } as BundledOrders;
+            quote: { ratio },
+        },
+    } as Pair;
 }
 
 function makeCounterpartyOrder(): TakeOrderDetails {
@@ -264,8 +262,8 @@ describe("Test trySimulateTrade", () => {
             }),
         );
         args.orderDetails = makeOrderDetails(1n * ONE18);
-        args.orderDetails.takeOrders[0].takeOrder.inputIOIndex = 2;
-        args.orderDetails.takeOrders[0].takeOrder.outputIOIndex = 3;
+        args.orderDetails.takeOrder.takeOrder.inputIOIndex = 2;
+        args.orderDetails.takeOrder.takeOrder.outputIOIndex = 3;
         args.counterpartyOrderDetails.takeOrder.inputIOIndex = 4;
         args.counterpartyOrderDetails.takeOrder.outputIOIndex = 5;
 

--- a/src/core/modes/intra/simulation.ts
+++ b/src/core/modes/intra/simulation.ts
@@ -4,7 +4,7 @@ import { estimateProfit } from "./utils";
 import { Attributes } from "@opentelemetry/api";
 import { RainSolverSigner } from "../../../signer";
 import { extendObjectWithHeader } from "../../../logger";
-import { BundledOrders, TakeOrderDetails } from "../../../order";
+import { Pair, TakeOrderDetails } from "../../../order";
 import { getWithdrawEnsureRainlang, parseRainlang } from "../../../task";
 import { encodeFunctionData, formatUnits, maxUint256, parseUnits } from "viem";
 import { FailedSimulation, SimulationResult, TaskType, TradeType } from "../../types";
@@ -13,7 +13,7 @@ import { Clear2Abi, OrderbookMulticallAbi, Withdraw2Abi, Result } from "../../..
 /** Arguments for simulating inter-orderbook trade */
 export type SimulateIntraOrderbookTradeArgs = {
     /** The bundled order details including tokens, decimals, and take orders */
-    orderDetails: BundledOrders;
+    orderDetails: Pair;
     /** The counterparty order to trade against */
     counterpartyOrderDetails: TakeOrderDetails;
     /** The RainSolverSigner instance used for signing transactions */
@@ -104,11 +104,11 @@ export async function trySimulateTrade(
         abi: Clear2Abi,
         functionName: "clear2",
         args: [
-            orderDetails.takeOrders[0].takeOrder.order,
+            orderDetails.takeOrder.takeOrder.order,
             counterpartyOrderDetails.takeOrder.order,
             {
-                aliceInputIOIndex: BigInt(orderDetails.takeOrders[0].takeOrder.inputIOIndex),
-                aliceOutputIOIndex: BigInt(orderDetails.takeOrders[0].takeOrder.outputIOIndex),
+                aliceInputIOIndex: BigInt(orderDetails.takeOrder.takeOrder.inputIOIndex),
+                aliceOutputIOIndex: BigInt(orderDetails.takeOrder.takeOrder.outputIOIndex),
                 bobInputIOIndex: BigInt(counterpartyOrderDetails.takeOrder.inputIOIndex),
                 bobOutputIOIndex: BigInt(counterpartyOrderDetails.takeOrder.outputIOIndex),
                 aliceBountyVaultId: inputBountyVaultId,

--- a/src/core/modes/intra/utils.test.ts
+++ b/src/core/modes/intra/utils.test.ts
@@ -1,20 +1,18 @@
 import { ONE18 } from "../../../math";
 import { estimateProfit } from "./utils";
 import { describe, it, expect } from "vitest";
-import { BundledOrders, TakeOrderDetails } from "../../../order";
+import { Pair, TakeOrderDetails } from "../../../order";
 
 const ONE17 = 10n ** 17n;
-function makeOrderPairObject(ratio: bigint, maxOutput: bigint): BundledOrders {
+function makeOrderPairObject(ratio: bigint, maxOutput: bigint): Pair {
     return {
-        takeOrders: [
-            {
-                quote: {
-                    ratio,
-                    maxOutput,
-                },
+        takeOrder: {
+            quote: {
+                ratio,
+                maxOutput,
             },
-        ],
-    } as BundledOrders;
+        },
+    } as Pair;
 }
 function makeCounterpartyOrder(ratio: bigint, maxOutput: bigint): TakeOrderDetails {
     return {

--- a/src/core/modes/intra/utils.ts
+++ b/src/core/modes/intra/utils.ts
@@ -1,5 +1,5 @@
 import { ONE18 } from "../../../math";
-import { BundledOrders, TakeOrderDetails } from "../../../order";
+import { Pair, TakeOrderDetails } from "../../../order";
 
 /**
  * Estimates profit for a arb/clear2 tx
@@ -11,24 +11,23 @@ import { BundledOrders, TakeOrderDetails } from "../../../order";
  * @param maxInput
  */
 export function estimateProfit(
-    orderDetails: BundledOrders,
+    orderDetails: Pair,
     inputToEthPrice: bigint,
     outputToEthPrice: bigint,
     counterpartyOrder: TakeOrderDetails,
 ): bigint {
     const orderMaxInput =
-        (orderDetails.takeOrders[0].quote!.maxOutput * orderDetails.takeOrders[0].quote!.ratio) /
-        ONE18;
+        (orderDetails.takeOrder.quote!.maxOutput * orderDetails.takeOrder.quote!.ratio) / ONE18;
     const opposingMaxInput =
         (counterpartyOrder.quote!.maxOutput * counterpartyOrder.quote!.ratio) / ONE18;
 
     const orderOutput =
         counterpartyOrder.quote!.ratio === 0n
-            ? orderDetails.takeOrders[0].quote!.maxOutput
-            : orderDetails.takeOrders[0].quote!.maxOutput <= opposingMaxInput
-              ? orderDetails.takeOrders[0].quote!.maxOutput
+            ? orderDetails.takeOrder.quote!.maxOutput
+            : orderDetails.takeOrder.quote!.maxOutput <= opposingMaxInput
+              ? orderDetails.takeOrder.quote!.maxOutput
               : opposingMaxInput;
-    const orderInput = (orderOutput * orderDetails.takeOrders[0].quote!.ratio) / ONE18;
+    const orderInput = (orderOutput * orderDetails.takeOrder.quote!.ratio) / ONE18;
 
     const opposingOutput =
         counterpartyOrder.quote!.ratio === 0n

--- a/src/core/modes/rp/index.test.ts
+++ b/src/core/modes/rp/index.test.ts
@@ -55,7 +55,7 @@ describe("Test findBestRouteProcessorTrade", () => {
         };
 
         orderDetails = {
-            takeOrders: [{ quote: { maxOutput: 1000n } }, { quote: { maxOutput: 2000n } }],
+            takeOrder: { quote: { maxOutput: 1000n } },
         };
 
         signer = { account: { address: "0xsigner" } };
@@ -92,7 +92,7 @@ describe("Test findBestRouteProcessorTrade", () => {
             fromToken,
             toToken,
             signer,
-            maximumInputFixed: 3000n, // 1000 + 2000
+            maximumInputFixed: 1000n,
             ethPrice,
             isPartial: false,
             blockNumber: 123n,
@@ -157,14 +157,14 @@ describe("Test findBestRouteProcessorTrade", () => {
         expect(result.value.spanAttributes.foundOpp).toBe(true);
         expect(result.value.estimatedProfit).toBe(50n);
         expect(result.value.type).toBe("routeProcessor");
-        expect(findLargestTradeSize).toHaveBeenCalledWith(orderDetails, toToken, fromToken, 3000n);
+        expect(findLargestTradeSize).toHaveBeenCalledWith(orderDetails, toToken, fromToken, 1000n);
         expect(trySimulateTrade).toHaveBeenCalledTimes(2);
         expect(trySimulateTrade).toHaveBeenLastCalledWith({
             orderDetails,
             fromToken,
             toToken,
             signer,
-            maximumInputFixed: 3000n, // still uses original maximumInput
+            maximumInputFixed: 1000n,
             ethPrice,
             isPartial: true,
             blockNumber: 123n,
@@ -273,14 +273,14 @@ describe("Test findBestRouteProcessorTrade", () => {
         expect(result.value.estimatedProfit).toBe(75n);
         expect(result.value.oppBlockNumber).toBe(123);
         expect(result.value.type).toBe("routeProcessor");
-        expect(findLargestTradeSize).toHaveBeenCalledWith(orderDetails, toToken, fromToken, 3000n);
+        expect(findLargestTradeSize).toHaveBeenCalledWith(orderDetails, toToken, fromToken, 1000n);
         expect(trySimulateTrade).toHaveBeenCalledTimes(2);
         expect(trySimulateTrade).toHaveBeenLastCalledWith({
             orderDetails,
             fromToken,
             toToken,
             signer,
-            maximumInputFixed: 3000n,
+            maximumInputFixed: 1000n,
             ethPrice,
             isPartial: true,
             blockNumber: 123n,

--- a/src/core/modes/rp/index.ts
+++ b/src/core/modes/rp/index.ts
@@ -1,7 +1,7 @@
 import { RainSolver } from "../..";
+import { Pair } from "../../../order";
 import { Token } from "sushi/currency";
 import { Result } from "../../../common";
-import { BundledOrders } from "../../../order";
 import { Attributes } from "@opentelemetry/api";
 import { RainSolverSigner } from "../../../signer";
 import { extendObjectWithHeader } from "../../../logger";
@@ -25,7 +25,7 @@ import {
  */
 export async function findBestRouteProcessorTrade(
     this: RainSolver,
-    orderDetails: BundledOrders,
+    orderDetails: Pair,
     signer: RainSolverSigner,
     ethPrice: string,
     toToken: Token,
@@ -42,7 +42,7 @@ export async function findBestRouteProcessorTrade(
         });
     }
 
-    const maximumInput = orderDetails.takeOrders.reduce((a, b) => a + b.quote!.maxOutput, 0n);
+    const maximumInput = orderDetails.takeOrder.quote!.maxOutput;
     const blockNumber = await this.state.client.getBlockNumber();
 
     // try simulation for full trade size and return if succeeds

--- a/src/core/modes/rp/simulate.test.ts
+++ b/src/core/modes/rp/simulate.test.ts
@@ -4,7 +4,7 @@ import { RainSolver } from "../..";
 import { ONE18 } from "../../../math";
 import { Token } from "sushi/currency";
 import { Result } from "../../../common";
-import { BundledOrders } from "../../../order";
+import { Pair } from "../../../order";
 import { SimulationResult } from "../../types";
 import { encodeFunctionData, encodeAbiParameters, maxUint256 } from "viem";
 import { describe, it, expect, vi, beforeEach, Mock, assert } from "vitest";
@@ -47,13 +47,13 @@ vi.mock("sushi", async (importOriginal) => ({
     },
 }));
 
-function makeOrderDetails(ratio = 1n * ONE18): BundledOrders {
+function makeOrderDetails(ratio = 1n * ONE18): Pair {
     return {
         orderbook: "0xorderbook",
         sellTokenDecimals: 18,
         buyTokenDecimals: 18,
-        takeOrders: [{ takeOrder: {}, quote: { ratio } }],
-    } as BundledOrders;
+        takeOrder: { takeOrder: {}, quote: { ratio } },
+    } as Pair;
 }
 
 describe("Test trySimulateTrade", () => {

--- a/src/core/modes/rp/utils.test.ts
+++ b/src/core/modes/rp/utils.test.ts
@@ -5,10 +5,8 @@ import { describe, it, expect } from "vitest";
 describe("Test estimateProfit", () => {
     it("should estimate profit correctly for typical values", () => {
         const orderDetails = {
-            takeOrders: [
-                { quote: { ratio: 2n * ONE18 } }, // ratio = 2.0
-            ],
-        };
+            takeOrder: { quote: { ratio: 2n * ONE18 } }, // ratio = 2.0
+        } as any;
         const ethPrice = 3n * ONE18; // 3 ETH
         const marketPrice = 4n * ONE18; // 4.0
         const maxInput = 10n * ONE18; // 10 units
@@ -23,8 +21,8 @@ describe("Test estimateProfit", () => {
 
     it("should return 0 if marketPrice equals order ratio", () => {
         const orderDetails = {
-            takeOrders: [{ quote: { ratio: 5n * ONE18 } }],
-        };
+            takeOrder: { quote: { ratio: 5n * ONE18 } },
+        } as any;
         const ethPrice = 1n * ONE18;
         const marketPrice = 5n * ONE18;
         const maxInput = 2n * ONE18;
@@ -39,8 +37,8 @@ describe("Test estimateProfit", () => {
 
     it("should return negative profit if order ratio > marketPrice", () => {
         const orderDetails = {
-            takeOrders: [{ quote: { ratio: 8n * ONE18 } }],
-        };
+            takeOrder: { quote: { ratio: 8n * ONE18 } },
+        } as any;
         const ethPrice = 2n * ONE18;
         const marketPrice = 5n * ONE18;
         const maxInput = 1n * ONE18;

--- a/src/core/modes/rp/utils.ts
+++ b/src/core/modes/rp/utils.ts
@@ -1,14 +1,15 @@
 import { ONE18 } from "../../../math";
+import { Pair } from "../../../order";
 
 /** Estimates profit for a route processor clear mode */
 export function estimateProfit(
-    orderDetails: any,
+    orderDetails: Pair,
     ethPrice: bigint,
     marketPrice: bigint,
     maxInput: bigint,
 ): bigint {
     const marketAmountOut = (maxInput * marketPrice) / ONE18;
-    const orderInput = (maxInput * orderDetails.takeOrders[0].quote.ratio) / ONE18;
+    const orderInput = (maxInput * orderDetails.takeOrder.quote!.ratio) / ONE18;
     const estimatedProfit = marketAmountOut - orderInput;
     return (estimatedProfit * ethPrice) / ONE18;
 }

--- a/src/core/process/log.ts
+++ b/src/core/process/log.ts
@@ -1,4 +1,4 @@
-import { ONE18, scale18 } from "../../math";
+import { ONE18, scaleTo18 } from "../../math";
 import { AfterClearAbi } from "../../common";
 import { erc20Abi, formatUnits, parseEventLogs, parseUnits, TransactionReceipt } from "viem";
 
@@ -109,7 +109,7 @@ export function getActualPrice(
                 log.args.from.toLowerCase() !== orderbook.toLowerCase()
             ) {
                 return formatUnits(
-                    (scale18(log.args.value, tokenDecimals) * ONE18) / BigInt(clearAmount),
+                    (scaleTo18(log.args.value, tokenDecimals) * ONE18) / BigInt(clearAmount),
                     18,
                 );
             }
@@ -133,7 +133,8 @@ export function getTotalIncome(
     const inputTokenIncomeInEth = (() => {
         if (inputTokenIncome) {
             return (
-                (parseUnits(inputTokenPrice, 18) * scale18(inputTokenIncome, inputTokenDecimals)) /
+                (parseUnits(inputTokenPrice, 18) *
+                    scaleTo18(inputTokenIncome, inputTokenDecimals)) /
                 ONE18
             );
         } else {
@@ -144,7 +145,7 @@ export function getTotalIncome(
         if (outputTokenIncome) {
             return (
                 (parseUnits(outputTokenPrice, 18) *
-                    scale18(outputTokenIncome, outputTokenDecimals)) /
+                    scaleTo18(outputTokenIncome, outputTokenDecimals)) /
                 ONE18
             );
         } else {

--- a/src/core/process/order.test.ts
+++ b/src/core/process/order.test.ts
@@ -38,6 +38,8 @@ describe("Test processOrder", () => {
         vi.clearAllMocks();
         mockOrderManager = {
             quoteOrder: vi.fn(),
+            addToPairMap: vi.fn(),
+            deleteFromPairMap: vi.fn(),
         } as any;
         mockState = {
             chainConfig: {
@@ -62,13 +64,12 @@ describe("Test processOrder", () => {
                 buyToken: "0xBUY",
                 sellTokenSymbol: "SELL",
                 buyTokenSymbol: "BUY",
-                takeOrders: [
-                    {
-                        id: 1,
-                        quote: { maxOutput: 1000000000000000000n, ratio: 2000000000000000000n },
-                        takeOrder: {},
-                    },
-                ],
+                orderbook: "0xorderbook",
+                takeOrder: {
+                    id: "0xid",
+                    quote: { maxOutput: 1000000000000000000n, ratio: 2000000000000000000n },
+                    takeOrder: {},
+                },
             },
             signer: {},
         } as any;
@@ -82,7 +83,7 @@ describe("Test processOrder", () => {
 
     it("should return ZeroOutput if quoted maxOutput is 0", async () => {
         (mockOrderManager.quoteOrder as Mock).mockResolvedValue(undefined);
-        mockArgs.orderDetails.takeOrders[0].quote = { maxOutput: 0n, ratio: 0n };
+        mockArgs.orderDetails.takeOrder.quote = { maxOutput: 0n, ratio: 0n };
 
         const fn: Awaited<ReturnType<typeof processOrder>> = await processOrder.call(
             mockRainSolver,
@@ -96,8 +97,12 @@ describe("Test processOrder", () => {
         expect(result.value.tokenPair).toBe("BUY/SELL");
         expect(result.value.buyToken).toBe("0xBUY");
         expect(result.value.sellToken).toBe("0xSELL");
-        expect(result.value.spanAttributes["details.orders"]).toEqual([1]);
+        expect(result.value.spanAttributes["details.orders"]).toEqual("0xid");
         expect(result.value.spanAttributes["details.pair"]).toBe("BUY/SELL");
+
+        // ensure pair maps are updated success quote
+        expect(mockOrderManager.addToPairMap).toHaveBeenCalledWith(mockArgs.orderDetails, false);
+        expect(mockOrderManager.addToPairMap).toHaveBeenCalledWith(mockArgs.orderDetails, true);
     });
 
     it("should return FailedToQuote if quoteOrder throws", async () => {
@@ -117,8 +122,24 @@ describe("Test processOrder", () => {
         expect(result.error.buyToken).toBe("0xBUY");
         expect(result.error.sellToken).toBe("0xSELL");
         expect(result.error.status).toBe(ProcessOrderStatus.NoOpportunity);
-        expect(result.error.spanAttributes["details.orders"]).toEqual([1]);
+        expect(result.error.spanAttributes["details.orders"]).toEqual("0xid");
         expect(result.error.spanAttributes["details.pair"]).toBe("BUY/SELL");
+
+        // ensure pair maps are updated on quote failure
+        expect(mockOrderManager.deleteFromPairMap).toHaveBeenCalledWith(
+            mockArgs.orderDetails.orderbook.toLowerCase(),
+            mockArgs.orderDetails.takeOrder.id.toLowerCase(),
+            mockArgs.orderDetails.sellToken.toLowerCase(),
+            mockArgs.orderDetails.buyToken.toLowerCase(),
+            false,
+        );
+        expect(mockOrderManager.deleteFromPairMap).toHaveBeenCalledWith(
+            mockArgs.orderDetails.orderbook.toLowerCase(),
+            mockArgs.orderDetails.takeOrder.id.toLowerCase(),
+            mockArgs.orderDetails.sellToken.toLowerCase(),
+            mockArgs.orderDetails.buyToken.toLowerCase(),
+            true,
+        );
     });
 
     it("should return FailedToUpdatePools if updatePools throws (not fetchPoolsForToken)", async () => {
@@ -141,7 +162,7 @@ describe("Test processOrder", () => {
         expect(result.error.spanAttributes["details.quote"]).toBe(
             JSON.stringify({ maxOutput: "1", ratio: "2" }),
         );
-        expect(result.error.spanAttributes["details.orders"]).toEqual([1]);
+        expect(result.error.spanAttributes["details.orders"]).toEqual("0xid");
         expect(result.error.spanAttributes["details.pair"]).toBe("BUY/SELL");
     });
 
@@ -165,7 +186,7 @@ describe("Test processOrder", () => {
         expect(result.error.spanAttributes["details.quote"]).toBe(
             JSON.stringify({ maxOutput: "1", ratio: "2" }),
         );
-        expect(result.error.spanAttributes["details.orders"]).toEqual([1]);
+        expect(result.error.spanAttributes["details.orders"]).toEqual("0xid");
         expect(result.error.spanAttributes["details.pair"]).toBe("BUY/SELL");
     });
 
@@ -192,7 +213,7 @@ describe("Test processOrder", () => {
         expect(result.value.spanAttributes["details.quote"]).toBe(
             JSON.stringify({ maxOutput: "1", ratio: "2" }),
         );
-        expect(result.value.spanAttributes["details.orders"]).toEqual([1]);
+        expect(result.value.spanAttributes["details.orders"]).toEqual("0xid");
         expect(result.value.spanAttributes["details.pair"]).toBe("BUY/SELL");
         expect(result.value.spanAttributes["details.inputToEthPrice"]).toBe("100");
         expect(result.value.spanAttributes["details.outputToEthPrice"]).toBe("no-way");
@@ -221,7 +242,7 @@ describe("Test processOrder", () => {
         expect(result.value.spanAttributes["details.quote"]).toBe(
             JSON.stringify({ maxOutput: "1", ratio: "2" }),
         );
-        expect(result.value.spanAttributes["details.orders"]).toEqual([1]);
+        expect(result.value.spanAttributes["details.orders"]).toEqual("0xid");
         expect(result.value.spanAttributes["details.pair"]).toBe("BUY/SELL");
         expect(result.value.spanAttributes["details.inputToEthPrice"]).toBe("100");
         expect(result.value.spanAttributes["details.outputToEthPrice"]).toBe("0");
@@ -246,7 +267,7 @@ describe("Test processOrder", () => {
         expect(result.error.spanAttributes["details.quote"]).toBe(
             JSON.stringify({ maxOutput: "1", ratio: "2" }),
         );
-        expect(result.error.spanAttributes["details.orders"]).toEqual([1]);
+        expect(result.error.spanAttributes["details.orders"]).toEqual("0xid");
         expect(result.error.spanAttributes["details.pair"]).toBe("BUY/SELL");
     });
 
@@ -271,7 +292,7 @@ describe("Test processOrder", () => {
         expect(result.value.spanAttributes["details.quote"]).toBe(
             JSON.stringify({ maxOutput: "1", ratio: "2" }),
         );
-        expect(result.value.spanAttributes["details.orders"]).toEqual([1]);
+        expect(result.value.spanAttributes["details.orders"]).toEqual("0xid");
         expect(result.value.spanAttributes["details.pair"]).toBe("BUY/SELL");
     });
 
@@ -294,7 +315,7 @@ describe("Test processOrder", () => {
         expect(result.value.spanAttributes["details.quote"]).toBe(
             JSON.stringify({ maxOutput: "1", ratio: "2" }),
         );
-        expect(result.value.spanAttributes["details.orders"]).toEqual([1]);
+        expect(result.value.spanAttributes["details.orders"]).toEqual("0xid");
         expect(result.value.spanAttributes["details.pair"]).toBe("BUY/SELL");
         expect(result.value.spanAttributes["details.marketQuote.str"]).toBe("100");
         expect(result.value.spanAttributes["details.marketQuote.num"]).toBe(100);
@@ -324,7 +345,7 @@ describe("Test processOrder", () => {
         expect(result.value.spanAttributes["details.quote"]).toBe(
             JSON.stringify({ maxOutput: "1", ratio: "2" }),
         );
-        expect(result.value.spanAttributes["details.orders"]).toEqual([1]);
+        expect(result.value.spanAttributes["details.orders"]).toEqual("0xid");
         expect(result.value.spanAttributes["details.pair"]).toBe("BUY/SELL");
         expect(result.value.spanAttributes["details.marketQuote.str"]).toBe("100");
         expect(result.value.spanAttributes["details.marketQuote.num"]).toBe(100);

--- a/src/core/process/order.test.ts
+++ b/src/core/process/order.test.ts
@@ -38,8 +38,8 @@ describe("Test processOrder", () => {
         vi.clearAllMocks();
         mockOrderManager = {
             quoteOrder: vi.fn(),
-            addToPairMap: vi.fn(),
-            deleteFromPairMap: vi.fn(),
+            addToPairMaps: vi.fn(),
+            removeFromPairMaps: vi.fn(),
         } as any;
         mockState = {
             chainConfig: {
@@ -100,9 +100,8 @@ describe("Test processOrder", () => {
         expect(result.value.spanAttributes["details.orders"]).toEqual("0xid");
         expect(result.value.spanAttributes["details.pair"]).toBe("BUY/SELL");
 
-        // ensure pair maps are updated success quote
-        expect(mockOrderManager.addToPairMap).toHaveBeenCalledWith(mockArgs.orderDetails, false);
-        expect(mockOrderManager.addToPairMap).toHaveBeenCalledWith(mockArgs.orderDetails, true);
+        // ensure pair maps are updated on quote 0
+        expect(mockOrderManager.removeFromPairMaps).toHaveBeenCalledWith(mockArgs.orderDetails);
     });
 
     it("should return FailedToQuote if quoteOrder throws", async () => {
@@ -126,20 +125,7 @@ describe("Test processOrder", () => {
         expect(result.error.spanAttributes["details.pair"]).toBe("BUY/SELL");
 
         // ensure pair maps are updated on quote failure
-        expect(mockOrderManager.deleteFromPairMap).toHaveBeenCalledWith(
-            mockArgs.orderDetails.orderbook.toLowerCase(),
-            mockArgs.orderDetails.takeOrder.id.toLowerCase(),
-            mockArgs.orderDetails.sellToken.toLowerCase(),
-            mockArgs.orderDetails.buyToken.toLowerCase(),
-            false,
-        );
-        expect(mockOrderManager.deleteFromPairMap).toHaveBeenCalledWith(
-            mockArgs.orderDetails.orderbook.toLowerCase(),
-            mockArgs.orderDetails.takeOrder.id.toLowerCase(),
-            mockArgs.orderDetails.sellToken.toLowerCase(),
-            mockArgs.orderDetails.buyToken.toLowerCase(),
-            true,
-        );
+        expect(mockOrderManager.removeFromPairMaps).toHaveBeenCalledWith(mockArgs.orderDetails);
     });
 
     it("should return FailedToUpdatePools if updatePools throws (not fetchPoolsForToken)", async () => {
@@ -164,6 +150,9 @@ describe("Test processOrder", () => {
         );
         expect(result.error.spanAttributes["details.orders"]).toEqual("0xid");
         expect(result.error.spanAttributes["details.pair"]).toBe("BUY/SELL");
+
+        // ensure pair maps are updated success quote
+        expect(mockOrderManager.addToPairMaps).toHaveBeenCalledWith(mockArgs.orderDetails);
     });
 
     it("should return FailedToGetPools if fetchPoolsForToken throws", async () => {

--- a/src/core/process/order.ts
+++ b/src/core/process/order.ts
@@ -1,8 +1,8 @@
 import { RainSolver } from "..";
+import { Pair } from "../../order";
 import { Result } from "../../common";
 import { toNumber } from "../../math";
 import { Token } from "sushi/currency";
-import { BundledOrders } from "../../order";
 import { errorSnapshot } from "../../error";
 import { PoolBlackList } from "../../router";
 import { formatUnits, parseUnits } from "viem";
@@ -20,7 +20,7 @@ import {
 
 /** Arguments for processing an order */
 export type ProcessOrderArgs = {
-    orderDetails: BundledOrders;
+    orderDetails: Pair;
     signer: RainSolverSigner;
 };
 
@@ -52,16 +52,20 @@ export async function processOrder(
         tokenPair,
         buyToken: orderDetails.buyToken,
         sellToken: orderDetails.sellToken,
-        status: ProcessOrderStatus.NoOpportunity, // set default result to no opp
+        status: ProcessOrderStatus.NoOpportunity, // set default status to no opp
         spanAttributes,
     };
-    spanAttributes["details.orders"] = orderDetails.takeOrders.map((v) => v.id);
+    spanAttributes["details.orders"] = orderDetails.takeOrder.id;
     spanAttributes["details.pair"] = tokenPair;
 
     spanAttributes["event.quoteOrder"] = Date.now();
     try {
         await this.orderManager.quoteOrder(orderDetails);
-        if (orderDetails.takeOrders[0].quote?.maxOutput === 0n) {
+        // include in pair maps if quote passes to keep the list of orders with quote clean
+        // addToPairMap already avoid dups, so it safe to add to the list again
+        this.orderManager.addToPairMap(orderDetails, false); // oi pair map
+        this.orderManager.addToPairMap(orderDetails, true); // io pair map
+        if (orderDetails.takeOrder.quote?.maxOutput === 0n) {
             return async () => {
                 return Result.ok({
                     ...baseResult,
@@ -70,6 +74,13 @@ export async function processOrder(
             };
         }
     } catch (e) {
+        // remove from pair maps if qoute fails, to keep the pair map list free of orders without quote
+        const ob = orderDetails.orderbook.toLowerCase();
+        const hash = orderDetails.takeOrder.id.toLowerCase();
+        const output = orderDetails.sellToken.toLowerCase();
+        const input = orderDetails.buyToken.toLowerCase();
+        this.orderManager.deleteFromPairMap(ob, hash, output, input, false); // oi pair map
+        this.orderManager.deleteFromPairMap(ob, hash, output, input, true); // io pair map
         return async () =>
             Result.err({
                 ...baseResult,
@@ -80,8 +91,8 @@ export async function processOrder(
 
     // record order quote details in span attributes
     spanAttributes["details.quote"] = JSON.stringify({
-        maxOutput: formatUnits(orderDetails.takeOrders[0].quote!.maxOutput, 18),
-        ratio: formatUnits(orderDetails.takeOrders[0].quote!.ratio, 18),
+        maxOutput: formatUnits(orderDetails.takeOrder.quote!.maxOutput, 18),
+        ratio: formatUnits(orderDetails.takeOrder.quote!.ratio, 18),
     });
 
     // get current block number

--- a/src/core/process/round.test.ts
+++ b/src/core/process/round.test.ts
@@ -55,19 +55,15 @@ describe("Test initializeRound", () => {
     describe("successful initialization", () => {
         it("should return settlements with correct structure for single order", async () => {
             const mockOrders = [
-                [
-                    {
-                        orderbook: "0x3333333333333333333333333333333333333333",
-                        buyTokenSymbol: "ETH",
-                        sellTokenSymbol: "USDC",
-                        takeOrders: [
-                            {
-                                id: "0xOrder123",
-                                takeOrder: { order: { owner: "0xOwner123" } },
-                            },
-                        ],
+                {
+                    orderbook: "0x3333333333333333333333333333333333333333",
+                    buyTokenSymbol: "ETH",
+                    sellTokenSymbol: "USDC",
+                    takeOrder: {
+                        id: "0xOrder123",
+                        takeOrder: { order: { owner: "0xOwner123" } },
                     },
-                ],
+                },
             ];
 
             const mockSettleFn = vi.fn();
@@ -98,27 +94,24 @@ describe("Test initializeRound", () => {
 
         it("should handle multiple orders from multiple orderbooks", async () => {
             const mockOrders = [
-                [
-                    {
-                        orderbook: "0x5555555555555555555555555555555555555555",
-                        buyTokenSymbol: "ETH",
-                        sellTokenSymbol: "USDC",
-                        takeOrders: [
-                            { id: "0xOrder1", takeOrder: { order: { owner: "0xOwner1" } } },
-                            { id: "0xOrder2", takeOrder: { order: { owner: "0xOwner2" } } },
-                        ],
-                    },
-                ],
-                [
-                    {
-                        orderbook: "0x6666666666666666666666666666666666666666",
-                        buyTokenSymbol: "BTC",
-                        sellTokenSymbol: "USDT",
-                        takeOrders: [
-                            { id: "0xOrder3", takeOrder: { order: { owner: "0xOwner3" } } },
-                        ],
-                    },
-                ],
+                {
+                    orderbook: "0x5555555555555555555555555555555555555555",
+                    buyTokenSymbol: "ETH",
+                    sellTokenSymbol: "USDC",
+                    takeOrder: { id: "0xOrder1", takeOrder: { order: { owner: "0xOwner1" } } },
+                },
+                {
+                    orderbook: "0x5555555555555555555555555555555555555555",
+                    buyTokenSymbol: "ETH",
+                    sellTokenSymbol: "USDC",
+                    takeOrder: { id: "0xOrder2", takeOrder: { order: { owner: "0xOwner2" } } },
+                },
+                {
+                    orderbook: "0x6666666666666666666666666666666666666666",
+                    buyTokenSymbol: "BTC",
+                    sellTokenSymbol: "USDT",
+                    takeOrder: { id: "0xOrder3", takeOrder: { order: { owner: "0xOwner3" } } },
+                },
             ];
 
             mockOrderManager.getNextRoundOrders.mockReturnValue(mockOrders);
@@ -157,16 +150,15 @@ describe("Test initializeRound", () => {
             mockSolver.appOptions.genericArbAddress = undefined;
 
             const mockOrders = [
-                [
-                    {
-                        orderbook: "0x3333333333333333333333333333333333333333",
-                        buyTokenSymbol: "ETH",
-                        sellTokenSymbol: "USDC",
-                        takeOrders: [
-                            { id: "0xOrder123", takeOrder: { order: { owner: "0xOwner123" } } },
-                        ],
+                {
+                    orderbook: "0x3333333333333333333333333333333333333333",
+                    buyTokenSymbol: "ETH",
+                    sellTokenSymbol: "USDC",
+                    takeOrder: {
+                        id: "0xOrder123",
+                        takeOrder: { order: { owner: "0xOwner123" } },
                     },
-                ],
+                },
             ];
 
             mockOrderManager.getNextRoundOrders.mockReturnValue(mockOrders);
@@ -177,7 +169,7 @@ describe("Test initializeRound", () => {
             expect(result.settlements).toHaveLength(1);
             expect(result.checkpointReports).toHaveLength(1);
             expect(mockSolver.processOrder).toHaveBeenCalledWith({
-                orderDetails: expect.objectContaining(mockOrders[0][0]),
+                orderDetails: expect.objectContaining(mockOrders[0]),
                 signer: mockSigner,
             });
         });
@@ -186,28 +178,6 @@ describe("Test initializeRound", () => {
     describe("empty orders handling", () => {
         it("should return empty settlements and checkpointReports for empty orders", async () => {
             mockOrderManager.getNextRoundOrders.mockReturnValue([]);
-
-            const result: initializeRoundType = await initializeRound.call(mockSolver);
-
-            expect(result.settlements).toHaveLength(0);
-            expect(result.checkpointReports).toHaveLength(0);
-            expect(mockWalletManager.getRandomSigner).not.toHaveBeenCalled();
-            expect(mockSolver.processOrder).not.toHaveBeenCalled();
-        });
-
-        it("should skip orderbooks with empty takeOrders", async () => {
-            const mockOrders = [
-                [
-                    {
-                        orderbook: "0x3333333333333333333333333333333333333333",
-                        buyTokenSymbol: "ETH",
-                        sellTokenSymbol: "USDC",
-                        takeOrders: [],
-                    },
-                ],
-            ];
-
-            mockOrderManager.getNextRoundOrders.mockReturnValue(mockOrders);
 
             const result: initializeRoundType = await initializeRound.call(mockSolver);
 
@@ -230,17 +200,18 @@ describe("Test initializeRound", () => {
 
         it("should call getRandomSigner for each order", async () => {
             const mockOrders = [
-                [
-                    {
-                        orderbook: "0x3333333333333333333333333333333333333333",
-                        buyTokenSymbol: "ETH",
-                        sellTokenSymbol: "USDC",
-                        takeOrders: [
-                            { id: "0xOrder1", takeOrder: { order: { owner: "0xOwner1" } } },
-                            { id: "0xOrder2", takeOrder: { order: { owner: "0xOwner2" } } },
-                        ],
-                    },
-                ],
+                {
+                    orderbook: "0x3333333333333333333333333333333333333333",
+                    buyTokenSymbol: "ETH",
+                    sellTokenSymbol: "USDC",
+                    takeOrder: { id: "0xOrder1", takeOrder: { order: { owner: "0xOwner1" } } },
+                },
+                {
+                    orderbook: "0x3333333333333333333333333333333333333333",
+                    buyTokenSymbol: "ETH",
+                    sellTokenSymbol: "USDC",
+                    takeOrder: { id: "0xOrder2", takeOrder: { order: { owner: "0xOwner2" } } },
+                },
             ];
 
             mockOrderManager.getNextRoundOrders.mockReturnValue(mockOrders);
@@ -261,9 +232,9 @@ describe("Test initializeRound", () => {
                 sellToken: "0xUSDC",
                 sellTokenSymbol: "USDC",
                 sellTokenDecimals: 6,
-                takeOrders: [{ id: "0xOrder123", takeOrder: { order: { owner: "0xOwner123" } } }],
+                takeOrder: { id: "0xOrder123", takeOrder: { order: { owner: "0xOwner123" } } },
             };
-            const mockOrders = [[orderDetails]];
+            const mockOrders = [orderDetails];
 
             mockOrderManager.getNextRoundOrders.mockReturnValue(mockOrders);
             mockWalletManager.getRandomSigner.mockResolvedValue(mockSigner);
@@ -280,16 +251,12 @@ describe("Test initializeRound", () => {
     describe("checkpoint reports verification", () => {
         it("should create checkpoint reports with correct attributes", async () => {
             const mockOrders = [
-                [
-                    {
-                        orderbook: "0x3333333333333333333333333333333333333333",
-                        buyTokenSymbol: "WETH",
-                        sellTokenSymbol: "DAI",
-                        takeOrders: [
-                            { id: "0xOrderABC", takeOrder: { order: { owner: "0xOwnerXYZ" } } },
-                        ],
-                    },
-                ],
+                {
+                    orderbook: "0x3333333333333333333333333333333333333333",
+                    buyTokenSymbol: "WETH",
+                    sellTokenSymbol: "DAI",
+                    takeOrder: { id: "0xOrderABC", takeOrder: { order: { owner: "0xOwnerXYZ" } } },
+                },
             ];
 
             mockOrderManager.getNextRoundOrders.mockReturnValue(mockOrders);
@@ -310,25 +277,24 @@ describe("Test initializeRound", () => {
 
         it("should create one checkpoint report per order", async () => {
             const mockOrders = [
-                [
-                    {
-                        orderbook: "0x1111111111111111111111111111111111111111",
-                        buyTokenSymbol: "ETH",
-                        sellTokenSymbol: "USDC",
-                        takeOrders: [
-                            { id: "0xOrder1", takeOrder: { order: { owner: "0xOwner1" } } },
-                            { id: "0xOrder2", takeOrder: { order: { owner: "0xOwner2" } } },
-                        ],
-                    },
-                    {
-                        orderbook: "0x1111111111111111111111111111111111111111",
-                        buyTokenSymbol: "BTC",
-                        sellTokenSymbol: "USDT",
-                        takeOrders: [
-                            { id: "0xOrder3", takeOrder: { order: { owner: "0xOwner3" } } },
-                        ],
-                    },
-                ],
+                {
+                    orderbook: "0x1111111111111111111111111111111111111111",
+                    buyTokenSymbol: "ETH",
+                    sellTokenSymbol: "USDC",
+                    takeOrder: { id: "0xOrder1", takeOrder: { order: { owner: "0xOwner1" } } },
+                },
+                {
+                    orderbook: "0x1111111111111111111111111111111111111111",
+                    buyTokenSymbol: "ETH",
+                    sellTokenSymbol: "USDC",
+                    takeOrder: { id: "0xOrder2", takeOrder: { order: { owner: "0xOwner2" } } },
+                },
+                {
+                    orderbook: "0x1111111111111111111111111111111111111111",
+                    buyTokenSymbol: "BTC",
+                    sellTokenSymbol: "USDT",
+                    takeOrder: { id: "0xOrder3", takeOrder: { order: { owner: "0xOwner3" } } },
+                },
             ];
 
             mockOrderManager.getNextRoundOrders.mockReturnValue(mockOrders);
@@ -351,17 +317,18 @@ describe("Test initializeRound", () => {
 
         it("should end all checkpoint reports", async () => {
             const mockOrders = [
-                [
-                    {
-                        orderbook: "0x3333333333333333333333333333333333333333",
-                        buyTokenSymbol: "ETH",
-                        sellTokenSymbol: "USDC",
-                        takeOrders: [
-                            { id: "0xOrder1", takeOrder: { order: { owner: "0xOwner1" } } },
-                            { id: "0xOrder2", takeOrder: { order: { owner: "0xOwner2" } } },
-                        ],
-                    },
-                ],
+                {
+                    orderbook: "0x3333333333333333333333333333333333333333",
+                    buyTokenSymbol: "ETH",
+                    sellTokenSymbol: "USDC",
+                    takeOrder: { id: "0xOrder1", takeOrder: { order: { owner: "0xOwner1" } } },
+                },
+                {
+                    orderbook: "0x3333333333333333333333333333333333333333",
+                    buyTokenSymbol: "ETH",
+                    sellTokenSymbol: "USDC",
+                    takeOrder: { id: "0xOrder2", takeOrder: { order: { owner: "0xOwner2" } } },
+                },
             ];
 
             mockOrderManager.getNextRoundOrders.mockReturnValue(mockOrders);
@@ -378,16 +345,12 @@ describe("Test initializeRound", () => {
 
         it("should export checkpoint report if logger is available", async () => {
             const mockOrders = [
-                [
-                    {
-                        orderbook: "0x3333333333333333333333333333333333333333",
-                        buyTokenSymbol: "ETH",
-                        sellTokenSymbol: "USDC",
-                        takeOrders: [
-                            { id: "0xOrder1", takeOrder: { order: { owner: "0xOwner1" } } },
-                        ],
-                    },
-                ],
+                {
+                    orderbook: "0x3333333333333333333333333333333333333333",
+                    buyTokenSymbol: "ETH",
+                    sellTokenSymbol: "USDC",
+                    takeOrder: { id: "0xOrder1", takeOrder: { order: { owner: "0xOwner1" } } },
+                },
             ];
             mockOrderManager.getNextRoundOrders.mockReturnValue(mockOrders);
             mockWalletManager.getRandomSigner.mockResolvedValue(mockSigner);
@@ -408,16 +371,12 @@ describe("Test initializeRound", () => {
 
         it("should NOT export checkpoint report if logger is NOT available", async () => {
             const mockOrders = [
-                [
-                    {
-                        orderbook: "0x3333333333333333333333333333333333333333",
-                        buyTokenSymbol: "ETH",
-                        sellTokenSymbol: "USDC",
-                        takeOrders: [
-                            { id: "0xOrder1", takeOrder: { order: { owner: "0xOwner1" } } },
-                        ],
-                    },
-                ],
+                {
+                    orderbook: "0x3333333333333333333333333333333333333333",
+                    buyTokenSymbol: "ETH",
+                    sellTokenSymbol: "USDC",
+                    takeOrder: { id: "0xOrder1", takeOrder: { order: { owner: "0xOwner1" } } },
+                },
             ];
             mockOrderManager.getNextRoundOrders.mockReturnValue(mockOrders);
             mockWalletManager.getRandomSigner.mockResolvedValue(mockSigner);
@@ -448,16 +407,12 @@ describe("Test initializeRound", () => {
 
         it("should return checkpointReports matching settlements count", async () => {
             const mockOrders = [
-                [
-                    {
-                        orderbook: "0x3333333333333333333333333333333333333333",
-                        buyTokenSymbol: "ETH",
-                        sellTokenSymbol: "USDC",
-                        takeOrders: [
-                            { id: "0xOrder123", takeOrder: { order: { owner: "0xOwner123" } } },
-                        ],
-                    },
-                ],
+                {
+                    orderbook: "0x3333333333333333333333333333333333333333",
+                    buyTokenSymbol: "ETH",
+                    sellTokenSymbol: "USDC",
+                    takeOrder: { id: "0xOrder123", takeOrder: { order: { owner: "0xOwner123" } } },
+                },
             ];
 
             mockOrderManager.getNextRoundOrders.mockReturnValue(mockOrders);

--- a/src/math/index.test.ts
+++ b/src/math/index.test.ts
@@ -1,4 +1,4 @@
-import { scale18, scale18To } from ".";
+import { scaleTo18, scaleFrom18 } from ".";
 import { describe, it, assert } from "vitest";
 
 describe("Test math functions", () => {
@@ -6,14 +6,14 @@ describe("Test math functions", () => {
         // down
         const value1 = 123456789n;
         const decimals1 = 3;
-        const result1 = scale18(value1, decimals1);
+        const result1 = scaleTo18(value1, decimals1);
         const expected1 = 123456789000000000000000n;
         assert.deepEqual(result1, expected1);
 
         // up
         const value2 = 123456789n;
         const decimals2 = 23;
-        const result2 = scale18(value2, decimals2);
+        const result2 = scaleTo18(value2, decimals2);
         const expected2 = 1234n;
         assert.deepEqual(result2, expected2);
     });
@@ -22,14 +22,14 @@ describe("Test math functions", () => {
         // down
         const value1 = 123456789n;
         const decimals1 = 12;
-        const result1 = scale18To(value1, decimals1);
+        const result1 = scaleFrom18(value1, decimals1);
         const expected1 = 123n;
         assert.deepEqual(result1, expected1);
 
         // up
         const value2 = 123456789n;
         const decimals2 = 23;
-        const result2 = scale18To(value2, decimals2);
+        const result2 = scaleFrom18(value2, decimals2);
         const expected2 = 12345678900000n;
         assert.deepEqual(result2, expected2);
     });

--- a/src/math/index.ts
+++ b/src/math/index.ts
@@ -7,8 +7,10 @@ export const ONE18 = 1_000_000_000_000_000_000n as const;
 
 /**
  * Scales a given value and its decimals to 18 fixed point decimals
+ * @param value - The value to scale to 18
+ * @param decimals - The decimals of the value to scale to 18
  */
-export function scale18(value: bigint, decimals: number): bigint {
+export function scaleTo18(value: bigint, decimals: number): bigint {
     if (decimals > 18) {
         return value / BigInt("1" + "0".repeat(decimals - 18));
     } else {
@@ -18,8 +20,10 @@ export function scale18(value: bigint, decimals: number): bigint {
 
 /**
  * Scales a given 18 fixed point decimals value to the given decimals point value
+ * @param value - The value to scale from 18 to target decimals
+ * @param targetDecimals - The target decimals to scale from 18 to
  */
-export function scale18To(value: bigint, targetDecimals: number): bigint {
+export function scaleFrom18(value: bigint, targetDecimals: number): bigint {
     if (targetDecimals > 18) {
         return value * BigInt("1" + "0".repeat(targetDecimals - 18));
     } else {

--- a/src/order/index.test.ts
+++ b/src/order/index.test.ts
@@ -287,8 +287,6 @@ describe("Test OrderManager", () => {
         expect(bundle).toHaveProperty("sellToken", "0xoutput");
         expect(bundle).toHaveProperty("sellTokenDecimals", 18);
         expect(bundle).toHaveProperty("sellTokenSymbol", "OUT");
-        // expect(Array.isArray(bundle.takeOrders)).toBe(true);
-        // expect(bundle.takeOrders.length).toBeGreaterThan(0);
 
         const takeOrder = bundle.takeOrder;
         expect(takeOrder).toHaveProperty("id", "0xhash");

--- a/src/order/index.test.ts
+++ b/src/order/index.test.ts
@@ -1,8 +1,9 @@
-import { Order } from "./types";
+import { CounterpartySource, Order } from "./types";
+import * as pairFns from "./pair";
 import { Result } from "../common";
 import { SharedState } from "../state";
 import { SubgraphManager } from "../subgraph";
-import { OrderManager, DEFAULT_OWNER_LIMIT, sortPairList } from "./index";
+import { OrderManager, DEFAULT_OWNER_LIMIT } from "./index";
 import { describe, it, expect, beforeEach, vi, Mock } from "vitest";
 
 vi.mock("viem", async (importOriginal) => ({
@@ -46,16 +47,6 @@ vi.mock("./types", async (importOriginal) => {
 });
 
 describe("Test OrderManager", () => {
-    const orderbook1 = "0xorderbook1";
-    const orderbook2 = "0xorderbook2";
-    const tkn1 = "0xtoken1";
-    const tkn2 = "0xtoken2";
-    const tkn3 = "0xtoken3";
-    const tkn4 = "0xtoken4";
-    const hash1 = "0xhash1";
-    const hash2 = "0xhash2";
-    const hash3 = "0xhash3";
-
     let orderManager: OrderManager;
     let state: SharedState;
     let subgraphManager: SubgraphManager;
@@ -211,11 +202,11 @@ describe("Test OrderManager", () => {
         const pairMap1 = orderManager.oiPairMap.get("0xorderbook1");
         expect(pairMap1).toBeDefined();
         const pairArr1 = pairMap1?.get("0xoutput")?.get("0xinput");
-        expect(Array.isArray(pairArr1)).toBe(true);
-        expect(pairArr1?.length).toBeGreaterThan(0);
-        expect(pairArr1?.[0].buyToken).toBe("0xinput");
-        expect(pairArr1?.[0].sellToken).toBe("0xoutput");
-        expect(pairArr1?.[0].takeOrder.id).toBe("0xhash1");
+        expect(pairArr1).toBeInstanceOf(Map);
+        expect(pairArr1?.size).toBeGreaterThan(0);
+        expect(pairArr1?.get("0xhash1")?.buyToken).toBe("0xinput");
+        expect(pairArr1?.get("0xhash1")?.sellToken).toBe("0xoutput");
+        expect(pairArr1?.get("0xhash1")?.takeOrder.id).toBe("0xhash1");
 
         // check second order in owner map
         const ownerProfileMap2 = orderManager.ownersMap.get("0xorderbook2");
@@ -234,11 +225,11 @@ describe("Test OrderManager", () => {
         const pairMap2 = orderManager.oiPairMap.get("0xorderbook2");
         expect(pairMap2).toBeDefined();
         const pairArr2 = pairMap2?.get("0xoutput")?.get("0xinput");
-        expect(Array.isArray(pairArr2)).toBe(true);
-        expect(pairArr2?.length).toBeGreaterThan(0);
-        expect(pairArr2?.[0].buyToken).toBe("0xinput");
-        expect(pairArr2?.[0].sellToken).toBe("0xoutput");
-        expect(pairArr2?.[0].takeOrder.id).toBe("0xhash2");
+        expect(pairArr2).toBeInstanceOf(Map);
+        expect(pairArr2?.size).toBeGreaterThan(0);
+        expect(pairArr2?.get("0xhash2")?.buyToken).toBe("0xinput");
+        expect(pairArr2?.get("0xhash2")?.sellToken).toBe("0xoutput");
+        expect(pairArr2?.get("0xhash2")?.takeOrder.id).toBe("0xhash2");
     });
 
     it("should remove orders", async () => {
@@ -256,9 +247,9 @@ describe("Test OrderManager", () => {
         const pairMapBefore = orderManager.oiPairMap.get("0xorderbook");
         expect(pairMapBefore).toBeDefined();
         const pairArrBefore = pairMapBefore?.get("0xoutput")?.get("0xinput");
-        expect(Array.isArray(pairArrBefore)).toBe(true);
-        expect(pairArrBefore?.length).toBeGreaterThan(0);
-        expect(pairArrBefore?.[0].takeOrder.id).toBe("0xhash");
+        expect(pairArrBefore).toBeInstanceOf(Map);
+        expect(pairArrBefore?.size).toBeGreaterThan(0);
+        expect(pairArrBefore?.get("0xhash")?.takeOrder.id).toBe("0xhash");
 
         await orderManager.removeOrders([mockOrder as any]);
         const ownerProfileMap = orderManager.ownersMap.get("0xorderbook");
@@ -516,8 +507,7 @@ describe("Test OrderManager", () => {
         const takeOrderFromOwnersMap = orderEntry?.takeOrders[0];
 
         const pairMap = orderManager.oiPairMap.get(orderbookKey);
-        const pairArr = pairMap?.get("0xoutput")?.get("0xinput");
-        const takeOrderFromPairMap = pairArr?.[0];
+        const takeOrderFromPairMap = pairMap?.get("0xoutput")?.get("0xinput")?.get("0xhash");
 
         expect(takeOrderFromOwnersMap?.takeOrder.quote).toEqual({ maxOutput: 999n, ratio: 888n });
         expect(takeOrderFromPairMap?.takeOrder.quote).toEqual({ maxOutput: 999n, ratio: 888n });
@@ -563,7 +553,10 @@ describe("Test OrderManager", () => {
         const roundOrders = orderManager.getNextRoundOrders(false);
 
         // should find orderB as opposing order for orderA in the same orderbook
-        const opposing = orderManager.getCounterpartyOrders(roundOrders[0], true);
+        const opposing = orderManager.getCounterpartyOrders(
+            roundOrders[0],
+            CounterpartySource.IntraOrderbook,
+        );
         expect(Array.isArray(opposing)).toBe(true);
         expect(opposing.length).toBe(1);
         expect(opposing[0].buyToken).toBe("0xoutput");
@@ -608,7 +601,10 @@ describe("Test OrderManager", () => {
         const roundOrders = orderManager.getNextRoundOrders(false);
 
         // should find orderB as opposing order for orderA across orderbooks
-        const opposing = orderManager.getCounterpartyOrders(roundOrders[0], false);
+        const opposing = orderManager.getCounterpartyOrders(
+            roundOrders[0],
+            CounterpartySource.InterOrderbook,
+        );
         for (const counteryparties of opposing) {
             expect(Array.isArray(counteryparties)).toBe(true);
             expect(counteryparties.length).toBe(1);
@@ -618,390 +614,53 @@ describe("Test OrderManager", () => {
         }
     });
 
-    describe("Test addToPairMap method", () => {
-        it("should add pair to empty pair map", async () => {
-            const pair = getPair(orderbook1, hash1, tkn1, tkn2);
+    it("should call addToPairMap with correct params", async () => {
+        const pair = getPair("0xorderbook", "0xhash", "0xtkn1", "0xtkn2");
+        const addToPairMapSpy = vi.spyOn(pairFns, "addToPairMap");
+        orderManager.addToPairMaps(pair);
 
-            // OI map
-            orderManager.addToPairMap(pair, false);
-            const oiMap = orderManager.oiPairMap.get(orderbook1);
-            expect(oiMap).toBeDefined();
-
-            const outputMap = oiMap!.get(tkn1);
-            expect(outputMap).toBeDefined();
-
-            const oiPairList = outputMap!.get(tkn2);
-            expect(oiPairList).toBeDefined();
-            expect(oiPairList).toHaveLength(1);
-            expect(oiPairList![0]).toBe(pair);
-
-            // IO map
-            orderManager.addToPairMap(pair, true);
-            const ioMap = orderManager.ioPairMap.get(orderbook1);
-            expect(ioMap).toBeDefined();
-
-            const inputMap = ioMap!.get(tkn2);
-            expect(inputMap).toBeDefined();
-
-            const ioPairList = inputMap!.get(tkn1);
-            expect(ioPairList).toBeDefined();
-            expect(ioPairList).toHaveLength(1);
-            expect(ioPairList![0]).toBe(pair);
-        });
-
-        it("should add pair to existing orderbook map", async () => {
-            const existingPair = getPair(orderbook1, hash1, tkn1, tkn2);
-            const newPair = getPair(orderbook1, hash2, tkn3, tkn4);
-
-            // add first pair
-            orderManager.addToPairMap(existingPair, false);
-            orderManager.addToPairMap(existingPair, true);
-
-            // OI map
-            orderManager.addToPairMap(existingPair, false);
-            const oiMap = orderManager.oiPairMap.get(orderbook1);
-            expect(oiMap).toBeDefined();
-
-            const outputMap = oiMap!.get(tkn1);
-            expect(outputMap).toBeDefined();
-
-            const oiPairList = outputMap!.get(tkn2);
-            expect(oiPairList).toBeDefined();
-            expect(oiPairList).toHaveLength(1);
-            expect(oiPairList![0]).toBe(existingPair);
-
-            // IO map
-            orderManager.addToPairMap(existingPair, true);
-            const ioMap = orderManager.ioPairMap.get(orderbook1);
-            expect(ioMap).toBeDefined();
-
-            const inputMap = ioMap!.get(tkn2);
-            expect(inputMap).toBeDefined();
-
-            const ioPairList = inputMap!.get(tkn1);
-            expect(ioPairList).toBeDefined();
-            expect(ioPairList).toHaveLength(1);
-            expect(ioPairList![0]).toBe(existingPair);
-
-            // add second pair
-            orderManager.addToPairMap(newPair, false);
-            orderManager.addToPairMap(newPair, true);
-
-            // OI map
-            orderManager.addToPairMap(newPair, false);
-            const oiMap2 = orderManager.oiPairMap.get(orderbook1);
-            expect(oiMap2).toBeDefined();
-
-            const outputMap2 = oiMap2!.get(tkn3);
-            expect(outputMap2).toBeDefined();
-
-            const oiPairList2 = outputMap2!.get(tkn4);
-            expect(oiPairList2).toBeDefined();
-            expect(oiPairList2).toHaveLength(1);
-            expect(oiPairList2![0]).toBe(newPair);
-
-            // IO map
-            orderManager.addToPairMap(newPair, true);
-            const ioMap2 = orderManager.ioPairMap.get(orderbook1);
-            expect(ioMap2).toBeDefined();
-
-            const inputMap2 = ioMap2!.get(tkn4);
-            expect(inputMap2).toBeDefined();
-
-            const ioPairList2 = inputMap2!.get(tkn3);
-            expect(ioPairList2).toBeDefined();
-            expect(ioPairList2).toHaveLength(1);
-            expect(ioPairList2![0]).toBe(newPair);
-        });
-
-        it("should add pair to existing output token map", async () => {
-            const existingPair = getPair(orderbook1, hash1, tkn1, tkn2);
-            const newPair = getPair(orderbook1, hash2, tkn1, tkn3);
-
-            orderManager.addToPairMap(existingPair, false);
-            orderManager.addToPairMap(existingPair, true);
-
-            // OI map
-            orderManager.addToPairMap(newPair, false);
-            const oiMap = orderManager.oiPairMap.get(orderbook1);
-            expect(oiMap).toBeDefined();
-
-            const outputMap = oiMap!.get(tkn1);
-            expect(outputMap).toBeDefined();
-            expect(outputMap!.size).toBe(2);
-
-            orderManager.addToPairMap(existingPair, false);
-            orderManager.addToPairMap(existingPair, true);
-
-            // OI map
-            const newPair2 = getPair(orderbook1, hash2, tkn3, tkn2);
-            orderManager.addToPairMap(newPair2, true);
-            const ioMap = orderManager.ioPairMap.get(orderbook1);
-            expect(ioMap).toBeDefined();
-
-            const outputMap2 = ioMap!.get(tkn2);
-            expect(outputMap2).toBeDefined();
-            expect(outputMap2!.size).toBe(2);
-        });
-
-        it("should add pair to existing buy token list", async () => {
-            const existingPair = getPair(orderbook1, hash1, tkn1, tkn2);
-            const newPair = getPair(orderbook1, hash2, tkn1, tkn2);
-
-            // OI map
-            orderManager.addToPairMap(existingPair, false);
-            orderManager.addToPairMap(newPair, false);
-            const oiMap = orderManager.oiPairMap.get(orderbook1);
-            expect(oiMap).toBeDefined();
-
-            const outputMap = oiMap!.get(tkn1);
-            expect(outputMap).toBeDefined();
-            expect(outputMap!.size).toBe(1);
-            const oiPairList = outputMap!.get(tkn2);
-            expect(oiPairList).toBeDefined();
-            expect(oiPairList).toHaveLength(2);
-
-            // OI map
-            orderManager.addToPairMap(existingPair, true);
-            orderManager.addToPairMap(newPair, true);
-            const ioMap = orderManager.ioPairMap.get(orderbook1);
-            expect(ioMap).toBeDefined();
-
-            const outputMap2 = ioMap!.get(tkn2);
-            expect(outputMap2).toBeDefined();
-            expect(outputMap2!.size).toBe(1);
-            const ioPairList = outputMap2!.get(tkn1);
-            expect(ioPairList).toBeDefined();
-            expect(ioPairList).toHaveLength(2);
-        });
-
-        it("should not duplicate pairs with same takeOrder id", async () => {
-            const existingPair = getPair(orderbook1, hash1, tkn1, tkn2);
-            const newPair = getPair(orderbook1, hash1, tkn1, tkn2);
-            orderManager.addToPairMap(existingPair, false);
-
-            orderManager.addToPairMap(newPair, false);
-            const oiMap = orderManager.oiPairMap.get(orderbook1);
-            expect(oiMap).toBeDefined();
-
-            const outputMap = oiMap!.get(tkn1);
-            expect(outputMap).toBeDefined();
-            expect(outputMap!.size).toBe(1);
-        });
-
-        it("should handle different orderbooks independently", async () => {
-            const pairs1 = getPair(orderbook1, hash1, tkn1, tkn2);
-            const pairs2 = getPair(orderbook2, hash1, tkn1, tkn2);
-            orderManager.addToPairMap(pairs1, false);
-            orderManager.addToPairMap(pairs2, false);
-
-            expect(orderManager.oiPairMap.size).toBe(2);
-            expect(orderManager.oiPairMap.get(orderbook1)).toBeDefined();
-            expect(orderManager.oiPairMap.get(orderbook2)).toBeDefined();
-
-            // check that each orderbook has its own pairs
-            expect(orderManager.oiPairMap.get(orderbook1)!.get(tkn1)).toBeDefined();
-            expect(orderManager.oiPairMap.get(orderbook2)!.get(tkn1)).toBeDefined();
-        });
+        expect(addToPairMapSpy).toHaveBeenCalledTimes(2);
+        expect(addToPairMapSpy).toHaveBeenCalledWith(
+            orderManager.oiPairMap,
+            "0xorderbook",
+            "0xhash",
+            "0xtkn1",
+            "0xtkn2",
+            pair,
+        );
+        expect(addToPairMapSpy).toHaveBeenCalledWith(
+            orderManager.ioPairMap,
+            "0xorderbook",
+            "0xhash",
+            "0xtkn2",
+            "0xtkn1",
+            pair,
+        );
+        addToPairMapSpy.mockRestore();
     });
 
-    describe("Test deleteFromPairMap method", () => {
-        it("should delete pair from io and oi pair maps when order is removed", async () => {
-            const pairs = getPair(orderbook1, hash1, tkn1, tkn2);
+    it("should call removeFromPairMaps with correct params", async () => {
+        const pair = getPair("0xorderbook", "0xhash", "0xtkn1", "0xtkn2");
+        orderManager.addToPairMaps(pair);
 
-            // add pair first
-            orderManager.addToPairMap(pairs, false);
-            orderManager.addToPairMap(pairs, true);
+        const removeFromPairMapSpy = vi.spyOn(pairFns, "removeFromPairMap");
+        orderManager.removeFromPairMaps(pair);
 
-            // verify pair exists
-            const oiMapBefore = orderManager.oiPairMap.get(orderbook1);
-            expect(oiMapBefore?.get(tkn1)?.get(tkn2)).toHaveLength(1);
-
-            const ioMapBefore = orderManager.ioPairMap.get(orderbook1);
-            expect(ioMapBefore?.get(tkn2)?.get(tkn1)).toHaveLength(1);
-
-            // delete pair
-            orderManager.deleteFromPairMap(orderbook1, hash1, tkn1, tkn2, false);
-            orderManager.deleteFromPairMap(orderbook1, hash1, tkn1, tkn2, true);
-
-            // verify pair is deleted
-            const oiMapAfter = orderManager.oiPairMap.get(orderbook1);
-            expect(oiMapAfter?.get(tkn1)?.get(tkn2)).toBeUndefined();
-            expect(oiMapAfter?.get(tkn1)).toBeUndefined();
-            expect(oiMapAfter?.size).toBe(0);
-
-            const ioMapAfter = orderManager.ioPairMap.get(orderbook1);
-            expect(ioMapAfter?.get(tkn2)?.get(tkn1)).toBeUndefined();
-            expect(ioMapAfter?.get(tkn2)).toBeUndefined();
-            expect(ioMapAfter?.size).toBe(0);
-        });
-
-        it("should only remove specific order from list when multiple orders exist for same pair", async () => {
-            const pairs1 = getPair(orderbook1, hash1, tkn1, tkn2);
-            const pairs2 = getPair(orderbook1, hash2, tkn1, tkn2);
-
-            // add two pairs with same tokens but different order hashes
-            orderManager.addToPairMap(pairs1, false);
-            orderManager.addToPairMap(pairs2, false);
-
-            // verify both pairs exist
-            const oiMapBefore = orderManager.oiPairMap.get(orderbook1);
-            expect(oiMapBefore?.get(tkn1)?.get(tkn2)).toHaveLength(2);
-
-            // delete only the first order
-            orderManager.deleteFromPairMap(orderbook1, hash1, tkn1, tkn2, false);
-
-            // verify only one pair remains
-            const oiMapAfter = orderManager.oiPairMap.get(orderbook1);
-            const remainingPairs = oiMapAfter?.get(tkn1)?.get(tkn2);
-            expect(remainingPairs).toHaveLength(1);
-            expect(remainingPairs![0].takeOrder.id).toBe(hash2);
-        });
-
-        it("should skip same token pairs during deletion", async () => {
-            const pairs = [
-                getPair(orderbook1, hash1, tkn1, tkn2), // different tokens
-                getPair(orderbook1, hash1, tkn1, tkn1), // same tokens (should be skipped)
-            ];
-
-            // add pairs
-            orderManager.addToPairMap(pairs[0], false);
-            orderManager.addToPairMap(pairs[1], false);
-
-            // verify only the different token pair exists (same token pairs are skipped in addToPairMap)
-            const oiMapBefore = orderManager.oiPairMap.get(orderbook1);
-            expect(oiMapBefore?.get(tkn1)?.get(tkn2)).toHaveLength(1);
-            expect(oiMapBefore?.get(tkn1)?.get(tkn1)).toHaveLength(1);
-
-            // delete the order
-            orderManager.deleteFromPairMap(orderbook1, hash1, tkn1, tkn2, false);
-
-            // verify the different token pair is deleted and tkn1/tkn1 still exists
-            const oiMapAfter = orderManager.oiPairMap.get(orderbook1);
-            expect(oiMapAfter?.size).toBe(1);
-            expect(oiMapAfter?.get(tkn1)?.get(tkn1)).toBeDefined();
-        });
-
-        it("should not affect other orderbooks when deleting from one", async () => {
-            const pairs1 = getPair(orderbook1, hash1, tkn1, tkn2);
-            const pairs2 = getPair(orderbook2, hash2, tkn1, tkn2);
-
-            // add pairs to both orderbooks
-            orderManager.addToPairMap(pairs1, false);
-            orderManager.addToPairMap(pairs2, false);
-
-            // verify both orderbooks have pairs
-            expect(orderManager.oiPairMap.get(orderbook1)?.get(tkn1)?.get(tkn2)).toHaveLength(1);
-            expect(orderManager.oiPairMap.get(orderbook2)?.get(tkn1)?.get(tkn2)).toHaveLength(1);
-
-            // delete from orderbook1 only
-            orderManager.deleteFromPairMap(orderbook1, hash1, tkn1, tkn2, false);
-
-            // verify orderbook1 is empty but orderbook2 still has pairs
-            expect(orderManager.oiPairMap.get(orderbook1)?.size).toBe(0);
-            expect(orderManager.oiPairMap.get(orderbook2)?.get(tkn1)?.get(tkn2)).toHaveLength(1);
-        });
-
-        it("should handle deletion from non-existent orderbook gracefully", async () => {
-            // Should not throw error when deleting from non-existent orderbook
-            expect(() => {
-                orderManager.deleteFromPairMap("0xnonexistent", hash1, tkn1, tkn2, false);
-            }).not.toThrow();
-        });
-
-        it("should handle deletion of non-existent order gracefully", async () => {
-            const pairs = getPair(orderbook1, hash1, tkn1, tkn2);
-
-            // add pair
-            orderManager.addToPairMap(pairs, false);
-
-            // Try to delete non-existent order
-            orderManager.deleteFromPairMap(orderbook1, hash2, tkn1, tkn2, false);
-
-            // verify original pair still exists
-            const oiMap = orderManager.oiPairMap.get(orderbook1);
-            expect(oiMap?.get(tkn1)?.get(tkn2)).toHaveLength(1);
-            expect(oiMap?.get(tkn1)?.get(tkn2)![0].takeOrder.id).toBe(hash1);
-        });
-
-        it("should handle complex deletion scenario with mixed pairs", async () => {
-            const pairs = [
-                getPair(orderbook1, hash1, tkn1, tkn2),
-                getPair(orderbook1, hash2, tkn1, tkn2), // Same pair, different order
-                getPair(orderbook1, hash1, tkn1, tkn3), // Same output, different input
-                getPair(orderbook1, hash3, tkn2, tkn1), // different output-input combination
-            ];
-
-            // add all pairs
-            for (const pair of pairs) {
-                orderManager.addToPairMap(pair, false);
-            }
-
-            // verify initial state
-            const oiMapBefore = orderManager.oiPairMap.get(orderbook1);
-            expect(oiMapBefore?.get(tkn1)?.get(tkn2)).toHaveLength(2); // hash1 and hash2
-            expect(oiMapBefore?.get(tkn1)?.get(tkn3)).toHaveLength(1); // hash1
-            expect(oiMapBefore?.get(tkn2)?.get(tkn1)).toHaveLength(1); // hash3
-
-            // delete hash1 order (should affect tkn1->tkn2 and tkn1->tkn3)
-            orderManager.deleteFromPairMap(orderbook1, hash1, tkn1, tkn2, false);
-            orderManager.deleteFromPairMap(orderbook1, hash1, tkn1, tkn3, false);
-
-            // verify final state
-            const oiMapAfter = orderManager.oiPairMap.get(orderbook1);
-            expect(oiMapAfter?.get(tkn1)?.get(tkn2)).toHaveLength(1); // Only hash2 remains
-            expect(oiMapAfter?.get(tkn1)?.get(tkn2)![0].takeOrder.id).toBe(hash2);
-            expect(oiMapAfter?.get(tkn1)?.get(tkn3)).toBeUndefined(); // hash1 removed, list deleted
-            expect(oiMapAfter?.get(tkn2)?.get(tkn1)).toHaveLength(1); // hash3 unaffected
-            expect(oiMapAfter?.get(tkn2)?.get(tkn1)![0].takeOrder.id).toBe(hash3);
-        });
-    });
-
-    describe("Test sortPairList function", () => {
-        it("should sort pairs correctly in descending order by ratio then by maxOutput", () => {
-            const createPair = (quote?: { ratio: bigint; maxOutput: bigint }): any => ({
-                takeOrder: { quote },
-            });
-
-            // create pairs with different combinations of quotes
-            const pairs: any[] = [
-                createPair(undefined), // no quote - should be last
-                createPair({ ratio: 5n, maxOutput: 500n }), // lower ratio, lower maxOutput
-                createPair({ ratio: 5n, maxOutput: 1000n }), // lower ratio, higher maxOutput
-                createPair({ ratio: 10n, maxOutput: 200n }), // higher ratio, lower maxOutput
-                createPair({ ratio: 10n, maxOutput: 800n }), // higher ratio, higher maxOutput
-                createPair({ ratio: 20n, maxOutput: 300n }), // highest ratio, medium maxOutput
-                createPair(undefined), // another no quote - should be last
-            ];
-            const sorted = [...pairs].sort(sortPairList);
-
-            // expected order (descending by ratio, then descending by maxOutput for same ratios):
-            // 1. ratio: 20n, maxOutput: 300n
-            // 2. ratio: 10n, maxOutput: 800n
-            // 3. ratio: 10n, maxOutput: 200n
-            // 4. ratio: 5n, maxOutput: 1000n
-            // 5. ratio: 5n, maxOutput: 500n
-            // 6. undefined quote
-            // 7. undefined quote
-
-            expect(sorted[0].takeOrder.quote?.ratio).toBe(20n);
-            expect(sorted[0].takeOrder.quote?.maxOutput).toBe(300n);
-
-            expect(sorted[1].takeOrder.quote?.ratio).toBe(10n);
-            expect(sorted[1].takeOrder.quote?.maxOutput).toBe(800n);
-
-            expect(sorted[2].takeOrder.quote?.ratio).toBe(10n);
-            expect(sorted[2].takeOrder.quote?.maxOutput).toBe(200n);
-
-            expect(sorted[3].takeOrder.quote?.ratio).toBe(5n);
-            expect(sorted[3].takeOrder.quote?.maxOutput).toBe(1000n);
-
-            expect(sorted[4].takeOrder.quote?.ratio).toBe(5n);
-            expect(sorted[4].takeOrder.quote?.maxOutput).toBe(500n);
-
-            // Last two should have no quotes
-            expect(sorted[5].takeOrder.quote).toBeUndefined();
-            expect(sorted[6].takeOrder.quote).toBeUndefined();
-        });
+        expect(removeFromPairMapSpy).toHaveBeenCalledTimes(2);
+        expect(removeFromPairMapSpy).toHaveBeenCalledWith(
+            orderManager.oiPairMap,
+            "0xorderbook",
+            "0xhash",
+            "0xtkn1",
+            "0xtkn2",
+        );
+        expect(removeFromPairMapSpy).toHaveBeenCalledWith(
+            orderManager.ioPairMap,
+            "0xorderbook",
+            "0xhash",
+            "0xtkn2",
+            "0xtkn1",
+        );
+        removeFromPairMapSpy.mockRestore();
     });
 });

--- a/src/order/index.ts
+++ b/src/order/index.ts
@@ -413,17 +413,17 @@ export class OrderManager {
     /**
      * Gets descending sorted list of counterparty orders by their ratios for a given order
      * @param orderDetails - Details of the order to find counterparty orders for
-     * @param counterpartyType - Determines the type of counterparty orders source to return
+     * @param counterpartySource - Determines the type of counterparty orders source to return
      */
     getCounterpartyOrders<
-        counterpartyType extends CounterpartySource = CounterpartySource.IntraOrderbook,
+        counterpartySource extends CounterpartySource = CounterpartySource.IntraOrderbook,
     >(
         orderDetails: Pair,
-        counterpartyType: counterpartyType,
-    ): counterpartyType extends CounterpartySource.IntraOrderbook ? Pair[] : Pair[][] {
+        counterpartySource: counterpartySource,
+    ): counterpartySource extends CounterpartySource.IntraOrderbook ? Pair[] : Pair[][] {
         const sellToken = orderDetails.sellToken.toLowerCase();
         const buyToken = orderDetails.buyToken.toLowerCase();
         const ob = orderDetails.orderbook.toLowerCase();
-        return getSortedPairList(this.oiPairMap, ob, buyToken, sellToken, counterpartyType);
+        return getSortedPairList(this.oiPairMap, ob, buyToken, sellToken, counterpartySource);
     }
 }

--- a/src/order/pair.test.ts
+++ b/src/order/pair.test.ts
@@ -1,0 +1,455 @@
+import { CounterpartySource, OrderbooksPairMap, Pair } from "./types";
+import { addToPairMap, removeFromPairMap, getSortedPairList, sortPairList } from "./pair";
+import { describe, it, expect, beforeEach } from "vitest";
+
+describe("Test add/remove to pairMap functions", () => {
+    const orderbook1 = "0xorderbook1";
+    const orderbook2 = "0xorderbook2";
+    const tkn1 = "0xtoken1";
+    const tkn2 = "0xtoken2";
+    const tkn3 = "0xtoken3";
+    const tkn4 = "0xtoken4";
+    const hash1 = "0xhash1";
+    const hash2 = "0xhash2";
+    const hash3 = "0xhash3";
+
+    let pairMap: OrderbooksPairMap = new Map();
+
+    const getPair = (orderbook: string, hash: string, output: string, input: string) =>
+        ({
+            orderbook,
+            buyToken: input,
+            sellToken: output,
+            takeOrder: { id: hash },
+        }) as any;
+
+    beforeEach(() => {
+        pairMap = new Map();
+    });
+
+    describe("Test addToPairMap funtion", () => {
+        it("should add pair to empty pair map", async () => {
+            const pair = getPair(orderbook1, hash1, tkn1, tkn2);
+
+            addToPairMap(pairMap, orderbook1, hash1, tkn1, tkn2, pair);
+            const map = pairMap.get(orderbook1);
+            expect(map).toBeDefined();
+
+            const outputMap = map!.get(tkn1);
+            expect(outputMap).toBeDefined();
+
+            const pairList = outputMap!.get(tkn2);
+            expect(pairList).toBeDefined();
+            expect(pairList?.size).toBe(1);
+            expect(pairList!.get(hash1)).toBe(pair);
+        });
+
+        it("should add pair to existing orderbook map", async () => {
+            const existingPair = getPair(orderbook1, hash1, tkn1, tkn2);
+            const newPair = getPair(orderbook1, hash2, tkn3, tkn4);
+
+            // add first pair
+            addToPairMap(pairMap, orderbook1, hash1, tkn1, tkn2, existingPair);
+            const map = pairMap.get(orderbook1);
+            expect(map).toBeDefined();
+
+            const outputMap = map!.get(tkn1);
+            expect(outputMap).toBeDefined();
+
+            const pairList = outputMap!.get(tkn2);
+            expect(pairList).toBeDefined();
+            expect(pairList?.size).toBe(1);
+            expect(pairList!.get(hash1)).toBe(existingPair);
+
+            // add second pair
+            addToPairMap(pairMap, orderbook1, hash2, tkn3, tkn4, newPair);
+            const map2 = pairMap.get(orderbook1);
+            expect(map2).toBeDefined();
+
+            const outputMap2 = map2!.get(tkn3);
+            expect(outputMap2).toBeDefined();
+
+            const pairList2 = outputMap2!.get(tkn4);
+            expect(pairList2).toBeDefined();
+            expect(pairList2?.size).toBe(1);
+            expect(pairList2!.get(hash2)).toBe(newPair);
+        });
+
+        it("should add pair to existing output token map", async () => {
+            const existingPair = getPair(orderbook1, hash1, tkn1, tkn2);
+            const newPair = getPair(orderbook1, hash2, tkn1, tkn3);
+
+            addToPairMap(pairMap, orderbook1, hash1, tkn1, tkn2, existingPair);
+            addToPairMap(pairMap, orderbook1, hash2, tkn1, tkn3, newPair);
+
+            const map = pairMap.get(orderbook1);
+            expect(map).toBeDefined();
+
+            const outputMap = map!.get(tkn1);
+            expect(outputMap).toBeDefined();
+            expect(outputMap!.size).toBe(2);
+        });
+
+        it("should add pair to existing buy token list", async () => {
+            const existingPair = getPair(orderbook1, hash1, tkn1, tkn2);
+            const newPair = getPair(orderbook1, hash2, tkn1, tkn2);
+
+            addToPairMap(pairMap, orderbook1, hash1, tkn1, tkn2, existingPair);
+            addToPairMap(pairMap, orderbook1, hash2, tkn1, tkn2, newPair);
+            const map = pairMap.get(orderbook1);
+            expect(map).toBeDefined();
+
+            const outputMap = map!.get(tkn1);
+            expect(outputMap).toBeDefined();
+            expect(outputMap!.size).toBe(1);
+            const pairList = outputMap!.get(tkn2);
+            expect(pairList).toBeDefined();
+            expect(pairList?.size).toBe(2);
+        });
+
+        it("should handle different orderbooks independently", async () => {
+            const pairs1 = getPair(orderbook1, hash1, tkn1, tkn2);
+            const pairs2 = getPair(orderbook2, hash1, tkn1, tkn2);
+            addToPairMap(pairMap, orderbook1, hash1, tkn1, tkn2, pairs1);
+            addToPairMap(pairMap, orderbook2, hash1, tkn1, tkn2, pairs2);
+
+            expect(pairMap.size).toBe(2);
+            expect(pairMap.get(orderbook1)).toBeDefined();
+            expect(pairMap.get(orderbook2)).toBeDefined();
+
+            // check that each orderbook has its own pairs
+            expect(pairMap.get(orderbook1)!.get(tkn1)).toBeDefined();
+            expect(pairMap.get(orderbook2)!.get(tkn1)).toBeDefined();
+        });
+    });
+
+    describe("Test deleteFromPairMap function", () => {
+        it("should delete pair from pair map", async () => {
+            const pairs = getPair(orderbook1, hash1, tkn1, tkn2);
+
+            // add pair first
+            addToPairMap(pairMap, orderbook1, hash1, tkn1, tkn2, pairs);
+
+            // verify pair exists
+            const mapBefore = pairMap.get(orderbook1);
+            expect(mapBefore?.get(tkn1)?.get(tkn2)).toHaveLength(1);
+
+            // delete pair
+            removeFromPairMap(pairMap, orderbook1, hash1, tkn1, tkn2);
+
+            // verify pair is deleted
+            const mapAfter = pairMap.get(orderbook1);
+            expect(mapAfter?.get(tkn1)?.get(tkn2)).toBeUndefined();
+            expect(mapAfter?.get(tkn1)).toBeUndefined();
+            expect(mapAfter?.size).toBe(0);
+        });
+
+        it("should only remove specific order from list when multiple orders exist for same pair", async () => {
+            const pairs1 = getPair(orderbook1, hash1, tkn1, tkn2);
+            const pairs2 = getPair(orderbook1, hash2, tkn1, tkn2);
+
+            // add two pairs with same tokens but different order hashes
+            addToPairMap(pairMap, orderbook1, hash1, tkn1, tkn2, pairs1);
+            addToPairMap(pairMap, orderbook1, hash2, tkn1, tkn2, pairs2);
+
+            // verify both pairs exist
+            const mapBefore = pairMap.get(orderbook1);
+            expect(mapBefore?.get(tkn1)?.get(tkn2)).toHaveLength(2);
+
+            // delete only the first order
+            removeFromPairMap(pairMap, orderbook1, hash1, tkn1, tkn2);
+
+            // verify only one pair remains
+            const mapAfter = pairMap.get(orderbook1);
+            const remainingPairs = mapAfter?.get(tkn1)?.get(tkn2);
+            expect(remainingPairs?.size).toBe(1);
+            expect(remainingPairs?.get(hash2)).toBeDefined();
+        });
+
+        it("should not affect other orderbooks when deleting from one", async () => {
+            const pairs1 = getPair(orderbook1, hash1, tkn1, tkn2);
+            const pairs2 = getPair(orderbook2, hash2, tkn1, tkn2);
+
+            // add pairs to both orderbooks
+            addToPairMap(pairMap, orderbook1, hash1, tkn1, tkn2, pairs1);
+            addToPairMap(pairMap, orderbook2, hash2, tkn1, tkn2, pairs2);
+
+            // verify both orderbooks have pairs
+            expect(pairMap.get(orderbook1)?.get(tkn1)?.get(tkn2)).toHaveLength(1);
+            expect(pairMap.get(orderbook2)?.get(tkn1)?.get(tkn2)).toHaveLength(1);
+
+            // delete from orderbook1 only
+            removeFromPairMap(pairMap, orderbook1, hash1, tkn1, tkn2);
+
+            // verify orderbook1 is empty but orderbook2 still has pairs
+            expect(pairMap.get(orderbook1)?.size).toBe(0);
+            expect(pairMap.get(orderbook2)?.get(tkn1)?.get(tkn2)).toHaveLength(1);
+        });
+
+        it("should handle deletion from non-existent orderbook gracefully", async () => {
+            // Should not throw error when deleting from non-existent orderbook
+            expect(() => {
+                removeFromPairMap(pairMap, "0xnonexistent", hash1, tkn1, tkn2);
+            }).not.toThrow();
+        });
+
+        it("should handle deletion of non-existent order gracefully", async () => {
+            const pair = getPair(orderbook1, hash1, tkn1, tkn2);
+
+            // add pair
+            addToPairMap(pairMap, orderbook1, hash1, tkn1, tkn2, pair);
+
+            // Try to delete non-existent order
+            removeFromPairMap(pairMap, orderbook1, hash2, tkn1, tkn2);
+
+            // verify original pair still exists
+            const map = pairMap.get(orderbook1);
+            expect(map?.get(tkn1)?.get(tkn2)).toHaveLength(1);
+            expect(map?.get(tkn1)?.get(tkn2)?.get(hash1)?.takeOrder.id).toBe(hash1);
+        });
+
+        it("should handle complex deletion scenario with mixed pairs", async () => {
+            const pairs = [
+                getPair(orderbook1, hash1, tkn1, tkn2),
+                getPair(orderbook1, hash2, tkn1, tkn2), // Same pair, different order
+                getPair(orderbook1, hash1, tkn1, tkn3), // Same output, different input
+                getPair(orderbook1, hash3, tkn2, tkn1), // different output-input combination
+            ];
+
+            // add all pairs
+            for (const pair of pairs) {
+                addToPairMap(
+                    pairMap,
+                    pair.orderbook,
+                    pair.takeOrder.id,
+                    pair.sellToken,
+                    pair.buyToken,
+                    pair,
+                );
+            }
+
+            // verify initial state
+            const mapBefore = pairMap.get(orderbook1);
+            expect(mapBefore?.get(tkn1)?.get(tkn2)?.size).toBe(2); // hash1 and hash2
+            expect(mapBefore?.get(tkn1)?.get(tkn3)?.size).toBe(1); // hash1
+            expect(mapBefore?.get(tkn2)?.get(tkn1)?.size).toBe(1); // hash3
+
+            // delete hash1 order (should affect tkn1->tkn2 and tkn1->tkn3)
+            removeFromPairMap(pairMap, orderbook1, hash1, tkn1, tkn2);
+            removeFromPairMap(pairMap, orderbook1, hash1, tkn1, tkn3);
+
+            // verify final state
+            const mapAfter = pairMap.get(orderbook1);
+            expect(mapAfter?.get(tkn1)?.get(tkn2)).toHaveLength(1); // Only hash2 remains
+            expect(mapAfter?.get(tkn1)?.get(tkn2)?.get(hash2)?.takeOrder.id).toBe(hash2);
+            expect(mapAfter?.get(tkn1)?.get(tkn3)).toBeUndefined(); // hash1 removed, list deleted
+            expect(mapAfter?.get(tkn2)?.get(tkn1)).toHaveLength(1); // hash3 unaffected
+            expect(mapAfter?.get(tkn2)?.get(tkn1)?.get(hash3)?.takeOrder.id).toBe(hash3);
+        });
+    });
+});
+
+describe("Test getSortedPairList function", () => {
+    let pairMap: OrderbooksPairMap;
+    const orderbook1 = "0xorderbook1";
+    const orderbook2 = "0xorderbook2";
+    const orderbook3 = "0xorderbook3";
+    const outputToken = "0xoutput";
+    const inputToken = "0xinput";
+
+    const createPair = (
+        orderbook: string,
+        hash: string,
+        quote?: { ratio: bigint; maxOutput: bigint },
+    ): Pair =>
+        ({
+            orderbook,
+            buyToken: inputToken,
+            sellToken: outputToken,
+            takeOrder: {
+                id: hash,
+                takeOrder: {} as any,
+                quote,
+            },
+        }) as any;
+
+    beforeEach(() => {
+        pairMap = new Map();
+
+        // setup orderbook1 with multiple pairs
+        const ob1Map = new Map();
+        const ob1OutputMap = new Map();
+        const ob1PairMap = new Map();
+
+        ob1PairMap.set("hash1", createPair(orderbook1, "hash1", { ratio: 10n, maxOutput: 500n }));
+        ob1PairMap.set("hash2", createPair(orderbook1, "hash2", { ratio: 20n, maxOutput: 300n }));
+        ob1PairMap.set("hash3", createPair(orderbook1, "hash3", { ratio: 10n, maxOutput: 800n }));
+        ob1PairMap.set("hash4", createPair(orderbook1, "hash4")); // no quote
+
+        ob1OutputMap.set(inputToken, ob1PairMap);
+        ob1Map.set(outputToken, ob1OutputMap);
+        pairMap.set(orderbook1, ob1Map);
+
+        // setup orderbook2 with pairs
+        const ob2Map = new Map();
+        const ob2OutputMap = new Map();
+        const ob2PairMap = new Map();
+
+        ob2PairMap.set("hash5", createPair(orderbook2, "hash5", { ratio: 5n, maxOutput: 400n }));
+        ob2PairMap.set("hash6", createPair(orderbook2, "hash6", { ratio: 5n, maxOutput: 600n }));
+
+        ob2OutputMap.set(inputToken, ob2PairMap);
+        ob2Map.set(outputToken, ob2OutputMap);
+        pairMap.set(orderbook2, ob2Map);
+
+        // setup orderbook3 with pairs
+        const ob3Map = new Map();
+        const ob3OutputMap = new Map();
+        const ob3PairMap = new Map();
+
+        ob3PairMap.set("hash7", createPair(orderbook3, "hash7", { ratio: 25n, maxOutput: 200n }));
+        ob3PairMap.set("hash8", createPair(orderbook3, "hash8", { ratio: 30n, maxOutput: 200n }));
+
+        ob3OutputMap.set(inputToken, ob3PairMap);
+        ob3Map.set(outputToken, ob3OutputMap);
+        pairMap.set(orderbook3, ob3Map);
+    });
+
+    it("should return the list with same order book true", () => {
+        const result = getSortedPairList(
+            pairMap,
+            orderbook1,
+            outputToken,
+            inputToken,
+            CounterpartySource.IntraOrderbook,
+        );
+
+        // should return Pair[] (single array of pairs from same orderbook)
+        expect(Array.isArray(result)).toBe(true);
+        expect(result).toHaveLength(4);
+
+        // check sorting order: descending by ratio, then by maxOutput
+        // expected order: hash2 (20n, 300n), hash3 (10n, 800n), hash1 (10n, 500n), hash4 (no quote)
+        expect(result[0].takeOrder.id).toBe("hash2");
+        expect(result[0].takeOrder.quote?.ratio).toBe(20n);
+        expect(result[0].takeOrder.quote?.maxOutput).toBe(300n);
+
+        expect(result[1].takeOrder.id).toBe("hash3");
+        expect(result[1].takeOrder.quote?.ratio).toBe(10n);
+        expect(result[1].takeOrder.quote?.maxOutput).toBe(800n);
+
+        expect(result[2].takeOrder.id).toBe("hash1");
+        expect(result[2].takeOrder.quote?.ratio).toBe(10n);
+        expect(result[2].takeOrder.quote?.maxOutput).toBe(500n);
+
+        expect(result[3].takeOrder.id).toBe("hash4");
+        expect(result[3].takeOrder.quote).toBeUndefined();
+
+        // verify the internal map is also sorted
+        const internalMap = pairMap.get(orderbook1)?.get(outputToken)?.get(inputToken);
+        const internalEntries = Array.from(internalMap!.entries());
+        expect(internalEntries[0][0]).toBe("hash2");
+        expect(internalEntries[1][0]).toBe("hash3");
+        expect(internalEntries[2][0]).toBe("hash1");
+        expect(internalEntries[3][0]).toBe("hash4");
+    });
+
+    it("should return the list with same order book false", () => {
+        const result = getSortedPairList(
+            pairMap,
+            orderbook1,
+            outputToken,
+            inputToken,
+            CounterpartySource.InterOrderbook,
+        );
+
+        // should return Pair[][] (array of arrays, one for each different orderbook)
+        expect(Array.isArray(result)).toBe(true);
+        expect(result).toHaveLength(2); // orderbook2 and orderbook3 (excluding orderbook1)
+
+        // check that each element is an array of pairs
+        expect(Array.isArray(result[0])).toBe(true);
+        expect(Array.isArray(result[1])).toBe(true);
+
+        // find which result array corresponds to which orderbook
+        const ob2Results = result[0];
+        const ob3Results = result[1];
+
+        expect(ob2Results).toBeDefined();
+        expect(ob3Results).toBeDefined();
+
+        // check orderbook2 sorting: hash6 (5n, 600n), hash5 (5n, 400n)
+        expect(ob2Results).toHaveLength(2);
+        expect(ob2Results![0].takeOrder.id).toBe("hash6");
+        expect(ob2Results![0].takeOrder.quote?.ratio).toBe(5n);
+        expect(ob2Results![1].takeOrder.id).toBe("hash5");
+        expect(ob2Results![1].takeOrder.quote?.ratio).toBe(5n);
+
+        // check orderbook3 sorting: hash8 (30n, 200n), hash7 (25n, 200n)
+        expect(ob3Results).toHaveLength(2);
+        expect(ob3Results![0].takeOrder.id).toBe("hash8");
+        expect(ob3Results![0].takeOrder.quote?.ratio).toBe(30n);
+        expect(ob3Results![1].takeOrder.id).toBe("hash7");
+        expect(ob3Results![1].takeOrder.quote?.ratio).toBe(25n);
+
+        // verify internal maps are also sorted
+        const ob2InternalMap = pairMap.get(orderbook2)?.get(outputToken)?.get(inputToken);
+        const ob2InternalEntries = Array.from(ob2InternalMap!.entries());
+        expect(ob2InternalEntries[0][0]).toBe("hash6");
+        expect(ob2InternalEntries[1][0]).toBe("hash5");
+
+        const ob3InternalMap = pairMap.get(orderbook3)?.get(outputToken)?.get(inputToken);
+        const ob3InternalEntries = Array.from(ob3InternalMap!.entries());
+        expect(ob3InternalEntries[0][0]).toBe("hash8");
+        expect(ob3InternalEntries[1][0]).toBe("hash7");
+    });
+});
+
+describe("Test sortPairList function", () => {
+    it("should sort pairs correctly in descending order by ratio then by maxOutput", () => {
+        const createPair = (quote?: { ratio: bigint; maxOutput: bigint }): any => [
+            "",
+            { takeOrder: { quote } },
+        ];
+
+        // create pairs with different combinations of quotes
+        const pairs: any[] = [
+            createPair(undefined), // no quote - should be last
+            createPair({ ratio: 5n, maxOutput: 500n }), // lower ratio, lower maxOutput
+            createPair({ ratio: 5n, maxOutput: 1000n }), // lower ratio, higher maxOutput
+            createPair({ ratio: 10n, maxOutput: 200n }), // higher ratio, lower maxOutput
+            createPair({ ratio: 10n, maxOutput: 800n }), // higher ratio, higher maxOutput
+            createPair({ ratio: 20n, maxOutput: 300n }), // highest ratio, medium maxOutput
+            createPair(undefined), // another no quote - should be last
+        ];
+        const sorted = [...pairs].sort(sortPairList);
+
+        // expected order (descending by ratio, then descending by maxOutput for same ratios):
+        // 1. ratio: 20n, maxOutput: 300n
+        // 2. ratio: 10n, maxOutput: 800n
+        // 3. ratio: 10n, maxOutput: 200n
+        // 4. ratio: 5n, maxOutput: 1000n
+        // 5. ratio: 5n, maxOutput: 500n
+        // 6. undefined quote
+        // 7. undefined quote
+
+        expect(sorted[0][1].takeOrder.quote?.ratio).toBe(20n);
+        expect(sorted[0][1].takeOrder.quote?.maxOutput).toBe(300n);
+
+        expect(sorted[1][1].takeOrder.quote?.ratio).toBe(10n);
+        expect(sorted[1][1].takeOrder.quote?.maxOutput).toBe(800n);
+
+        expect(sorted[2][1].takeOrder.quote?.ratio).toBe(10n);
+        expect(sorted[2][1].takeOrder.quote?.maxOutput).toBe(200n);
+
+        expect(sorted[3][1].takeOrder.quote?.ratio).toBe(5n);
+        expect(sorted[3][1].takeOrder.quote?.maxOutput).toBe(1000n);
+
+        expect(sorted[4][1].takeOrder.quote?.ratio).toBe(5n);
+        expect(sorted[4][1].takeOrder.quote?.maxOutput).toBe(500n);
+
+        // last two should have no quotes
+        expect(sorted[5][1].takeOrder.quote).toBeUndefined();
+        expect(sorted[6][1].takeOrder.quote).toBeUndefined();
+    });
+});

--- a/src/order/pair.ts
+++ b/src/order/pair.ts
@@ -78,19 +78,19 @@ export function removeFromPairMap(
  * @param orderbook - The orderbook address to get pairs from
  * @param output - The output token address to get pairs from
  * @param input - The input token address to get pairs from
- * @param counterpartyType - Determines the type of counterparty orders source to return
+ * @param counterpartySource - Determines the type of counterparty orders source to return
  */
 export function getSortedPairList<
-    counterpartyType extends CounterpartySource = CounterpartySource.IntraOrderbook,
+    counterpartySource extends CounterpartySource = CounterpartySource.IntraOrderbook,
 >(
     pairMap: OrderbooksPairMap,
     orderbook: string,
     output: string,
     input: string,
-    counterpartyType: CounterpartySource,
-): counterpartyType extends CounterpartySource.IntraOrderbook ? Pair[] : Pair[][] {
+    counterpartySource: CounterpartySource,
+): counterpartySource extends CounterpartySource.IntraOrderbook ? Pair[] : Pair[][] {
     const empty = new Map<string, Pair>();
-    if (counterpartyType === CounterpartySource.IntraOrderbook) {
+    if (counterpartySource === CounterpartySource.IntraOrderbook) {
         // get orders as array and set them back as new sorted map
         const arr = Array.from(pairMap.get(orderbook)?.get(output)?.get(input) ?? empty).sort(
             sortPairList,
@@ -100,7 +100,7 @@ export function getSortedPairList<
         // return the sorted orders
         return Array.from(
             pairMap.get(orderbook)?.get(output)?.get(input)?.values() ?? empty.values(),
-        ) as counterpartyType extends CounterpartySource.IntraOrderbook ? Pair[] : Pair[][];
+        ) as counterpartySource extends CounterpartySource.IntraOrderbook ? Pair[] : Pair[][];
     } else {
         const counterpartyOrders: Pair[][] = [];
         pairMap.forEach((innerMap, ob) => {
@@ -116,7 +116,7 @@ export function getSortedPairList<
                 Array.from(innerMap.get(output)?.get(input)?.values() ?? empty.values()),
             );
         });
-        return counterpartyOrders as counterpartyType extends CounterpartySource.IntraOrderbook
+        return counterpartyOrders as counterpartySource extends CounterpartySource.IntraOrderbook
             ? Pair[]
             : Pair[][];
     }

--- a/src/order/pair.ts
+++ b/src/order/pair.ts
@@ -1,0 +1,163 @@
+import { CounterpartySource, OrderbooksPairMap, Pair } from "./types";
+
+/**
+ * Adds the given order pair to the given pair map
+ * @param pairMap - The pair map to add the pair to
+ * @param orderbook - The orderbook address
+ * @param orderHash - The hash of the order
+ * @param output - The output token address
+ * @param input - The input token address
+ * @param pair - The order pair object
+ */
+export function addToPairMap(
+    pairMap: OrderbooksPairMap,
+    orderbook: string,
+    orderHash: string,
+    output: string,
+    input: string,
+    pair: Pair,
+) {
+    const map = pairMap.get(orderbook);
+    if (map) {
+        const innerMap = map.get(output);
+        if (!innerMap) {
+            map.set(output, new Map([[input, new Map([[orderHash, pair]])]]));
+        } else {
+            const list = innerMap.get(input);
+            if (!list) {
+                innerMap.set(input, new Map([[orderHash, pair]]));
+            } else {
+                list.set(orderHash, pair);
+            }
+        }
+    } else {
+        pairMap.set(
+            orderbook,
+            new Map([[output, new Map([[input, new Map([[orderHash, pair]])]])]]),
+        );
+    }
+}
+
+/**
+ * Removes the order from the given pair map
+ * @param pairMap - The pair map to remove the pair from
+ * @param orderbook - The orderbook address
+ * @param orderHash - The hash of the order
+ * @param output - The output token address
+ * @param input - The input token address
+ */
+export function removeFromPairMap(
+    pairMap: OrderbooksPairMap,
+    orderbook: string,
+    orderHash: string,
+    output: string,
+    input: string,
+) {
+    const map = pairMap.get(orderbook.toLowerCase());
+    if (map) {
+        const innerMap = map.get(output);
+        if (innerMap) {
+            const list = innerMap.get(input);
+            if (list) {
+                // remove the order from the list
+                list.delete(orderHash);
+                if (list.size === 0) {
+                    innerMap.delete(input);
+                }
+                if (innerMap.size === 0) {
+                    map.delete(output);
+                }
+            }
+        }
+    }
+}
+
+// export function getSortedPairList(
+//     pairMap: OrderbooksPairMap,
+//     orderbook: string,
+//     output: string,
+//     input: string,
+//     counterpartyType: CounterpartyType.IntraOrderbook,
+// ): Pair[];
+// export function getSortedPairList(
+//     pairMap: OrderbooksPairMap,
+//     orderbook: string,
+//     output: string,
+//     input: string,
+//     counterpartyType: CounterpartyType.IntraOrderbook,
+// ): Pair[][];
+
+/**
+ * Gets descending sorted list of pairs from the given pairMap by their ratios
+ * @param pairMap - The pair map to get pairs from
+ * @param orderbook - The orderbook address to get pairs from
+ * @param output - The output token address to get pairs from
+ * @param input - The input token address to get pairs from
+ * @param counterpartyType - Determines the type of counterparty orders source to return
+ */
+export function getSortedPairList<
+    counterpartyType extends CounterpartySource = CounterpartySource.IntraOrderbook,
+>(
+    pairMap: OrderbooksPairMap,
+    orderbook: string,
+    output: string,
+    input: string,
+    counterpartyType: CounterpartySource,
+): counterpartyType extends CounterpartySource.IntraOrderbook ? Pair[] : Pair[][] {
+    const empty = new Map<string, Pair>();
+    if (counterpartyType === CounterpartySource.IntraOrderbook) {
+        // get orders as array and set them back as new sorted map
+        const arr = Array.from(pairMap.get(orderbook)?.get(output)?.get(input) ?? empty).sort(
+            sortPairList,
+        );
+        pairMap.get(orderbook)?.get(output)?.set(input, new Map(arr));
+
+        // return the sorted orders
+        return Array.from(
+            pairMap.get(orderbook)?.get(output)?.get(input)?.values() ?? empty.values(),
+        ) as counterpartyType extends CounterpartySource.IntraOrderbook ? Pair[] : Pair[][];
+    } else {
+        const counterpartyOrders: Pair[][] = [];
+        pairMap.forEach((innerMap, ob) => {
+            // skip same orderbook
+            if (ob === orderbook) return;
+
+            // get orders as array and set them back as new sorted map
+            const arr = Array.from(innerMap.get(output)?.get(input) ?? empty).sort(sortPairList);
+            innerMap.get(output)?.set(input, new Map(arr));
+
+            // push the sorted orders to the result
+            counterpartyOrders.push(
+                Array.from(innerMap.get(output)?.get(input)?.values() ?? empty.values()),
+            );
+        });
+        return counterpartyOrders as counterpartyType extends CounterpartySource.IntraOrderbook
+            ? Pair[]
+            : Pair[][];
+    }
+}
+
+/**
+ * Sorts a pair list in descending order by their quotes ratio and maxoutput
+ * @param a - The first pair to compare
+ * @param b - The second pair to compare
+ */
+export function sortPairList(a: [string, Pair], b: [string, Pair]): number {
+    if (!a[1].takeOrder.quote && !b[1].takeOrder.quote) return 0;
+    if (!a[1].takeOrder.quote) return 1;
+    if (!b[1].takeOrder.quote) return -1;
+    if (a[1].takeOrder.quote.ratio < b[1].takeOrder.quote.ratio) {
+        return 1;
+    } else if (a[1].takeOrder.quote.ratio > b[1].takeOrder.quote.ratio) {
+        return -1;
+    } else {
+        // if ratios are equal, sort by maxoutput
+        if (a[1].takeOrder.quote.maxOutput < b[1].takeOrder.quote.maxOutput) {
+            return 1;
+        } else if (a[1].takeOrder.quote.maxOutput > b[1].takeOrder.quote.maxOutput) {
+            return -1;
+        } else {
+            return 0;
+        }
+    }
+}

--- a/src/order/pair.ts
+++ b/src/order/pair.ts
@@ -72,21 +72,6 @@ export function removeFromPairMap(
     }
 }
 
-// export function getSortedPairList(
-//     pairMap: OrderbooksPairMap,
-//     orderbook: string,
-//     output: string,
-//     input: string,
-//     counterpartyType: CounterpartyType.IntraOrderbook,
-// ): Pair[];
-// export function getSortedPairList(
-//     pairMap: OrderbooksPairMap,
-//     orderbook: string,
-//     output: string,
-//     input: string,
-//     counterpartyType: CounterpartyType.IntraOrderbook,
-// ): Pair[][];
-
 /**
  * Gets descending sorted list of pairs from the given pairMap by their ratios
  * @param pairMap - The pair map to get pairs from

--- a/src/order/quote.test.ts
+++ b/src/order/quote.test.ts
@@ -25,18 +25,16 @@ describe("Test quoteSingleOrder", () => {
     beforeEach(() => {
         orderDetails = {
             orderbook: "0xorderbook",
-            takeOrders: [
-                {
-                    takeOrder: {},
-                },
-            ],
+            takeOrder: {
+                takeOrder: {},
+            },
         };
     });
 
     it("should set quote on the takeOrder when data is returned", async () => {
         await quoteSingleOrder(orderDetails, client);
 
-        expect(orderDetails.takeOrders[0].quote).toEqual({
+        expect(orderDetails.takeOrder.quote).toEqual({
             maxOutput: 100n,
             ratio: 2n,
         });

--- a/src/order/quote.ts
+++ b/src/order/quote.ts
@@ -1,7 +1,7 @@
 import { ChainId } from "sushi";
 import { SharedState } from "../state";
 import { AppOptions } from "../config";
-import { BundledOrders, TakeOrder } from "./types";
+import { BundledOrders, Pair, TakeOrder } from "./types";
 import { decodeFunctionResult, encodeFunctionData, PublicClient } from "viem";
 import {
     OrderbookQuoteAbi,
@@ -17,7 +17,7 @@ import {
  * @param gas - Optional read gas
  */
 export async function quoteSingleOrder(
-    orderDetails: BundledOrders,
+    orderDetails: Pair,
     viemClient: PublicClient,
     blockNumber?: bigint,
     gas?: bigint,
@@ -28,13 +28,13 @@ export async function quoteSingleOrder(
             data: encodeFunctionData({
                 abi: OrderbookQuoteAbi,
                 functionName: "quote",
-                args: [TakeOrder.getQuoteConfig(orderDetails.takeOrders[0].takeOrder)],
+                args: [TakeOrder.getQuoteConfig(orderDetails.takeOrder.takeOrder)],
             }),
             blockNumber,
             gas,
         })
         .catch((error) => {
-            orderDetails.takeOrders[0].quote = undefined;
+            orderDetails.takeOrder.quote = undefined;
             throw error;
         });
     if (typeof data !== "undefined") {
@@ -43,7 +43,7 @@ export async function quoteSingleOrder(
             functionName: "quote",
             data,
         });
-        orderDetails.takeOrders[0].quote = {
+        orderDetails.takeOrder.quote = {
             maxOutput: quoteResult[1],
             ratio: quoteResult[2],
         };

--- a/src/order/types.ts
+++ b/src/order/types.ts
@@ -120,4 +120,4 @@ export type OrderbooksOwnersProfileMap = Map<string, OwnersProfileMap>;
 
 export type OrderbooksPairMap = Map<string, PairMap>;
 
-export type PairMap = Map<string, Pair[]>;
+export type PairMap = Map<string, Map<string, Pair[]>>;

--- a/src/order/types.ts
+++ b/src/order/types.ts
@@ -78,6 +78,13 @@ export namespace Order {
     }
 }
 
+/** Represents the source of the counterparty order for an order */
+export enum CounterpartySource {
+    IntraOrderbook,
+    InterOrderbook,
+}
+// export type CounterpartyType = "IntraOrderbook" | "InterOrderbook";
+
 export type BundledOrders = {
     orderbook: string;
     buyToken: string;
@@ -120,4 +127,4 @@ export type OrderbooksOwnersProfileMap = Map<string, OwnersProfileMap>;
 
 export type OrderbooksPairMap = Map<string, PairMap>;
 
-export type PairMap = Map<string, Map<string, Pair[]>>;
+export type PairMap = Map<string, Map<string, Map<string, Pair>>>;

--- a/src/router/marketPrice.ts
+++ b/src/router/marketPrice.ts
@@ -1,7 +1,7 @@
 import { SharedState } from "../state";
 import { Token } from "sushi/currency";
 import { ChainId, Router } from "sushi";
-import { scale18, ONE18 } from "../math";
+import { scaleTo18, ONE18 } from "../math";
 import { PoolBlackList, RPoolFilter } from ".";
 import { formatUnits, parseUnits, maxUint256 } from "viem";
 
@@ -44,7 +44,7 @@ export async function getMarketPrice(
         if (route.status == "NoWay") {
             return;
         } else {
-            const price = scale18(route.amountOutBI, toToken.decimals);
+            const price = scaleTo18(route.amountOutBI, toToken.decimals);
             return {
                 price: formatUnits(price, 18),
                 amountOut: formatUnits(route.amountOutBI, toToken.decimals),

--- a/test/e2e/e2e.test.js
+++ b/test/e2e/e2e.test.js
@@ -604,22 +604,18 @@ for (let i = 0; i < testData.length; i++) {
                 orders = orderManager.getNextRoundOrders(false);
 
                 // mock init quotes
-                orders.forEach((ob) => {
-                    ob.forEach((pair) => {
-                        pair.takeOrders.forEach((takeOrder) => {
-                            takeOrder.quote = {
-                                ratio: ethers.constants.Zero.toBigInt(),
-                                maxOutput: tokens
-                                    .find(
-                                        (t) =>
-                                            t.contract.address.toLowerCase() ===
-                                            pair.sellToken.toLowerCase(),
-                                    )
-                                    ?.depositAmount.mul("1" + "0".repeat(18 - ob.decimals))
-                                    .toBigInt(),
-                            };
-                        });
-                    });
+                orders.forEach((pair) => {
+                    pair.takeOrder.quote = {
+                        ratio: ethers.constants.Zero.toBigInt(),
+                        maxOutput: tokens
+                            .find(
+                                (t) =>
+                                    t.contract.address.toLowerCase() ===
+                                    pair.sellToken.toLowerCase(),
+                            )
+                            ?.depositAmount.mul("1" + "0".repeat(18 - pair.sellTokenDecimals))
+                            .toBigInt(),
+                    };
                 });
                 state.gasPrice = await bot.getGasPrice();
                 orderManager.getNextRoundOrders = () => orders;
@@ -961,22 +957,18 @@ for (let i = 0; i < testData.length; i++) {
                 orders = orderManager.getNextRoundOrders(false);
 
                 // mock init quotes
-                orders.forEach((ob) => {
-                    ob.forEach((pair) => {
-                        pair.takeOrders.forEach((takeOrder) => {
-                            takeOrder.quote = {
-                                ratio: ethers.constants.Zero.toBigInt(),
-                                maxOutput: tokens
-                                    .find(
-                                        (t) =>
-                                            t.contract.address.toLowerCase() ===
-                                            pair.sellToken.toLowerCase(),
-                                    )
-                                    ?.depositAmount.mul("1" + "0".repeat(18 - ob.decimals))
-                                    .toBigInt(),
-                            };
-                        });
-                    });
+                orders.forEach((pair) => {
+                    pair.takeOrder.quote = {
+                        ratio: ethers.constants.Zero.toBigInt(),
+                        maxOutput: tokens
+                            .find(
+                                (t) =>
+                                    t.contract.address.toLowerCase() ===
+                                    pair.sellToken.toLowerCase(),
+                            )
+                            ?.depositAmount.mul("1" + "0".repeat(18 - pair.sellTokenDecimals))
+                            .toBigInt(),
+                    };
                 });
                 state.gasPrice = await bot.getGasPrice();
                 orderManager.getNextRoundOrders = () => orders;


### PR DESCRIPTION
<!-- Thanks for your Pull Request, please read the contributing guidelines before submitting. -->

## Motivation
## ⚠️ Do NOT merge before #375 

This PR updates:
- `OrderbooksPairMap` to be in form of `orderbook -> output -> input -> orderhash -> Pair obj` so that we can instantly access the Pair objects based on given args
- add an opposing map to `OrderManager` that stores the order Pairs as in `input -> output` format, ie 2 `OrderbooksPairMap` maps, 1 `output -> input` and the other `input -> output`, this is the ground work for implementing the feature of rain internal router where for example a trade can happen with for example `tkn2/tkn1 -> tkn3/tkn2 -> tkn1/tkn3` with internal clear, these maps allows us to instantly build a route which will come in following PRs
- use `Pair` instead of `BundledOrders` type for processing order, the latter was grouping orders based on their IO which is not needed going forward
- update rest of the code base to use these updates
- a few item renames
- add/update tests
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## Checks
<!-- It's important you've done these, or your PR will not be considered for review -->
By submitting this for review, I'm confirming I've done the following:
- [x] made this PR as small as possible
- [x] unit-tested any new functionality
- [x] linked any relevant issues or PRs
- [ ] ~~included screenshots (if this involves a front-end change)~~
