### PR TITLE
owner token vault map update

### DIFF
--- a/src/cli/index.test.ts
+++ b/src/cli/index.test.ts
@@ -170,6 +170,7 @@ describe("Test RainSolverCli", () => {
 
         mockOrderManager = {
             sync: vi.fn(),
+            downscaleProtection: vi.fn(),
         } as any;
 
         mockWalletManager = {
@@ -585,6 +586,7 @@ describe("Test RainSolverCli", () => {
                 mockRetryAddReports,
             );
             (mockWalletManager.assessWorkers as Mock).mockResolvedValue(mockAssessReports);
+            (mockOrderManager.downscaleProtection as Mock).mockResolvedValue(undefined);
 
             await rainSolverCli.runWalletOpsForRound(mockRoundCtx as any);
 
@@ -592,6 +594,7 @@ describe("Test RainSolverCli", () => {
             expect(mockWalletManager.assessWorkers).toHaveBeenCalledTimes(1);
             expect(mockWalletManager.retryPendingRemoveWorkers).not.toHaveBeenCalled();
             expect(mockWalletManager.convertHoldingsToGas).not.toHaveBeenCalled();
+            expect(mockOrderManager.downscaleProtection).not.toHaveBeenCalled();
 
             expect(mockLogger.exportPreAssembledSpan).toHaveBeenCalledWith(
                 { name: "retry-add-1" },
@@ -633,11 +636,13 @@ describe("Test RainSolverCli", () => {
             (mockWalletManager.convertHoldingsToGas as Mock).mockResolvedValue(
                 mockConvertHoldingsReport,
             );
+            (mockOrderManager.downscaleProtection as Mock).mockResolvedValue(undefined);
 
             await rainSolverCli.runWalletOpsForRound(mockRoundCtx as any);
 
             expect(mockWalletManager.retryPendingRemoveWorkers).toHaveBeenCalledTimes(1);
             expect(mockWalletManager.convertHoldingsToGas).toHaveBeenCalledTimes(1);
+            expect(mockOrderManager.downscaleProtection).toHaveBeenCalledOnce();
 
             expect(mockLogger.exportPreAssembledSpan).toHaveBeenCalledWith(
                 { name: "pending-remove-1" },

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -335,6 +335,9 @@ export class RainSolverCli {
             // try to sweep main wallet's tokens back to gas
             const convertHoldingsToGasReport = await this.walletManager.convertHoldingsToGas();
             this.logger.exportPreAssembledSpan(convertHoldingsToGasReport, roundCtx);
+
+            // re-evaluate owner limits
+            await this.orderManager.downscaleProtection();
         }
     }
 

--- a/src/common/abis.ts
+++ b/src/common/abis.ts
@@ -82,10 +82,12 @@ export const arbAbis = [
 ] as const;
 
 export const Call3 = "(address target, bool allowFailure, bytes callData)" as const;
+export const Call = "(address target, bytes callData)" as const;
 export const MulticallResult = "(bool success, bytes returnData)" as const;
 export const multicall3Abi = [
     "function getEthBalance(address addr) external view returns (uint256 balance)",
     `function aggregate3(${Call3}[] calldata calls) external payable returns (${MulticallResult}[] memory returnData)`,
+    `function aggregate(${Call}[] calldata calls) external payable returns (uint256 blockNumber, bytes[] memory returnData)`,
 ] as const;
 
 // an empty evaluable mainly used as default evaluable for arb contracts

--- a/src/core/process/round.test.ts
+++ b/src/core/process/round.test.ts
@@ -23,6 +23,7 @@ describe("Test initializeRound", () => {
         // mock order manager
         mockOrderManager = {
             getNextRoundOrders: vi.fn(),
+            ownerTokenVaultMap: new Map(),
         };
 
         // mock wallet manager

--- a/src/core/process/round.ts
+++ b/src/core/process/round.ts
@@ -28,12 +28,35 @@ export async function initializeRound(this: RainSolver, roundSpanCtx?: SpanWithC
     for (const orderDetails of orders) {
         const pair = `${orderDetails.buyTokenSymbol}/${orderDetails.sellTokenSymbol}`;
         const report = new PreAssembledSpan(`checkpoint_${pair}`);
+        const owner = orderDetails.takeOrder.takeOrder.order.owner.toLowerCase();
         report.extendAttrs({
             "details.pair": pair,
             "details.orderHash": orderDetails.takeOrder.id,
             "details.orderbook": orderDetails.orderbook,
             "details.owner": orderDetails.takeOrder.takeOrder.order.owner,
         });
+
+        // update the orderDetails vault balances from owner vaults map
+        orderDetails.sellTokenVaultBalance =
+            this.orderManager.ownerTokenVaultMap
+                .get(orderDetails.orderbook)
+                ?.get(owner)
+                ?.get(orderDetails.sellToken)
+                ?.get(
+                    orderDetails.takeOrder.takeOrder.order.validOutputs[
+                        orderDetails.takeOrder.takeOrder.outputIOIndex
+                    ].vaultId,
+                )?.balance ?? orderDetails.sellTokenVaultBalance;
+        orderDetails.buyTokenVaultBalance =
+            this.orderManager.ownerTokenVaultMap
+                .get(orderDetails.orderbook)
+                ?.get(owner)
+                ?.get(orderDetails.buyToken)
+                ?.get(
+                    orderDetails.takeOrder.takeOrder.order.validInputs[
+                        orderDetails.takeOrder.takeOrder.inputIOIndex
+                    ].vaultId,
+                )?.balance ?? orderDetails.buyTokenVaultBalance;
 
         // skip if the output vault is empty
         if (orderDetails.sellTokenVaultBalance <= 0n) {

--- a/src/core/process/round.ts
+++ b/src/core/process/round.ts
@@ -26,18 +26,45 @@ export async function initializeRound(this: RainSolver, roundSpanCtx?: SpanWithC
     const settlements: Settlement[] = [];
     const checkpointReports: PreAssembledSpan[] = [];
     for (const orderDetails of orders) {
-        // await for first available random free signer
-        const signer = await this.walletManager.getRandomSigner(true);
-
         const pair = `${orderDetails.buyTokenSymbol}/${orderDetails.sellTokenSymbol}`;
         const report = new PreAssembledSpan(`checkpoint_${pair}`);
         report.extendAttrs({
             "details.pair": pair,
             "details.orderHash": orderDetails.takeOrder.id,
             "details.orderbook": orderDetails.orderbook,
-            "details.sender": signer.account.address,
             "details.owner": orderDetails.takeOrder.takeOrder.order.owner,
         });
+
+        // skip if the output vault is empty
+        if (orderDetails.sellTokenVaultBalance <= 0n) {
+            settlements.push({
+                pair,
+                orderHash: orderDetails.takeOrder.id,
+                owner: orderDetails.takeOrder.takeOrder.order.owner,
+                settle: async () => {
+                    return Result.ok({
+                        tokenPair: pair,
+                        buyToken: orderDetails.buyToken,
+                        sellToken: orderDetails.sellToken,
+                        status: ProcessOrderStatus.ZeroOutput,
+                        spanAttributes: {
+                            "details.pair": pair,
+                            "details.orders": orderDetails.takeOrder.id,
+                        },
+                    });
+                },
+            });
+            report.end();
+            checkpointReports.push(report);
+
+            // export the report to logger if logger is available
+            this.logger?.exportPreAssembledSpan(report, roundSpanCtx?.context);
+            continue;
+        }
+
+        // await for first available random free signer
+        const signer = await this.walletManager.getRandomSigner(true);
+        report.setAttr("details.sender", signer.account.address);
 
         // call process pair and save the settlement fn
         // to later settle without needing to pause if

--- a/src/order/index.test.ts
+++ b/src/order/index.test.ts
@@ -289,33 +289,6 @@ describe("Test OrderManager", () => {
         };
         await orderManager.addOrders([mockOrder as any]);
 
-        // set arbitrary vault balances for testing
-        expect(
-            orderManager.ownerTokenVaultMap
-                .get("0xorderbook")!
-                .get("0xowner")!
-                .get("0xoutput")!
-                .get(1n)!.balance,
-        ).toBe(1n);
-        orderManager.ownerTokenVaultMap
-            .get("0xorderbook")!
-            .get("0xowner")!
-            .get("0xoutput")!
-            .get(1n)!.balance = 55n;
-
-        expect(
-            orderManager.ownerTokenVaultMap
-                .get("0xorderbook")!
-                .get("0xowner")!
-                .get("0xinput")!
-                .get(1n)!.balance,
-        ).toBe(2n);
-        orderManager.ownerTokenVaultMap
-            .get("0xorderbook")!
-            .get("0xowner")!
-            .get("0xinput")!
-            .get(1n)!.balance = 66n;
-
         const result = orderManager.getNextRoundOrders(false);
         expect(Array.isArray(result)).toBe(true);
         expect(result.length).toBeGreaterThan(0);
@@ -333,8 +306,8 @@ describe("Test OrderManager", () => {
         expect(bundle).toHaveProperty("sellToken", "0xoutput");
         expect(bundle).toHaveProperty("sellTokenDecimals", 18);
         expect(bundle).toHaveProperty("sellTokenSymbol", "OUT");
-        expect(bundle).toHaveProperty("sellTokenVaultBalance", 55n);
-        expect(bundle).toHaveProperty("buyTokenVaultBalance", 66n);
+        expect(bundle).toHaveProperty("sellTokenVaultBalance", 1n);
+        expect(bundle).toHaveProperty("buyTokenVaultBalance", 2n);
 
         const takeOrder = bundle.takeOrder;
         expect(takeOrder).toHaveProperty("id", "0xhash");
@@ -344,30 +317,6 @@ describe("Test OrderManager", () => {
         expect(takeOrder.takeOrder).toHaveProperty("outputIOIndex", 0);
         expect(takeOrder.takeOrder).toHaveProperty("signedContext");
         expect(Array.isArray(takeOrder.takeOrder.signedContext)).toBe(true);
-
-        // check that vault balances are updated correctly from the ownerTokenVaultMap
-        const orderbookVaultMap = orderManager.ownerTokenVaultMap.get("0xorderbook");
-        expect(orderbookVaultMap).toBeDefined();
-        const ownerVaultMap = orderbookVaultMap?.get("0xowner");
-        expect(ownerVaultMap).toBeDefined();
-
-        // check sell token vault balance
-        const sellTokenVaultMap = ownerVaultMap?.get("0xoutput");
-        expect(sellTokenVaultMap).toBeDefined();
-        const sellTokenVault = sellTokenVaultMap?.get(1n);
-        expect(sellTokenVault).toBeDefined();
-        expect(bundle.sellTokenVaultBalance).toBe(55n);
-
-        // check buy token vault balance
-        const buyTokenVaultMap = ownerVaultMap?.get("0xinput");
-        expect(buyTokenVaultMap).toBeDefined();
-        const buyTokenVault = buyTokenVaultMap?.get(1n);
-        expect(buyTokenVault).toBeDefined();
-        expect(bundle.buyTokenVaultBalance).toBe(66n);
-
-        // verify the vault balances match the expected values
-        expect(bundle.sellTokenVaultBalance).toBe(55n);
-        expect(bundle.buyTokenVaultBalance).toBe(66n);
     });
 
     it("should reset limits to default", async () => {

--- a/src/order/index.ts
+++ b/src/order/index.ts
@@ -426,7 +426,7 @@ export class OrderManager {
     getNextRoundOrders(shuffle = true): Pair[] {
         const result: Pair[] = [];
         this.ownersMap.forEach((ownersProfileMap) => {
-            ownersProfileMap.forEach((ownerProfile, owner) => {
+            ownersProfileMap.forEach((ownerProfile) => {
                 let remainingLimit = ownerProfile.limit;
 
                 // consume orders limits
@@ -442,30 +442,6 @@ export class OrderManager {
                     ownerProfile.lastIndex += remainingConsumingOrders.length;
                     consumingOrders.push(...remainingConsumingOrders);
                 }
-
-                // update vault balance of each Pair object from ownerTokenVault map
-                consumingOrders.forEach((pair) => {
-                    pair.sellTokenVaultBalance =
-                        this.ownerTokenVaultMap
-                            .get(pair.orderbook)
-                            ?.get(owner)
-                            ?.get(pair.sellToken)
-                            ?.get(
-                                pair.takeOrder.takeOrder.order.validOutputs[
-                                    pair.takeOrder.takeOrder.outputIOIndex
-                                ].vaultId,
-                            )?.balance ?? pair.sellTokenVaultBalance;
-                    pair.buyTokenVaultBalance =
-                        this.ownerTokenVaultMap
-                            .get(pair.orderbook)
-                            ?.get(owner)
-                            ?.get(pair.buyToken)
-                            ?.get(
-                                pair.takeOrder.takeOrder.order.validInputs[
-                                    pair.takeOrder.takeOrder.inputIOIndex
-                                ].vaultId,
-                            )?.balance ?? pair.buyTokenVaultBalance;
-                });
                 result.push(...consumingOrders);
             });
         });

--- a/src/order/index.ts
+++ b/src/order/index.ts
@@ -1,21 +1,23 @@
 import { erc20Abi } from "viem";
+import { syncOrders } from "./sync";
 import { SgOrder } from "../subgraph";
-import { SharedState } from "../state";
 import { shuffleArray } from "../common";
 import { quoteSingleOrder } from "./quote";
 import { PreAssembledSpan } from "../logger";
 import { SubgraphManager } from "../subgraph";
-import { buildOrderbookTokenOwnerVaultsMap, downscaleProtection } from "./protection";
+import { downscaleProtection } from "./protection";
+import { SharedState, TokenDetails } from "../state";
+import { addToPairMap, removeFromPairMap, getSortedPairList } from "./pair";
 import {
     Pair,
     Order,
     OrdersProfileMap,
     OwnersProfileMap,
     OrderbooksPairMap,
-    OrderbooksOwnersProfileMap,
     CounterpartySource,
+    OrderbooksOwnersProfileMap,
+    OrderbookOwnerTokenVaultsMap,
 } from "./types";
-import { addToPairMap, removeFromPairMap, getSortedPairList } from "./pair";
 
 export * from "./types";
 export * from "./quote";
@@ -54,6 +56,17 @@ export class OrderManager {
      * Same as oiPairMap but inverted, ie input -> output -> orderhash -> Pair
      */
     ioPairMap: OrderbooksPairMap;
+    /**
+     * Keeps a map of owner token vaults details, this is used to evaluate
+     * owners limits and to keep track of vault balance changes throughout
+     * the runtime, helping us to avoid running order pairs with empty vault
+     * balances.
+     * Vault balances are updated on each order sync operation when the recent
+     * transactions are processed and those that have vault balance changes
+     * are updated in this map.
+     * orderbook -> owner -> token -> vaultsId -> vaultDetails
+     */
+    ownerTokenVaultMap: OrderbookOwnerTokenVaultsMap;
 
     /**
      * Creates a new OrderManager instance
@@ -65,6 +78,7 @@ export class OrderManager {
         this.oiPairMap = new Map();
         this.ownersMap = new Map();
         this.ioPairMap = new Map();
+        this.ownerTokenVaultMap = new Map();
         this.quoteGas = state.orderManagerConfig.quoteGas;
         this.ownerLimits = state.orderManagerConfig.ownerLimits;
         this.subgraphManager = subgraphManager ?? new SubgraphManager(state.subgraphConfig);
@@ -94,20 +108,7 @@ export class OrderManager {
 
     /** Syncs orders to upstream subgraphs */
     async sync(): Promise<PreAssembledSpan> {
-        const { result, report } = await this.subgraphManager.syncOrders();
-        let ordersDidChange = false;
-        for (const key in result) {
-            if (result[key].addOrders.length || result[key].removeOrders.length) {
-                ordersDidChange = true;
-            }
-            await this.addOrders(result[key].addOrders.map((v) => v.order));
-            await this.removeOrders(result[key].removeOrders.map((v) => v.order));
-        }
-
-        // run protection if there has been upstream changes
-        if (ordersDidChange) this.downscaleProtection(true);
-
-        return report;
+        return await syncOrders.call(this);
     }
 
     /**
@@ -173,6 +174,7 @@ export class OrderManager {
             // add to the pair maps
             for (let j = 0; j < pairs.length; j++) {
                 this.addToPairMaps(pairs[j]);
+                this.addToTokenVaultsMap(pairs[j]);
             }
         }
     }
@@ -189,6 +191,88 @@ export class OrderManager {
         const inputKey = pair.buyToken.toLowerCase();
         addToPairMap(this.oiPairMap, orderbook, hash, outputKey, inputKey, pair);
         addToPairMap(this.ioPairMap, orderbook, hash, inputKey, outputKey, pair);
+    }
+
+    /**
+     * Adds the given order pair vault details to the token vaults map, since
+     * vaults dont get destroyed, there is no need to have any remove operation
+     * for this this map
+     * @param pair - The order pair object
+     */
+    addToTokenVaultsMap(pair: Pair) {
+        const orderbook = pair.orderbook.toLowerCase();
+        const owner = pair.takeOrder.takeOrder.order.owner.toLowerCase();
+        const outputVault =
+            pair.takeOrder.takeOrder.order.validOutputs[pair.takeOrder.takeOrder.outputIOIndex];
+        const inputVault =
+            pair.takeOrder.takeOrder.order.validInputs[pair.takeOrder.takeOrder.inputIOIndex];
+
+        this.updateVault(
+            orderbook,
+            owner,
+            {
+                address: outputVault.token.toLowerCase(),
+                decimals: outputVault.decimals,
+                symbol: pair.sellTokenSymbol,
+            },
+            outputVault.vaultId,
+            pair.sellTokenVaultBalance,
+        );
+        this.updateVault(
+            orderbook,
+            owner,
+            {
+                address: inputVault.token.toLowerCase(),
+                decimals: inputVault.decimals,
+                symbol: pair.buyTokenSymbol,
+            },
+            inputVault.vaultId,
+            pair.buyTokenVaultBalance,
+        );
+    }
+
+    /**
+     * Updates the vault balance in the ownerTokenVaultMap
+     * @param orderbook - The orderbook address
+     * @param owner - The owner address
+     * @param token - The token details
+     * @param vaultId - The vault id
+     * @param balance - The new vault balance
+     */
+    updateVault(
+        orderbook: string,
+        owner: string,
+        token: TokenDetails,
+        vaultId: bigint,
+        balance: bigint,
+    ) {
+        // get or create the empty map to store orderbook owner vaults
+        if (!this.ownerTokenVaultMap.has(orderbook)) {
+            this.ownerTokenVaultMap.set(orderbook, new Map());
+        }
+        const ownersTokenVaultsMap = this.ownerTokenVaultMap.get(orderbook)!;
+
+        // get or create the empty map to store owner vaults
+        if (!ownersTokenVaultsMap.has(owner)) {
+            ownersTokenVaultsMap.set(owner, new Map());
+        }
+        const tokenVaultMap = ownersTokenVaultsMap.get(owner)!;
+
+        // get or create the empty map to store output vault details
+        if (!tokenVaultMap.has(token.address)) {
+            tokenVaultMap.set(token.address, new Map());
+        }
+        const vaultsMap = tokenVaultMap.get(token.address)!;
+        const vault = vaultsMap.get(vaultId);
+        if (!vault) {
+            vaultsMap.set(vaultId, {
+                id: vaultId,
+                balance,
+                token,
+            });
+        } else {
+            vault.balance = balance;
+        }
     }
 
     /**
@@ -314,9 +398,11 @@ export class OrderManager {
                         buyToken: _input.token.toLowerCase(),
                         buyTokenSymbol: _inputSymbol,
                         buyTokenDecimals: _input.decimals,
+                        buyTokenVaultBalance: BigInt(orderDetails.inputs[k].balance),
                         sellToken: _output.token.toLowerCase(),
                         sellTokenSymbol: _outputSymbol,
                         sellTokenDecimals: _output.decimals,
+                        sellTokenVaultBalance: BigInt(orderDetails.outputs[j].balance),
                         takeOrder: {
                             id: orderHash,
                             takeOrder: {
@@ -340,12 +426,13 @@ export class OrderManager {
     getNextRoundOrders(shuffle = true): Pair[] {
         const result: Pair[] = [];
         this.ownersMap.forEach((ownersProfileMap) => {
-            ownersProfileMap.forEach((ownerProfile) => {
+            ownersProfileMap.forEach((ownerProfile, owner) => {
                 let remainingLimit = ownerProfile.limit;
 
                 // consume orders limits
-                const allOrders: Pair[] = [];
-                ownerProfile.orders.forEach((v) => allOrders.push(...v.takeOrders));
+                const allOrders = Array.from(ownerProfile.orders.values()).flatMap(
+                    (profile) => profile.takeOrders,
+                );
                 const consumingOrders = allOrders.splice(ownerProfile.lastIndex, remainingLimit);
                 remainingLimit -= consumingOrders.length;
                 ownerProfile.lastIndex += consumingOrders.length;
@@ -355,6 +442,30 @@ export class OrderManager {
                     ownerProfile.lastIndex += remainingConsumingOrders.length;
                     consumingOrders.push(...remainingConsumingOrders);
                 }
+
+                // update vault balance of each Pair object from ownerTokenVault map
+                consumingOrders.forEach((pair) => {
+                    pair.sellTokenVaultBalance =
+                        this.ownerTokenVaultMap
+                            .get(pair.orderbook)
+                            ?.get(owner)
+                            ?.get(pair.sellToken)
+                            ?.get(
+                                pair.takeOrder.takeOrder.order.validOutputs[
+                                    pair.takeOrder.takeOrder.outputIOIndex
+                                ].vaultId,
+                            )?.balance ?? pair.sellTokenVaultBalance;
+                    pair.buyTokenVaultBalance =
+                        this.ownerTokenVaultMap
+                            .get(pair.orderbook)
+                            ?.get(owner)
+                            ?.get(pair.buyToken)
+                            ?.get(
+                                pair.takeOrder.takeOrder.order.validInputs[
+                                    pair.takeOrder.takeOrder.inputIOIndex
+                                ].vaultId,
+                            )?.balance ?? pair.buyTokenVaultBalance;
+                });
                 result.push(...consumingOrders);
             });
         });
@@ -396,17 +507,15 @@ export class OrderManager {
      * all other owners cumulative balances, the calculated ratio is used as a reducing
      * factor for the owner limit when averaged out for all of tokens the owner has
      */
-    async downscaleProtection(reset = true, multicallAddressOverride?: string) {
+    async downscaleProtection(reset = true) {
         if (reset) {
             this.resetLimits();
         }
-        const otovMap = buildOrderbookTokenOwnerVaultsMap(this.ownersMap);
         await downscaleProtection(
             this.ownersMap,
-            otovMap,
+            this.ownerTokenVaultMap,
             this.state.client,
             this.ownerLimits,
-            multicallAddressOverride,
         ).catch(() => {});
     }
 

--- a/src/order/protection.test.ts
+++ b/src/order/protection.test.ts
@@ -1,11 +1,7 @@
-import { type PublicClient } from "viem";
+import { PublicClient } from "viem";
+import { downscaleProtection } from "./protection";
 import { describe, it, expect, vi, beforeEach, Mock } from "vitest";
-import { OwnerProfile, type OrderbooksOwnersProfileMap } from "./types";
-import {
-    fetchVaultBalances,
-    downscaleProtection,
-    buildOrderbookTokenOwnerVaultsMap,
-} from "./protection";
+import { OwnerProfile, OrderbooksOwnersProfileMap, OrderbookOwnerTokenVaultsMap } from "./types";
 
 // mock data
 const orderProfile = {
@@ -42,30 +38,6 @@ const mockPublicClient = {
     chain: { id: 1 },
 } as any as PublicClient;
 
-describe("Test buildOrderbookTokenOwnerVaultsMap", () => {
-    it("should correctly build the map structure", () => {
-        const result = buildOrderbookTokenOwnerVaultsMap(mockOrderbooksOwnersProfileMap);
-
-        // check if orderbook exists
-        expect(result.has("orderbook1")).toBe(true);
-
-        const tokenOwnersVaults = result.get("orderbook1");
-        expect(tokenOwnersVaults?.has("0xtoken1")).toBe(true);
-
-        const ownersVaults = tokenOwnersVaults?.get("0xtoken1");
-        expect(ownersVaults?.has("owner1")).toBe(true);
-
-        const vaults = ownersVaults?.get("owner1");
-        expect(vaults).toEqual([{ vaultId: 1n, balance: 0n }]);
-    });
-
-    it("should handle empty input", () => {
-        const emptyMap = new Map();
-        const result = buildOrderbookTokenOwnerVaultsMap(emptyMap);
-        expect(result.size).toBe(0);
-    });
-});
-
 describe("Test downscaleProtection", () => {
     beforeEach(() => {
         vi.clearAllMocks();
@@ -74,9 +46,20 @@ describe("Test downscaleProtection", () => {
     it("should correctly downscale owner limits based on vault balances", async () => {
         (mockPublicClient.multicall as Mock).mockResolvedValue([100n]);
         (mockPublicClient.readContract as Mock).mockResolvedValue(1000n);
+        const ownerTokenVaultsMap: OrderbookOwnerTokenVaultsMap = new Map([
+            [
+                "orderbook1",
+                new Map([
+                    ["owner1", new Map([["0xToken1", new Map([[1n, { id: 1n, balance: 100n }]])]])],
+                ]),
+            ],
+        ]) as any;
 
-        const otovMap = buildOrderbookTokenOwnerVaultsMap(mockOrderbooksOwnersProfileMap);
-        await downscaleProtection(mockOrderbooksOwnersProfileMap, otovMap, mockPublicClient);
+        await downscaleProtection(
+            mockOrderbooksOwnersProfileMap,
+            ownerTokenVaultsMap,
+            mockPublicClient,
+        );
 
         // get the updated owner profile and verify the limit was adjusted
         const ownerProfile = mockOrderbooksOwnersProfileMap.get("orderbook1")?.get("owner1");
@@ -87,13 +70,20 @@ describe("Test downscaleProtection", () => {
         const ownerLimits = {
             owner1: 5,
         };
-        const otovMap = buildOrderbookTokenOwnerVaultsMap(mockOrderbooksOwnersProfileMap);
+        const ownerTokenVaultsMap: OrderbookOwnerTokenVaultsMap = new Map([
+            [
+                "orderbook1",
+                new Map([
+                    ["owner1", new Map([["0xToken1", new Map([[1n, { id: 1n, balance: 100n }]])]])],
+                ]),
+            ],
+        ]) as any;
         const originalLimit = mockOrderbooksOwnersProfileMap
             .get("orderbook1")
             ?.get("owner1")?.limit;
         await downscaleProtection(
             mockOrderbooksOwnersProfileMap,
-            otovMap,
+            ownerTokenVaultsMap,
             mockPublicClient,
             ownerLimits,
         );
@@ -105,31 +95,23 @@ describe("Test downscaleProtection", () => {
     it("should handle empty balances", async () => {
         (mockPublicClient.multicall as Mock).mockResolvedValue([0n]);
         (mockPublicClient.readContract as Mock).mockResolvedValue(0n);
+        const ownerTokenVaultsMap: OrderbookOwnerTokenVaultsMap = new Map([
+            [
+                "orderbook1",
+                new Map([
+                    ["owner1", new Map([["0xToken1", new Map([[1n, { id: 1n, balance: 100n }]])]])],
+                ]),
+            ],
+        ]) as any;
 
-        const otovMap = buildOrderbookTokenOwnerVaultsMap(mockOrderbooksOwnersProfileMap);
-        await downscaleProtection(mockOrderbooksOwnersProfileMap, otovMap, mockPublicClient);
+        await downscaleProtection(
+            mockOrderbooksOwnersProfileMap,
+            ownerTokenVaultsMap,
+            mockPublicClient,
+        );
 
         // ensure minimum limit of 1 is applied
         const ownerProfile = mockOrderbooksOwnersProfileMap.get("orderbook1")?.get("owner1");
         expect(ownerProfile?.limit).toBeGreaterThanOrEqual(1);
-    });
-});
-
-describe("Test fetchVaultBalances", () => {
-    beforeEach(() => {
-        vi.clearAllMocks();
-    });
-
-    it("should correctly fetch and update vault balances", async () => {
-        const vaults = [
-            { vaultId: 1n, balance: 0n },
-            { vaultId: 2n, balance: 0n },
-        ];
-        (mockPublicClient.multicall as Mock).mockResolvedValue([100n, 200n]);
-        await fetchVaultBalances("0xorderbook", "0xtoken", "0xowner", vaults, mockPublicClient);
-
-        // verify the balances were updated
-        expect(vaults[0].balance).toBe(100n);
-        expect(vaults[1].balance).toBe(200n);
     });
 });

--- a/src/order/sync.test.ts
+++ b/src/order/sync.test.ts
@@ -1,0 +1,404 @@
+import { OrderManager } from ".";
+import { syncOrders } from "./sync";
+import { PreAssembledSpan } from "../logger";
+import { applyFilters } from "../subgraph/filter";
+import { describe, it, expect, vi, beforeEach, Mock } from "vitest";
+
+vi.mock("../logger", () => ({
+    PreAssembledSpan: vi.fn().mockImplementation((name) => ({
+        name,
+        setAttr: vi.fn(),
+        end: vi.fn(),
+    })),
+}));
+
+vi.mock("../subgraph/filter", () => ({
+    applyFilters: vi.fn(),
+}));
+
+describe("Test syncOrders", () => {
+    let mockOrderManager: OrderManager;
+    let mockSubgraphManager: any;
+    let mockUpdateVault: Mock;
+    let mockAddOrders: Mock;
+    let mockRemoveOrders: Mock;
+
+    beforeEach(() => {
+        vi.clearAllMocks();
+
+        mockUpdateVault = vi.fn();
+        mockAddOrders = vi.fn();
+        mockRemoveOrders = vi.fn();
+
+        mockSubgraphManager = {
+            getUpstreamEvents: vi.fn(),
+            filters: { someFilter: "test" },
+        };
+
+        mockOrderManager = {
+            subgraphManager: mockSubgraphManager,
+            updateVault: mockUpdateVault,
+            addOrders: mockAddOrders,
+            removeOrders: mockRemoveOrders,
+        } as any;
+    });
+
+    it("should handle Deposit events correctly", async () => {
+        const mockResult = {
+            "https://subgraph1.com": [
+                {
+                    timestamp: "1640995200",
+                    events: [
+                        {
+                            __typename: "Deposit",
+                            orderbook: { id: "0xorderbook1" },
+                            vault: {
+                                owner: "0xowner1",
+                                token: {
+                                    address: "0xtoken1",
+                                    symbol: "TOKEN1",
+                                    decimals: "18",
+                                },
+                                vaultId: "123",
+                                balance: "1000000000000000000",
+                            },
+                        },
+                    ],
+                },
+            ],
+        };
+        mockSubgraphManager.getUpstreamEvents.mockResolvedValue({
+            status: {},
+            result: mockResult,
+        });
+
+        await syncOrders.call(mockOrderManager);
+        expect(mockUpdateVault).toHaveBeenCalledWith(
+            "0xorderbook1",
+            "0xowner1",
+            {
+                address: "0xtoken1",
+                symbol: "TOKEN1",
+                decimals: 18,
+            },
+            123n,
+            1000000000000000000n,
+        );
+        expect(mockUpdateVault).toHaveBeenCalledTimes(1);
+    });
+
+    it("should handle Withdrawal events correctly", async () => {
+        const mockResult = {
+            "https://subgraph1.com": [
+                {
+                    timestamp: "1640995200",
+                    events: [
+                        {
+                            __typename: "Withdrawal",
+                            orderbook: { id: "0xorderbook2" },
+                            vault: {
+                                owner: "0xowner2",
+                                token: {
+                                    address: "0xtoken2",
+                                    symbol: "TOKEN2",
+                                    decimals: "6",
+                                },
+                                vaultId: "456",
+                                balance: "500000000",
+                            },
+                        },
+                    ],
+                },
+            ],
+        };
+        mockSubgraphManager.getUpstreamEvents.mockResolvedValue({
+            status: {},
+            result: mockResult,
+        });
+
+        await syncOrders.call(mockOrderManager);
+        expect(mockUpdateVault).toHaveBeenCalledWith(
+            "0xorderbook2",
+            "0xowner2",
+            {
+                address: "0xtoken2",
+                symbol: "TOKEN2",
+                decimals: 6,
+            },
+            456n,
+            500000000n,
+        );
+        expect(mockUpdateVault).toHaveBeenCalledTimes(1);
+    });
+
+    it("should handle Clear events with trades correctly", async () => {
+        const mockResult = {
+            "https://subgraph1.com": [
+                {
+                    timestamp: "1640995200",
+                    events: [
+                        {
+                            __typename: "Clear",
+                            trades: [
+                                {
+                                    inputVaultBalanceChange: {
+                                        orderbook: { id: "0xorderbook1" },
+                                        vault: {
+                                            owner: "0xowner1",
+                                            token: {
+                                                address: "0xinputtoken",
+                                                symbol: "INPUT",
+                                                decimals: "18",
+                                            },
+                                            vaultId: "100",
+                                            balance: "2000000000000000000",
+                                        },
+                                    },
+                                    outputVaultBalanceChange: {
+                                        orderbook: { id: "0xorderbook1" },
+                                        vault: {
+                                            owner: "0xowner2",
+                                            token: {
+                                                address: "0xoutputtoken",
+                                                symbol: "OUTPUT",
+                                                decimals: "6",
+                                            },
+                                            vaultId: "200",
+                                            balance: "1000000000",
+                                        },
+                                    },
+                                },
+                            ],
+                        },
+                    ],
+                },
+            ],
+        };
+        mockSubgraphManager.getUpstreamEvents.mockResolvedValue({
+            status: {},
+            result: mockResult,
+        });
+
+        await syncOrders.call(mockOrderManager);
+        expect(mockUpdateVault).toHaveBeenCalledTimes(2);
+        expect(mockUpdateVault).toHaveBeenNthCalledWith(
+            1,
+            "0xorderbook1",
+            "0xowner1",
+            {
+                address: "0xinputtoken",
+                symbol: "INPUT",
+                decimals: 18,
+            },
+            100n,
+            2000000000000000000n,
+        );
+        expect(mockUpdateVault).toHaveBeenNthCalledWith(
+            2,
+            "0xorderbook1",
+            "0xowner2",
+            {
+                address: "0xoutputtoken",
+                symbol: "OUTPUT",
+                decimals: 6,
+            },
+            200n,
+            1000000000n,
+        );
+    });
+
+    it("should handle TakeOrder events with trades correctly", async () => {
+        const mockResult = {
+            "https://subgraph1.com": [
+                {
+                    timestamp: "1640995200",
+                    events: [
+                        {
+                            __typename: "TakeOrder",
+                            trades: [
+                                {
+                                    inputVaultBalanceChange: {
+                                        orderbook: { id: "0xorderbook3" },
+                                        vault: {
+                                            owner: "0xowner3",
+                                            token: {
+                                                address: "0xtoken3",
+                                                symbol: "TOKEN3",
+                                                decimals: "8",
+                                            },
+                                            vaultId: "789",
+                                            balance: "50000000",
+                                        },
+                                    },
+                                    outputVaultBalanceChange: {
+                                        orderbook: { id: "0xorderbook3" },
+                                        vault: {
+                                            owner: "0xowner4",
+                                            token: {
+                                                address: "0xtoken4",
+                                                symbol: "TOKEN4",
+                                                decimals: "18",
+                                            },
+                                            vaultId: "101112",
+                                            balance: "3000000000000000000",
+                                        },
+                                    },
+                                },
+                            ],
+                        },
+                    ],
+                },
+            ],
+        };
+        mockSubgraphManager.getUpstreamEvents.mockResolvedValue({
+            status: {},
+            result: mockResult,
+        });
+
+        await syncOrders.call(mockOrderManager);
+        expect(mockUpdateVault).toHaveBeenCalledTimes(2);
+        expect(mockUpdateVault).toHaveBeenNthCalledWith(
+            1,
+            "0xorderbook3",
+            "0xowner3",
+            {
+                address: "0xtoken3",
+                symbol: "TOKEN3",
+                decimals: 8,
+            },
+            789n,
+            50000000n,
+        );
+        expect(mockUpdateVault).toHaveBeenNthCalledWith(
+            2,
+            "0xorderbook3",
+            "0xowner4",
+            {
+                address: "0xtoken4",
+                symbol: "TOKEN4",
+                decimals: 18,
+            },
+            101112n,
+            3000000000000000000n,
+        );
+    });
+
+    it("should handle AddOrder events", async () => {
+        const mockOrder = {
+            orderHash: "0xorderhash1",
+            orderbook: { id: "0xorderbook1" },
+            active: true,
+        };
+        const mockResult = {
+            "https://subgraph1.com": [
+                {
+                    timestamp: "1640995200",
+                    events: [
+                        {
+                            __typename: "AddOrder",
+                            order: mockOrder,
+                        },
+                    ],
+                },
+            ],
+        };
+        const mockSyncStatus = {
+            "https://subgraph1.com": {},
+        };
+        (applyFilters as Mock).mockReturnValue(true);
+        mockSubgraphManager.getUpstreamEvents.mockResolvedValue({
+            status: mockSyncStatus,
+            result: mockResult,
+        });
+
+        await syncOrders.call(mockOrderManager);
+        expect(applyFilters).toHaveBeenCalledWith(mockOrder, mockSubgraphManager.filters);
+        expect(mockAddOrders).toHaveBeenCalledWith([mockOrder]);
+        expect(mockSyncStatus["https://subgraph1.com"]["0xorderbook1"]).toEqual({
+            added: ["0xorderhash1"],
+            removed: [],
+        });
+    });
+
+    it("should handle RemoveOrder events correctly", async () => {
+        const mockOrder = {
+            orderHash: "0xorderhash4",
+            orderbook: { id: "0xorderbook4" },
+            active: false,
+        };
+        const mockResult = {
+            "https://subgraph2.com": [
+                {
+                    timestamp: "1640995200",
+                    events: [
+                        {
+                            __typename: "RemoveOrder",
+                            order: mockOrder,
+                        },
+                    ],
+                },
+            ],
+        };
+        const mockSyncStatus = {
+            "https://subgraph2.com": {},
+        };
+        mockSubgraphManager.getUpstreamEvents.mockResolvedValue({
+            status: mockSyncStatus,
+            result: mockResult,
+        });
+
+        await syncOrders.call(mockOrderManager);
+        expect(mockRemoveOrders).toHaveBeenCalledWith([mockOrder]);
+        expect(mockSyncStatus["https://subgraph2.com"]["0xorderbook4"]).toEqual({
+            added: [],
+            removed: ["0xorderhash4"],
+        });
+    });
+
+    it("should skip transactions with no events", async () => {
+        const mockResult = {
+            "https://subgraph1.com": [
+                {
+                    timestamp: "1640995200",
+                    events: [],
+                },
+                {
+                    timestamp: "1640995300",
+                    // events: undefined
+                },
+            ],
+        };
+        mockSubgraphManager.getUpstreamEvents.mockResolvedValue({
+            status: {},
+            result: mockResult,
+        });
+
+        await syncOrders.call(mockOrderManager);
+        expect(mockUpdateVault).not.toHaveBeenCalled();
+        expect(mockAddOrders).not.toHaveBeenCalled();
+        expect(mockRemoveOrders).not.toHaveBeenCalled();
+    });
+
+    it("should properly conclude report with syncStatus", async () => {
+        const mockReport = {
+            name: "",
+            setAttr: vi.fn(),
+            end: vi.fn(),
+        };
+        (PreAssembledSpan as Mock).mockReturnValue(mockReport);
+        const mockSyncStatus = { "https://subgraph1.com": {} };
+        mockSubgraphManager.getUpstreamEvents.mockResolvedValue({
+            status: mockSyncStatus,
+            result: {},
+        });
+
+        const result = await syncOrders.call(mockOrderManager);
+        expect(mockReport.name).toBe("sync-orders");
+        expect(mockReport.setAttr).toHaveBeenCalledWith(
+            "syncStatus",
+            JSON.stringify(mockSyncStatus),
+        );
+        expect(mockReport.end).toHaveBeenCalled();
+        expect(result).toBe(mockReport);
+    });
+});

--- a/src/order/sync.ts
+++ b/src/order/sync.ts
@@ -1,0 +1,102 @@
+import { OrderManager } from ".";
+import { SgTransaction } from "../subgraph";
+import { PreAssembledSpan } from "../logger";
+import { applyFilters } from "../subgraph/filter";
+
+/** Syncs orders and vaults to upstream changes since the last fetch */
+export async function syncOrders(this: OrderManager) {
+    const report = new PreAssembledSpan("sync-orders");
+    const { status: syncStatus, result } = await this.subgraphManager.getUpstreamEvents();
+
+    // helper generator fn to yield events one by one
+    const iterEvents = function* (events: Record<string, SgTransaction[]>) {
+        for (const url in events) {
+            for (const res of events[url]) {
+                if (!res?.events?.length) continue;
+                for (const event of res.events) {
+                    yield { event, url, timestamp: Number(res.timestamp) };
+                }
+            }
+        }
+    };
+
+    // process events one by one using generator
+    for (const { event, url } of iterEvents(result)) {
+        if (event.__typename === "Deposit" || event.__typename === "Withdrawal") {
+            // handle vault balance changes in deposits and withdrawals
+            this.updateVault(
+                event.orderbook.id,
+                event.vault.owner,
+                {
+                    address: event.vault.token.address,
+                    symbol: event.vault.token.symbol,
+                    decimals: Number(event.vault.token.decimals),
+                },
+                BigInt(event.vault.vaultId),
+                BigInt(event.vault.balance),
+            );
+        }
+        if (event.__typename === "Clear" || event.__typename === "TakeOrder") {
+            // handle vault balance changes in trades
+            event?.trades?.forEach((trade) => {
+                this.updateVault(
+                    trade.inputVaultBalanceChange.orderbook.id,
+                    trade.inputVaultBalanceChange.vault.owner,
+                    {
+                        address: trade.inputVaultBalanceChange.vault.token.address,
+                        symbol: trade.inputVaultBalanceChange.vault.token.symbol,
+                        decimals: Number(trade.inputVaultBalanceChange.vault.token.decimals),
+                    },
+                    BigInt(trade.inputVaultBalanceChange.vault.vaultId),
+                    BigInt(trade.inputVaultBalanceChange.vault.balance),
+                );
+                this.updateVault(
+                    trade.outputVaultBalanceChange.orderbook.id,
+                    trade.outputVaultBalanceChange.vault.owner,
+                    {
+                        address: trade.outputVaultBalanceChange.vault.token.address,
+                        symbol: trade.outputVaultBalanceChange.vault.token.symbol,
+                        decimals: Number(trade.outputVaultBalanceChange.vault.token.decimals),
+                    },
+                    BigInt(trade.outputVaultBalanceChange.vault.vaultId),
+                    BigInt(trade.outputVaultBalanceChange.vault.balance),
+                );
+            });
+        }
+        if (event.__typename === "AddOrder") {
+            // handle order addition if passes filters
+            if (typeof event?.order?.active === "boolean" && event.order.active) {
+                if (applyFilters(event.order, this.subgraphManager.filters)) {
+                    if (!syncStatus[url][event.order.orderbook.id]) {
+                        syncStatus[url][event.order.orderbook.id] = {
+                            added: [],
+                            removed: [],
+                        };
+                    }
+                    syncStatus[url][event.order.orderbook.id].added.push(event.order.orderHash);
+                    await this.addOrders([event.order]);
+                }
+            }
+        }
+        if (event.__typename === "RemoveOrder") {
+            // handle order removal
+            if (typeof event?.order?.active === "boolean" && !event.order.active) {
+                if (!syncStatus[url][event.order.orderbook.id]) {
+                    syncStatus[url][event.order.orderbook.id] = {
+                        added: [],
+                        removed: [],
+                    };
+                }
+                syncStatus[url][event.order.orderbook.id].removed.push(event.order.orderHash);
+                this.removeOrders([event.order]);
+            }
+        }
+    }
+
+    // conclude the report
+    report.name = "sync-orders";
+    report.setAttr("syncStatus", JSON.stringify(syncStatus));
+    report.end();
+
+    return report;
+}

--- a/src/order/types.ts
+++ b/src/order/types.ts
@@ -1,3 +1,4 @@
+import { TokenDetails } from "../state";
 import { Result, OrderV3 } from "../common";
 import { decodeAbiParameters, DecodeAbiParametersErrorType, parseAbiParameters } from "viem";
 
@@ -101,9 +102,11 @@ export type Pair = {
     buyToken: string;
     buyTokenDecimals: number;
     buyTokenSymbol: string;
+    buyTokenVaultBalance: bigint;
     sellToken: string;
     sellTokenDecimals: number;
     sellTokenSymbol: string;
+    sellTokenVaultBalance: bigint;
     takeOrder: TakeOrderDetails;
 };
 
@@ -128,3 +131,16 @@ export type OrderbooksOwnersProfileMap = Map<string, OwnersProfileMap>;
 export type OrderbooksPairMap = Map<string, PairMap>;
 
 export type PairMap = Map<string, Map<string, Map<string, Pair>>>;
+
+/** Represents the details of a token vault */
+export type VaultDetails = {
+    id: bigint;
+    token: TokenDetails;
+    balance: bigint;
+};
+/** token -> vault id -> vault details map */
+export type TokenVaultMap = Map<string, Map<bigint, VaultDetails>>;
+/** owner -> TokenVaultMap */
+export type OwnerTokenVaultsMap = Map<string, TokenVaultMap>;
+/** orderbook -> OwnerTokenVaultsMap */
+export type OrderbookOwnerTokenVaultsMap = Map<string, OwnerTokenVaultsMap>;

--- a/src/subgraph/query.ts
+++ b/src/subgraph/query.ts
@@ -164,6 +164,78 @@ export const getTxsQuery = (startTimestamp: number, skip: number) => {
                 }
             }
         }
+        ... on Deposit {
+            newVaultBalance
+            oldVaultBalance
+            vault {
+                owner
+                vaultId
+                balance
+                token {
+                    address
+                    decimals
+                    symbol
+                }
+            }
+            orderbook {
+                id
+            }
+        }
+        ... on Withdrawal {
+            newVaultBalance
+            oldVaultBalance
+            vault {
+                owner
+                vaultId
+                balance
+                token {
+                    address
+                    decimals
+                    symbol
+                }
+            }
+            orderbook {
+                id
+            }
+        }
+        ... on TradeEvent {
+            trades {
+                inputVaultBalanceChange {
+                    newVaultBalance
+                    oldVaultBalance
+                    vault {
+                        owner
+                        balance
+                        vaultId
+                        token {
+                            address
+                            decimals
+                            symbol
+                        }
+                    }
+                    orderbook {
+                        id
+                    }
+                }
+                outputVaultBalanceChange {
+                    newVaultBalance
+                    oldVaultBalance
+                    vault {
+                        owner
+                        balance
+                        vaultId
+                        token {
+                            address
+                            decimals
+                            symbol
+                        }
+                    }
+                    orderbook {
+                        id
+                    }
+                }
+            }
+        }
     }
     timestamp
 }}`;

--- a/src/subgraph/types.ts
+++ b/src/subgraph/types.ts
@@ -42,7 +42,7 @@ export type SgTransaction = {
 };
 
 /** Type of a RainOrderbook subgraph event */
-export type SgEvent = SgAddRemoveEvent | SgOtherEvents;
+export type SgEvent = SgAddRemoveEvent | SgVaultOperationEvent | SgTradeEvent;
 
 /** Represents Add/Remove Order event */
 export type SgAddRemoveEvent = {
@@ -50,9 +50,40 @@ export type SgAddRemoveEvent = {
     order: SgOrder;
 };
 
-/** Other event types */
-export type SgOtherEvents = {
+/** Vault operation event types, deposit and withdraw */
+export type SgVaultOperationEvent = {
     __typename: "Withdrawal" | "Deposit";
+} & VaultChangeEvent;
+
+/** Represents trade events */
+export type SgTradeEvent = {
+    __typename: "TakeOrder" | "Clear";
+    trades: SgTrade[];
+};
+
+/** Represents vault balance change event */
+export type VaultChangeEvent = {
+    newVaultBalance: string;
+    oldVaultBalance: string;
+    vault: {
+        owner: string;
+        vaultId: string;
+        balance: string;
+        token: {
+            address: string;
+            symbol: string;
+            decimals: string | number;
+        };
+    };
+    orderbook: {
+        id: string;
+    };
+};
+
+/** Represents trade event details */
+export type SgTrade = {
+    inputVaultBalanceChange: VaultChangeEvent;
+    outputVaultBalanceChange: VaultChangeEvent;
 };
 
 /** Represents subgraph sync result that include added and removed orders */


### PR DESCRIPTION
<!-- Thanks for your Pull Request, please read the contributing guidelines before submitting. -->

## Motivation
## ⚠️ Do NOT merge before #377 

Partially resolves #312 

This PR adds:
- `ownerTokenVaultsMap` to the `OrderManager` where vault details are stored per owner per token per vault id, for instant access to them and use them to skip over the orders that have empty vaults when batches of orders are being processed
- add deposit/withdrwaw and trade transactions to subgraph events query to fetch details of all transactions
- updated the `syncOrder` method in `SubgraphManager` to just fetch the upstream events with also renaming it to `getUpstreamEvents`
- adds a new method to called `syncOrders` to `OrderManager` where fetched events from subgraph are them processed and added to their respective in-memory maps so that at any given point in time the vault and order details are updated and can be used throughout the program
- uses the newly added `ownerTokenVaultMap` in `OrderManager` to re-evaluate owner limits and as a result remove the unnecessary functions
- adds extensive tests for any new functionalities and updates the ones that are affected by these changes
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## Checks
<!-- It's important you've done these, or your PR will not be considered for review -->
By submitting this for review, I'm confirming I've done the following:
- [x] made this PR as small as possible
- [x] unit-tested any new functionality
- [x] linked any relevant issues or PRs
- [ ] ~~included screenshots (if this involves a front-end change)~~
