### PR TITLE
fix error decoder bug

### DIFF
--- a/src/error/common.ts
+++ b/src/error/common.ts
@@ -15,6 +15,7 @@ import {
     TransactionReceiptNotFoundError,
     WaitForTransactionReceiptTimeoutError,
 } from "viem";
+import { withBigintSerializer } from "../common";
 
 /**
  * Constructs a snapshot from the given error which is mainly used for reporting
@@ -48,7 +49,9 @@ export async function errorSnapshot(
             if (decoded) {
                 message.push("Error Name: " + decoded.name);
                 if (decoded.args.length) {
-                    message.push("Error Args: " + JSON.stringify(decoded.args));
+                    message.push(
+                        "Error Args: " + JSON.stringify(decoded.args, withBigintSerializer),
+                    );
                 }
             } else if (raw.data) {
                 message.push("Error Raw Data: " + raw.data);

--- a/src/error/decoder.test.ts
+++ b/src/error/decoder.test.ts
@@ -1,5 +1,5 @@
 import axios from "axios";
-import { decodeErrorResult, isHex } from "viem";
+import { decodeErrorResult, isHex, parseAbiItem } from "viem";
 import { PANIC_REASONS, PANIC_SELECTOR, SELECTOR_REGISTRY } from "./types";
 import { describe, it, expect, vi, beforeEach, Mock, assert } from "vitest";
 import { tryDecodeError, tryGetSignature, tryDecodePanic, SelectorCache } from "./decoder";
@@ -66,7 +66,7 @@ describe("Test decoder functions", () => {
                 args: ["Test error message"],
             });
             expect(decodeErrorResult).toHaveBeenCalledWith({
-                abi: [cachedSignatures[0]],
+                abi: [parseAbiItem("error " + cachedSignatures[0])],
                 data: errorData,
             });
         });

--- a/src/error/decoder.ts
+++ b/src/error/decoder.ts
@@ -1,7 +1,7 @@
 import axios from "axios";
 import assert from "assert";
 import { Result } from "../common";
-import { decodeErrorResult, isHex } from "viem";
+import { decodeErrorResult, isHex, parseAbiItem } from "viem";
 import {
     PANIC_ABI,
     PANIC_SELECTOR,
@@ -37,7 +37,7 @@ export async function tryDecodeError(data: any): Promise<Result<DecodedErrorType
     }
     for (const sig of signatures.value) {
         try {
-            const result = decodeErrorResult({ abi: [sig], data });
+            const result = decodeErrorResult({ abi: [parseAbiItem("error " + sig)], data });
             return Result.ok({
                 name: result.errorName,
                 args: result.args as any[],


### PR DESCRIPTION
<!-- Thanks for your Pull Request, please read the contributing guidelines before submitting. -->

## Motivation
## ⚠️ Do NOT merge before #378 

This PR fixes a small bug with error decoder where signatures need to be parsed before trying to decode the error data
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## Checks
<!-- It's important you've done these, or your PR will not be considered for review -->
By submitting this for review, I'm confirming I've done the following:
- [x] made this PR as small as possible
- [x] unit-tested any new functionality
- [ ] linked any relevant issues or PRs
- [ ] ~~included screenshots (if this involves a front-end change)~~
