### PR TITLE
fix signer actions `this` context

### DIFF
--- a/src/error/revert.test.ts
+++ b/src/error/revert.test.ts
@@ -148,6 +148,7 @@ describe("Test revert error handling functions", () => {
             (isDeepStrictEqual as Mock).mockReturnValue(true);
             (containsNodeError as Mock).mockResolvedValue(true);
             (errorSnapshot as Mock).mockResolvedValue("Error snapshot with frontrun info");
+            (getRpcError as Mock).mockReturnValue({});
 
             const result = await handleRevert(
                 mockViemClient,
@@ -194,6 +195,7 @@ describe("Test revert error handling functions", () => {
             mockViemClient.getLogs.mockResolvedValue([]);
             (containsNodeError as Mock).mockResolvedValue(false);
             (errorSnapshot as Mock).mockResolvedValue("Error snapshot without frontrun");
+            (getRpcError as Mock).mockReturnValue({});
 
             const result = await handleRevert(
                 mockViemClient,
@@ -277,7 +279,6 @@ describe("Test revert error handling functions", () => {
             const mockRawError = {
                 code: -32000,
                 message: "execution reverted",
-                data: undefined,
             };
             (getRpcError as Mock).mockReturnValue(mockRawError);
 

--- a/src/error/revert.ts
+++ b/src/error/revert.ts
@@ -92,8 +92,8 @@ export async function handleRevert(
 export async function parseRevertError(error: BaseError): Promise<TxRevertError> {
     const raw = getRpcError(error);
     let decoded: DecodedErrorType | undefined;
-    if ("data" in error && isHex(error.data, { strict: true })) {
-        const result = await tryDecodeError(error.data);
+    if ("data" in raw && isHex(raw.data, { strict: true })) {
+        const result = await tryDecodeError(raw.data);
         if (result.isOk()) {
             decoded = result.value;
         }

--- a/src/signer/actions.test.ts
+++ b/src/signer/actions.test.ts
@@ -72,7 +72,7 @@ describe("Test sendTx", () => {
     });
 
     it("should successfully send a transaction", async () => {
-        const txHash = await sendTx.call(mockSigner, mockTx);
+        const txHash = await sendTx(mockSigner, mockTx);
 
         expect(mockSigner.waitUntilFree).toHaveBeenCalled();
         expect(mockSigner.getTransactionCount).toHaveBeenCalledWith({
@@ -94,7 +94,7 @@ describe("Test sendTx", () => {
             return Promise.resolve();
         });
 
-        await sendTx.call(mockSigner, mockTx);
+        await sendTx(mockSigner, mockTx);
 
         expect(busyResolved).toBe(true);
         expect(mockSigner.sendTransaction).toHaveBeenCalled();
@@ -108,7 +108,7 @@ describe("Test sendTx", () => {
         });
 
         expect(mockSigner.busy).toBe(false);
-        await sendTx.call(mockSigner, mockTx);
+        await sendTx(mockSigner, mockTx);
         expect(mockSigner.busy).toBe(false);
         expect(states).toContain(true); // Was busy during transaction
     });
@@ -118,7 +118,7 @@ describe("Test sendTx", () => {
         mockSigner.sendTransaction = vi.fn().mockRejectedValue(error);
 
         expect(mockSigner.busy).toBe(false);
-        await expect(sendTx.call(mockSigner, mockTx)).rejects.toThrow(error);
+        await expect(sendTx(mockSigner, mockTx)).rejects.toThrow(error);
         expect(mockSigner.busy).toBe(false);
     });
 
@@ -126,7 +126,7 @@ describe("Test sendTx", () => {
         const error = new Error("Wait until free failed");
         mockSigner.waitUntilFree = vi.fn().mockRejectedValue(error);
 
-        await expect(sendTx.call(mockSigner, mockTx)).rejects.toThrow(error);
+        await expect(sendTx(mockSigner, mockTx)).rejects.toThrow(error);
         expect(mockSigner.busy).toBe(false);
         expect(mockSigner.sendTransaction).not.toHaveBeenCalled();
     });
@@ -135,7 +135,7 @@ describe("Test sendTx", () => {
         const error = new Error("Failed to get nonce");
         mockSigner.getTransactionCount = vi.fn().mockRejectedValue(error);
 
-        await expect(sendTx.call(mockSigner, mockTx)).rejects.toThrow(error);
+        await expect(sendTx(mockSigner, mockTx)).rejects.toThrow(error);
         expect(mockSigner.busy).toBe(false);
         expect(mockSigner.sendTransaction).not.toHaveBeenCalled();
     });
@@ -146,7 +146,7 @@ describe("Test sendTx", () => {
             gas: 200000n,
         };
 
-        await sendTx.call(mockSigner, txWithGas);
+        await sendTx(mockSigner, txWithGas);
 
         expect(mockSigner.sendTransaction).toHaveBeenCalledWith(
             expect.objectContaining({
@@ -179,7 +179,7 @@ describe("Test estimateGasCost", () => {
     });
 
     it("should calculate basic gas cost non-L2 chains", async () => {
-        const result = await estimateGasCost.call(mockSigner, mockTx);
+        const result = await estimateGasCost(mockSigner, mockTx);
 
         expect(mockSigner.estimateGas).toHaveBeenCalledWith(mockTx);
         expect(result).toEqual({
@@ -199,7 +199,7 @@ describe("Test estimateGasCost", () => {
         mockSigner.state.chainConfig.isSpecialL2 = true;
         (mockSigner.extend as Mock).mockReturnValue(mockL2Client);
 
-        const result = await estimateGasCost.call(mockSigner, mockTx);
+        const result = await estimateGasCost(mockSigner, mockTx);
 
         expect(mockSigner.extend).toHaveBeenCalledWith(publicActionsL2());
         expect(mockL2Client.getL1BaseFee).toHaveBeenCalled();
@@ -225,7 +225,7 @@ describe("Test estimateGasCost", () => {
         mockSigner.state.l1GasPrice = 40000000000n; // 40 gwei
         (mockSigner.extend as Mock).mockReturnValue(mockL2Client);
 
-        const result = await estimateGasCost.call(mockSigner, mockTx);
+        const result = await estimateGasCost(mockSigner, mockTx);
 
         expect(mockL2Client.getL1BaseFee).not.toHaveBeenCalled();
         expect(result.l1GasPrice).toBe(0n);
@@ -239,7 +239,7 @@ describe("Test estimateGasCost", () => {
         mockSigner.state.chainConfig.isSpecialL2 = true;
         (mockSigner.extend as Mock).mockReturnValue(mockL2Client);
 
-        const result = await estimateGasCost.call(mockSigner, mockTx);
+        const result = await estimateGasCost(mockSigner, mockTx);
 
         expect(result).toEqual({
             gas: 100000n,
@@ -297,7 +297,7 @@ describe("Test waitUntilFree", () => {
 
     it("should call sleep once and resolve after 30 ms", async () => {
         setTimeout(() => (mockSigner.busy = false), 10); // set busy to false after 10 ms
-        await waitUntilFree.call(mockSigner);
+        await waitUntilFree(mockSigner);
 
         expect(sleepSpy).toHaveBeenCalledTimes(1);
         expect(sleepSpy).toHaveBeenCalledWith(30);
@@ -305,7 +305,7 @@ describe("Test waitUntilFree", () => {
 
     it("should call sleep ywice and resolve after 60 ms", async () => {
         setTimeout(() => (mockSigner.busy = false), 40); // set busy to false after 40 ms
-        await waitUntilFree.call(mockSigner);
+        await waitUntilFree(mockSigner);
 
         expect(sleepSpy).toHaveBeenCalledTimes(2);
         expect(sleepSpy).toHaveBeenCalledWith(30);
@@ -322,7 +322,7 @@ describe("Test getSelfBalance", () => {
         } as unknown as RainSolverSigner;
         const expectedBalance = 1000000n;
         (mockSigner.getBalance as any).mockResolvedValue(expectedBalance);
-        const balance = await getSelfBalance.call(mockSigner);
+        const balance = await getSelfBalance(mockSigner);
 
         expect(mockSigner.getBalance).toHaveBeenCalledWith({
             address: "0xuser",
@@ -347,7 +347,7 @@ describe("Test getWriteSignerFrom", () => {
 
         const signer = RainSolverSigner.create(account, mockState);
         const spySigner = vi.spyOn(RainSolverSigner, "create");
-        getWriteSignerFrom.call(signer, mockState);
+        getWriteSignerFrom(signer);
 
         expect(spySigner).toHaveBeenCalledTimes(0);
 
@@ -366,7 +366,7 @@ describe("Test getWriteSignerFrom", () => {
 
         const signer: any = RainSolverSigner.create(account, mockState);
         const spySigner = vi.spyOn(RainSolverSigner, "create");
-        getWriteSignerFrom.call(signer, mockState);
+        getWriteSignerFrom(signer);
 
         expect(spySigner).toHaveBeenCalledTimes(1);
         expect(spySigner).toHaveBeenCalledWith(account, mockState, true);

--- a/src/signer/index.ts
+++ b/src/signer/index.ts
@@ -83,9 +83,10 @@ export namespace RainSolverSigner {
             ),
         })
             .extend(publicActions)
-            .extend(() => ({ state }))
             .extend(
-                RainSolverSignerActions.fromSharedState(state) as any,
+                RainSolverSignerActions.fromSharedState(
+                    state,
+                ) as any as () => RainSolverSignerActions<account>,
             ) as RainSolverSigner<account>;
     }
 }

--- a/src/subgraph/index.ts
+++ b/src/subgraph/index.ts
@@ -155,7 +155,7 @@ export class SubgraphManager {
                 throw "Received invalid response";
             }
         }
-        this.syncState[url].lastFetchTimestamp = timestamp;
+        this.syncState[url].lastFetchTimestamp = Math.floor(timestamp / 1000);
         return result;
     }
 

--- a/test/e2e/e2e.test.js
+++ b/test/e2e/e2e.test.js
@@ -132,13 +132,13 @@ for (let i = 0; i < testData.length; i++) {
                           .extend(publicActions)
                           .extend(walletActions);
                 bot.sendTx = async (tx) => {
-                    return await sendTx.call(bot, tx);
+                    return await sendTx(bot, tx);
                 };
                 bot.waitUntilFree = async () => {
-                    return await waitUntilFree.call(bot);
+                    return await waitUntilFree(bot);
                 };
                 bot.estimateGasCost = async (tx) => {
-                    return await estimateGasCost.call(bot, tx);
+                    return await estimateGasCost(bot, tx);
                 };
                 bot.asWriteSigner = () => bot;
                 bot.state = state;
@@ -384,13 +384,13 @@ for (let i = 0; i < testData.length; i++) {
                           .extend(publicActions)
                           .extend(walletActions);
                 bot.sendTx = async (tx) => {
-                    return await sendTx.call(bot, tx);
+                    return await sendTx(bot, tx);
                 };
                 bot.waitUntilFree = async () => {
-                    return await waitUntilFree.call(bot);
+                    return await waitUntilFree(bot);
                 };
                 bot.estimateGasCost = async (tx) => {
-                    return await estimateGasCost.call(bot, tx);
+                    return await estimateGasCost(bot, tx);
                 };
                 bot.asWriteSigner = () => bot;
                 bot.state = state;
@@ -727,13 +727,13 @@ for (let i = 0; i < testData.length; i++) {
                           .extend(publicActions)
                           .extend(walletActions);
                 bot.sendTx = async (tx) => {
-                    return await sendTx.call(bot, tx);
+                    return await sendTx(bot, tx);
                 };
                 bot.waitUntilFree = async () => {
-                    return await waitUntilFree.call(bot);
+                    return await waitUntilFree(bot);
                 };
                 bot.estimateGasCost = async (tx) => {
-                    return await estimateGasCost.call(bot, tx);
+                    return await estimateGasCost(bot, tx);
                 };
                 bot.asWriteSigner = () => bot;
                 bot.state = state;

--- a/test/e2e/e2e.test.js
+++ b/test/e2e/e2e.test.js
@@ -132,13 +132,13 @@ for (let i = 0; i < testData.length; i++) {
                           .extend(publicActions)
                           .extend(walletActions);
                 bot.sendTx = async (tx) => {
-                    return await sendTx(bot, tx);
+                    return await sendTx.call(bot, tx);
                 };
                 bot.waitUntilFree = async () => {
-                    return await waitUntilFree(bot);
+                    return await waitUntilFree.call(bot);
                 };
                 bot.estimateGasCost = async (tx) => {
-                    return await estimateGasCost(bot, tx);
+                    return await estimateGasCost.call(bot, tx);
                 };
                 bot.asWriteSigner = () => bot;
                 bot.state = state;
@@ -384,13 +384,13 @@ for (let i = 0; i < testData.length; i++) {
                           .extend(publicActions)
                           .extend(walletActions);
                 bot.sendTx = async (tx) => {
-                    return await sendTx(bot, tx);
+                    return await sendTx.call(bot, tx);
                 };
                 bot.waitUntilFree = async () => {
-                    return await waitUntilFree(bot);
+                    return await waitUntilFree.call(bot);
                 };
                 bot.estimateGasCost = async (tx) => {
-                    return await estimateGasCost(bot, tx);
+                    return await estimateGasCost.call(bot, tx);
                 };
                 bot.asWriteSigner = () => bot;
                 bot.state = state;
@@ -727,13 +727,13 @@ for (let i = 0; i < testData.length; i++) {
                           .extend(publicActions)
                           .extend(walletActions);
                 bot.sendTx = async (tx) => {
-                    return await sendTx(bot, tx);
+                    return await sendTx.call(bot, tx);
                 };
                 bot.waitUntilFree = async () => {
-                    return await waitUntilFree(bot);
+                    return await waitUntilFree.call(bot);
                 };
                 bot.estimateGasCost = async (tx) => {
-                    return await estimateGasCost(bot, tx);
+                    return await estimateGasCost.call(bot, tx);
                 };
                 bot.asWriteSigner = () => bot;
                 bot.state = state;


### PR DESCRIPTION
<!-- Thanks for your Pull Request, please read the contributing guidelines before submitting. -->

## Motivation
## ⚠️ Do NOT merge before #376 

This PR fixes the `this` context for signer actions.
due to the fact that view client extension create a new object and don't simply extend the existing object, the new extended actions need to keep the `this` context when they call inner methods.
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## Checks
<!-- It's important you've done these, or your PR will not be considered for review -->
By submitting this for review, I'm confirming I've done the following:
- [x] made this PR as small as possible
- [x] unit-tested any new functionality
- [x] linked any relevant issues or PRs
- [ ] ~~included screenshots (if this involves a front-end change)~~
