### PR TITLE
update tx receipt polling

### DIFF
--- a/src/common/utils.ts
+++ b/src/common/utils.ts
@@ -45,15 +45,15 @@ export async function sleep(ms: number, msg = "") {
  * @returns A new promise that gets settled with initial promise settlement or rejected with exception value
  * if the time runs out before the main promise settlement
  */
-export async function promiseTimeout(
-    promise: Promise<any>,
+export async function promiseTimeout<T>(
+    promise: Promise<T>,
     time: number,
     exception: Error | string | number | bigint | symbol | boolean,
-) {
+): Promise<T> {
     let timer: string | number | NodeJS.Timeout | undefined;
     return Promise.race([
         promise,
-        new Promise((_res, _rej) => (timer = setTimeout(_rej, time, exception))),
+        new Promise((_res, _rej) => (timer = setTimeout(_rej, time, exception))) as any,
     ]).finally(() => clearTimeout(timer));
 }
 

--- a/src/core/process/receipt.ts
+++ b/src/core/process/receipt.ts
@@ -155,30 +155,6 @@ export async function processReceipt({
 }
 
 /**
- * Tries to get the transaction receipt for a given transaction hash
- * @param signer - The RainSolverSigner instance
- * @param hash - The transaction hash
- * @param txSendTime - The time the transaction was sent
- */
-export async function tryGetReceipt(
-    signer: RainSolverSigner,
-    hash: `0x${string}`,
-    txSendTime: number,
-): Promise<TransactionReceipt> {
-    try {
-        return await signer.state.client.waitForTransactionReceipt({
-            hash,
-            confirmations: 1,
-            timeout: 120_000,
-        });
-    } catch {
-        // in case waiting for tx receipt was unsuccessful, try getting the receipt directly
-        await sleep(Math.max(90_000 + txSendTime - Date.now(), 0));
-        return await signer.state.client.getTransactionReceipt({ hash });
-    }
-}
-
-/**
  * Returns the L1 gas cost of a transaction
  * @param receipt - The transaction receipt
  * @returns The L1 fee as a bigint, or 0n if not applicable

--- a/src/core/process/transaction.test.ts
+++ b/src/core/process/transaction.test.ts
@@ -53,7 +53,6 @@ describe("Test processTransaction", () => {
             },
             state: {
                 client: {
-                    waitForTransactionReceipt: vi.fn(),
                     getTransactionReceipt: vi.fn(),
                 },
                 chainConfig: {
@@ -66,6 +65,7 @@ describe("Test processTransaction", () => {
                 },
             },
             asWriteSigner: vi.fn().mockReturnValue(mockWriteSigner),
+            waitForReceipt: vi.fn(),
         } as any;
 
         // mock raw transaction
@@ -114,9 +114,7 @@ describe("Test processTransaction", () => {
                 gasUsed: 21000n,
                 effectiveGasPrice: 20000000000n,
             };
-            (mockSigner.state.client.waitForTransactionReceipt as Mock).mockResolvedValueOnce(
-                mockReceipt,
-            );
+            (mockSigner.waitForReceipt as Mock).mockResolvedValueOnce(mockReceipt);
             const mockHandleReceiptResult = Result.ok<ProcessOrderSuccess, ProcessOrderFailure>({
                 ...mockArgs.baseResult,
                 clearedAmount: "100",
@@ -200,9 +198,7 @@ describe("Test processTransaction", () => {
             const mockTxHash = "0xFailedReceiptHash";
             const receiptError = new Error("Receipt retrieval failed");
             mockWriteSigner.sendTx.mockResolvedValueOnce(mockTxHash);
-            (mockSigner.state.client.waitForTransactionReceipt as Mock).mockRejectedValueOnce(
-                receiptError,
-            );
+            (mockSigner.waitForReceipt as Mock).mockRejectedValueOnce(receiptError);
             (mockSigner.state.client.getTransactionReceipt as Mock).mockRejectedValue(receiptError);
             (containsNodeError as Mock).mockResolvedValue(true);
             const settlerFn = await processTransaction(mockArgs);
@@ -230,9 +226,7 @@ describe("Test processTransaction", () => {
             };
             const handleReceiptError = new Error("Handle receipt failed");
             mockWriteSigner.sendTx.mockResolvedValueOnce(mockTxHash);
-            (mockSigner.state.client.waitForTransactionReceipt as Mock).mockResolvedValueOnce(
-                mockReceipt,
-            );
+            (mockSigner.waitForReceipt as Mock).mockResolvedValueOnce(mockReceipt);
             (processReceipt as Mock).mockRejectedValueOnce(handleReceiptError);
             (containsNodeError as Mock).mockResolvedValue(false);
             const settlerFn = await processTransaction(mockArgs);

--- a/src/core/process/transaction.ts
+++ b/src/core/process/transaction.ts
@@ -1,9 +1,9 @@
 import { BaseError } from "viem";
 import { Result } from "../../common";
 import { Token } from "sushi/currency";
+import { processReceipt } from "./receipt";
 import { RainSolverSigner } from "../../signer";
 import { containsNodeError } from "../../error";
-import { processReceipt, tryGetReceipt } from "./receipt";
 import { withBigintSerializer, RawTransaction } from "../../common";
 import {
     ProcessOrderSuccess,
@@ -77,7 +77,7 @@ export async function processTransaction({
     }
 
     // start getting tx receipt in background and return the settler fn
-    const receiptPromise = tryGetReceipt(signer, txhash!, txSendTime);
+    const receiptPromise = signer.waitForReceipt({ hash: txhash! });
 
     return async () => {
         try {

--- a/src/signer/actions.ts
+++ b/src/signer/actions.ts
@@ -294,7 +294,7 @@ export async function tryGetReceipt(
                     await sleep(pollingInterval);
                     return await signer.state.client.getTransactionReceipt({ hash });
                 } catch {
-                    // Ignore errors and continue polling until timeout or success
+                    // ignore errors and continue polling until timeout or success
                     continue;
                 }
             }

--- a/src/state/gasPrice.ts
+++ b/src/state/gasPrice.ts
@@ -27,8 +27,8 @@ export async function getGasPrice(
     // try to fetch gas prices concurrently
     const promises = [client.getGasPrice()];
     if (chainConfig.isSpecialL2) {
-        const l1Client = client.extend(publicActionsL2());
-        promises.push(l1Client.getL1BaseFee());
+        const l2Client = client.extend(publicActionsL2());
+        promises.push(l2Client.getL1BaseFee());
     }
     const [gasPriceResult, l1GasPriceResult = undefined] = await Promise.allSettled(promises);
 

--- a/src/wallet/fundVault.test.ts
+++ b/src/wallet/fundVault.test.ts
@@ -91,7 +91,7 @@ describe("Test fundVault", () => {
             readContract: vi.fn(),
             writeContract: vi.fn(),
             sendTx: vi.fn(),
-            waitForTransactionReceipt: vi.fn(),
+            waitForReceipt: vi.fn(),
         } as any;
 
         // setup vault details
@@ -113,7 +113,7 @@ describe("Test fundVault", () => {
             .mockResolvedValueOnce(parseUnits("2000", 18)); // sufficient allowance
 
         (mockSigner.writeContract as Mock).mockResolvedValue("0xdeposit");
-        (mockSigner.waitForTransactionReceipt as Mock).mockResolvedValue({ status: "success" });
+        (mockSigner.waitForReceipt as Mock).mockResolvedValue({ status: "success" });
 
         const result = await fundVault(vaultDetails, mockSigner);
 
@@ -147,7 +147,7 @@ describe("Test fundVault", () => {
 
         (mockSigner.sendTx as Mock).mockResolvedValue("0xswap");
         (mockSigner.writeContract as Mock).mockResolvedValue("0xdeposit");
-        (mockSigner.waitForTransactionReceipt as Mock)
+        (mockSigner.waitForReceipt as Mock)
             .mockResolvedValueOnce({ status: "success" }) // swap receipt
             .mockResolvedValueOnce({ status: "success" }); // deposit receipt
 
@@ -189,7 +189,7 @@ describe("Test fundVault", () => {
             .mockResolvedValueOnce(parseUnits("2000", 18)); // allowance
 
         (mockSigner.writeContract as Mock).mockResolvedValue("0xdeposit");
-        (mockSigner.waitForTransactionReceipt as Mock).mockResolvedValue({ status: "success" });
+        (mockSigner.waitForReceipt as Mock).mockResolvedValue({ status: "success" });
 
         const result = await fundVault(vaultDetails, mockSigner);
 
@@ -214,7 +214,7 @@ describe("Test fundVault", () => {
             .mockResolvedValueOnce(parseUnits("2000", 18)); // allowance
 
         (mockSigner.writeContract as Mock).mockResolvedValue("0xdeposit");
-        (mockSigner.waitForTransactionReceipt as Mock).mockResolvedValue({ status: "success" });
+        (mockSigner.waitForReceipt as Mock).mockResolvedValue({ status: "success" });
 
         const result = await fundVault(vaultDetails, mockSigner);
 
@@ -233,7 +233,7 @@ describe("Test fundVault", () => {
             .mockResolvedValueOnce(parseUnits("2000", 18)); // allowance
 
         (mockSigner.writeContract as Mock).mockResolvedValue("0xdeposit");
-        (mockSigner.waitForTransactionReceipt as Mock).mockResolvedValue({ status: "success" });
+        (mockSigner.waitForReceipt as Mock).mockResolvedValue({ status: "success" });
 
         const result = await fundVault(vaultDetails, mockSigner);
 
@@ -270,7 +270,7 @@ describe("Test fundVault", () => {
 
         (mockSigner.sendTx as Mock).mockResolvedValue("0xswap");
         (mockSigner.writeContract as Mock).mockResolvedValue("0xdeposit");
-        (mockSigner.waitForTransactionReceipt as Mock)
+        (mockSigner.waitForReceipt as Mock)
             .mockResolvedValueOnce({ status: "success" }) // swap
             .mockResolvedValueOnce({ status: "success" }); // deposit
 
@@ -290,7 +290,7 @@ describe("Test fundVault", () => {
             .mockResolvedValueOnce(parseUnits("10", 18)); // insufficient token balance
 
         (mockSigner.sendTx as Mock).mockResolvedValue("0xswap");
-        (mockSigner.waitForTransactionReceipt as Mock).mockResolvedValue({ status: "reverted" });
+        (mockSigner.waitForReceipt as Mock).mockResolvedValue({ status: "reverted" });
 
         await expect(fundVault(vaultDetails, mockSigner)).rejects.toThrow(
             "Failed to swap gas to target token to acquire the balance needed for depositing into the vault",
@@ -309,7 +309,7 @@ describe("Test fundVault", () => {
             .mockResolvedValueOnce("0xapprove") // approve tx
             .mockResolvedValueOnce("0xdeposit"); // deposit tx
 
-        (mockSigner.waitForTransactionReceipt as Mock)
+        (mockSigner.waitForReceipt as Mock)
             .mockResolvedValueOnce({ status: "success" }) // approve
             .mockResolvedValueOnce({ status: "success" }); // deposit
 
@@ -330,7 +330,7 @@ describe("Test fundVault", () => {
             .mockResolvedValueOnce(0n); // zero allowance
 
         (mockSigner.writeContract as Mock).mockResolvedValue("0xapprove");
-        (mockSigner.waitForTransactionReceipt as Mock).mockResolvedValue({ status: "reverted" });
+        (mockSigner.waitForReceipt as Mock).mockResolvedValue({ status: "reverted" });
 
         await expect(fundVault(vaultDetails, mockSigner)).rejects.toThrow(
             "Failed to approve token spend cap for depositing",
@@ -346,7 +346,7 @@ describe("Test fundVault", () => {
             .mockResolvedValueOnce(parseUnits("2000", 18)); // sufficient allowance
 
         (mockSigner.writeContract as Mock).mockResolvedValue("0xdeposit");
-        (mockSigner.waitForTransactionReceipt as Mock).mockResolvedValue({ status: "reverted" });
+        (mockSigner.waitForReceipt as Mock).mockResolvedValue({ status: "reverted" });
 
         await expect(fundVault(vaultDetails, mockSigner)).rejects.toMatchObject({
             txHash: "0xdeposit",

--- a/src/wallet/fundVault.ts
+++ b/src/wallet/fundVault.ts
@@ -121,11 +121,7 @@ export async function fundVault(details: SelfFundVault, signer: RainSolverSigner
                 data: rpParams.data as `0x${string}`,
                 value: route.amountInBI,
             });
-            const receipt = await signer.waitForTransactionReceipt({
-                hash,
-                confirmations: 4,
-                timeout: 100_000,
-            });
+            const receipt = await signer.waitForReceipt({ hash });
             if (receipt.status === "reverted") {
                 throw new Error(
                     "Failed to swap gas to target token to acquire the balance needed for depositing into the vault, reason: transaction reverted onchain",
@@ -147,11 +143,7 @@ export async function fundVault(details: SelfFundVault, signer: RainSolverSigner
                 functionName: "approve",
                 args: [details.orderbook as `0x${string}`, maxUint256],
             });
-            const receipt = await signer.waitForTransactionReceipt({
-                hash,
-                confirmations: 4,
-                timeout: 100_000,
-            });
+            const receipt = await signer.waitForReceipt({ hash });
             if (receipt.status === "reverted") {
                 throw new Error(
                     "Failed to approve token spend cap for depositing, reason: transaction reverted onchain",
@@ -166,11 +158,7 @@ export async function fundVault(details: SelfFundVault, signer: RainSolverSigner
             functionName: "deposit2",
             args: [vaultToken.address, BigInt(details.vaultId), topupAmount, []],
         });
-        const receipt = await signer.waitForTransactionReceipt({
-            hash,
-            confirmations: 4,
-            timeout: 100_000,
-        });
+        const receipt = await signer.waitForReceipt({ hash });
         if (receipt.status === "success") {
             return { txHash: hash };
         } else {

--- a/src/wallet/index.test.ts
+++ b/src/wallet/index.test.ts
@@ -20,7 +20,7 @@ vi.mock("../signer", () => ({
             getSelfBalance: vi.fn(),
             getBalance: vi.fn().mockResolvedValue(0n),
             sendTx: vi.fn(),
-            waitForTransactionReceipt: vi.fn(),
+            waitForReceipt: vi.fn(),
         })),
     },
 }));
@@ -174,7 +174,7 @@ describe("Test WalletManager", () => {
                 parseUnits("1", 18),
             );
             (walletManager.mainSigner.sendTx as Mock).mockResolvedValue("0x123");
-            (walletManager.mainSigner.waitForTransactionReceipt as Mock).mockResolvedValue({
+            (walletManager.mainSigner.waitForReceipt as Mock).mockResolvedValue({
                 status: "success",
             });
 
@@ -194,7 +194,7 @@ describe("Test WalletManager", () => {
                 parseUnits("1", 18),
             );
             (walletManager.mainSigner.sendTx as Mock).mockResolvedValue("0x123");
-            (walletManager.mainSigner.waitForTransactionReceipt as Mock).mockResolvedValue({
+            (walletManager.mainSigner.waitForReceipt as Mock).mockResolvedValue({
                 status: "reverted",
             });
 
@@ -228,8 +228,8 @@ describe("Test WalletManager", () => {
             const sendTxSpy = vi
                 .spyOn(walletManager.mainSigner, "sendTx")
                 .mockResolvedValue("0x123");
-            const waitForTransactionReceiptSpy = vi
-                .spyOn(walletManager.mainSigner, "waitForTransactionReceipt")
+            const waitForReceiptSpy = vi
+                .spyOn(walletManager.mainSigner, "waitForReceipt")
                 .mockResolvedValue({
                     status: "success",
                 } as any);
@@ -243,11 +243,11 @@ describe("Test WalletManager", () => {
 
             expect(getSelfBalanceSpy).toHaveBeenCalledTimes(1);
             expect(sendTxSpy).toHaveBeenCalledTimes(1);
-            expect(waitForTransactionReceiptSpy).toHaveBeenCalledTimes(1);
+            expect(waitForReceiptSpy).toHaveBeenCalledTimes(1);
 
             getSelfBalanceSpy.mockRestore();
             sendTxSpy.mockRestore();
-            waitForTransactionReceiptSpy.mockRestore();
+            waitForReceiptSpy.mockRestore();
         });
     });
 

--- a/src/wallet/index.ts
+++ b/src/wallet/index.ts
@@ -191,11 +191,7 @@ export class WalletManager {
                     to: wallet as `0x${string}`,
                     value: amount,
                 });
-                const receipt = await this.mainSigner.waitForTransactionReceipt({
-                    hash,
-                    confirmations: 4,
-                    timeout: 100_000,
-                });
+                const receipt = await this.mainSigner.waitForReceipt({ hash });
                 if (receipt.status === "success") {
                     report.setStatus({
                         code: SpanStatusCode.OK,

--- a/src/wallet/sweep.test.ts
+++ b/src/wallet/sweep.test.ts
@@ -59,7 +59,7 @@ describe("Test sweep functions", () => {
             writeContract: vi.fn(),
             getSelfBalance: vi.fn(),
             estimateGasCost: vi.fn(),
-            waitForTransactionReceipt: vi.fn(),
+            waitForReceipt: vi.fn(),
             sendTx: vi.fn(),
         } as any;
 
@@ -71,7 +71,7 @@ describe("Test sweep functions", () => {
             writeContract: vi.fn(),
             getSelfBalance: vi.fn(),
             estimateGasCost: vi.fn(),
-            waitForTransactionReceipt: vi.fn(),
+            waitForReceipt: vi.fn(),
             sendTx: vi.fn(),
         } as any;
     });
@@ -91,11 +91,11 @@ describe("Test sweep functions", () => {
             (mockFromSigner.getSelfBalance as Mock).mockResolvedValue(50n);
             (mockFromSigner.estimateGasCost as Mock).mockResolvedValue({ totalGasCost: 100n });
             (mockToSigner.sendTx as Mock).mockResolvedValue("0xhash");
-            (mockToSigner.waitForTransactionReceipt as Mock).mockResolvedValue({
+            (mockToSigner.waitForReceipt as Mock).mockResolvedValue({
                 status: "success",
             });
             (mockFromSigner.writeContract as Mock).mockResolvedValue("0xtransferhash");
-            (mockFromSigner.waitForTransactionReceipt as Mock).mockResolvedValue({
+            (mockFromSigner.waitForReceipt as Mock).mockResolvedValue({
                 status: "success",
             });
 
@@ -113,7 +113,7 @@ describe("Test sweep functions", () => {
             (mockFromSigner.getSelfBalance as Mock).mockResolvedValue(50n);
             (mockFromSigner.estimateGasCost as Mock).mockResolvedValue({ totalGasCost: 100n });
             (mockToSigner.sendTx as Mock).mockResolvedValue("0xhash");
-            (mockToSigner.waitForTransactionReceipt as Mock).mockResolvedValue({
+            (mockToSigner.waitForReceipt as Mock).mockResolvedValue({
                 status: "reverted",
             });
 
@@ -132,7 +132,7 @@ describe("Test sweep functions", () => {
             (mockFromSigner.getSelfBalance as Mock).mockResolvedValue(1000n);
             (mockFromSigner.estimateGasCost as Mock).mockResolvedValue({ totalGasCost: 50n });
             (mockFromSigner.writeContract as Mock).mockResolvedValue("0xhash");
-            (mockFromSigner.waitForTransactionReceipt as Mock).mockResolvedValue({
+            (mockFromSigner.waitForReceipt as Mock).mockResolvedValue({
                 status: "success",
             });
 
@@ -152,7 +152,7 @@ describe("Test sweep functions", () => {
             (mockFromSigner.getSelfBalance as Mock).mockResolvedValue(1000n);
             (mockFromSigner.estimateGasCost as Mock).mockResolvedValue({ totalGasCost: 50n });
             (mockFromSigner.writeContract as Mock).mockResolvedValue("0xhash");
-            (mockFromSigner.waitForTransactionReceipt as Mock).mockResolvedValue({
+            (mockFromSigner.waitForReceipt as Mock).mockResolvedValue({
                 status: "reverted",
             });
 
@@ -191,7 +191,7 @@ describe("Test sweep functions", () => {
             (mockFromSigner.getSelfBalance as Mock).mockResolvedValue(1000n);
             (mockFromSigner.estimateGasCost as Mock).mockResolvedValue({ totalGasCost: 100n });
             (mockFromSigner.sendTx as Mock).mockResolvedValue("0xhash");
-            (mockFromSigner.waitForTransactionReceipt as Mock).mockResolvedValue({
+            (mockFromSigner.waitForReceipt as Mock).mockResolvedValue({
                 status: "success",
             });
 
@@ -212,7 +212,7 @@ describe("Test sweep functions", () => {
             (mockFromSigner.getSelfBalance as Mock).mockResolvedValue(1000n);
             (mockFromSigner.estimateGasCost as Mock).mockResolvedValue({ totalGasCost: 100n });
             (mockFromSigner.sendTx as Mock).mockResolvedValue("0xhash");
-            (mockFromSigner.waitForTransactionReceipt as Mock).mockResolvedValue({
+            (mockFromSigner.waitForReceipt as Mock).mockResolvedValue({
                 status: "reverted",
             });
 
@@ -286,7 +286,7 @@ describe("Test sweep functions", () => {
 
             // mock approval transaction
             (mockFromSigner.writeContract as Mock).mockResolvedValue("0xapprove");
-            (mockFromSigner.waitForTransactionReceipt as Mock).mockResolvedValue({
+            (mockFromSigner.waitForReceipt as Mock).mockResolvedValue({
                 status: "success",
             });
 
@@ -383,7 +383,7 @@ describe("Test sweep functions", () => {
 
             // mock successful swap
             (mockFromSigner.sendTx as Mock).mockResolvedValue("0xswap");
-            (mockFromSigner.waitForTransactionReceipt as Mock).mockResolvedValue({
+            (mockFromSigner.waitForReceipt as Mock).mockResolvedValue({
                 status: "success",
             });
 
@@ -423,7 +423,7 @@ describe("Test sweep functions", () => {
 
             // mock failed swap
             (mockFromSigner.sendTx as Mock).mockResolvedValue("0xfailed");
-            (mockFromSigner.waitForTransactionReceipt as Mock).mockResolvedValue({
+            (mockFromSigner.waitForReceipt as Mock).mockResolvedValue({
                 status: "reverted",
             });
 
@@ -463,7 +463,7 @@ describe("Test sweep functions", () => {
 
             // mock successful swap
             (mockFromSigner.sendTx as Mock).mockResolvedValue("0xswap");
-            (mockFromSigner.waitForTransactionReceipt as Mock).mockResolvedValue({
+            (mockFromSigner.waitForReceipt as Mock).mockResolvedValue({
                 status: "success",
             });
 

--- a/src/wallet/sweep.ts
+++ b/src/wallet/sweep.ts
@@ -41,11 +41,7 @@ export async function transferTokenFrom(
     if (totalCost > gasBalance) {
         // fund the wallet
         const hash = await to.sendTx({ to: from.account.address, value: totalCost });
-        const receipt = await to.waitForTransactionReceipt({
-            hash,
-            confirmations: 4,
-            timeout: 100_000,
-        });
+        const receipt = await to.waitForReceipt({ hash });
         if (receipt.status !== "success") {
             throw {
                 txHash: hash,
@@ -63,11 +59,7 @@ export async function transferTokenFrom(
         functionName: "transfer",
         args: [to.account.address, balance],
     });
-    const receipt = await from.waitForTransactionReceipt({
-        hash,
-        confirmations: 4,
-        timeout: 100_000,
-    });
+    const receipt = await from.waitForReceipt({ hash });
     if (receipt.status === "success") {
         return { amount: balance, txHash: hash };
     } else {
@@ -93,11 +85,7 @@ export async function transferRemainingGasFrom(from: RainSolverSigner, to: `0x${
     if (balance > totalCost) {
         const amount = balance - totalCost;
         const hash = await from.sendTx({ to, value: amount });
-        const receipt = await from.waitForTransactionReceipt({
-            hash,
-            confirmations: 4,
-            timeout: 100_000,
-        });
+        const receipt = await from.waitForReceipt({ hash });
         if (receipt.status === "success") {
             return { amount, txHash: hash };
         } else {
@@ -164,11 +152,7 @@ export async function convertToGas(
             functionName: "approve",
             args: [rp4Address, maxUint256],
         });
-        await from.waitForTransactionReceipt({
-            hash,
-            confirmations: 4,
-            timeout: 100_000,
-        });
+        await from.waitForReceipt({ hash });
     }
 
     // find best route and build swap contract call params
@@ -218,11 +202,7 @@ export async function convertToGas(
             to: rp4Address,
             data: rpParams.data as `0x${string}`,
         });
-        const receipt = await from.waitForTransactionReceipt({
-            hash,
-            confirmations: 4,
-            timeout: 100_000,
-        });
+        const receipt = await from.waitForReceipt({ hash });
         if (receipt.status === "success") {
             return {
                 txHash: hash,

--- a/test/e2e/e2e.test.js
+++ b/test/e2e/e2e.test.js
@@ -18,9 +18,14 @@ const { publicActions, walletActions, createPublicClient } = require("viem");
 const { ABI, Result, toFloat, normalizeFloat } = require("../../src/common");
 const { OTLPTraceExporter } = require("@opentelemetry/exporter-trace-otlp-http");
 const { SEMRESATTRS_SERVICE_NAME } = require("@opentelemetry/semantic-conventions");
-const { sendTx, waitUntilFree, estimateGasCost } = require("../../src/signer/actions");
 const { BasicTracerProvider, BatchSpanProcessor } = require("@opentelemetry/sdk-trace-base");
 const { OrderManager } = require("../../src/order");
+const {
+    sendTx,
+    waitUntilFree,
+    estimateGasCost,
+    tryGetReceipt,
+} = require("../../src/signer/actions");
 const {
     arbDeploy,
     encodeMeta,
@@ -190,6 +195,9 @@ for (let i = 0; i < testData.length; i++) {
                         return await estimateGasCost(bot, tx);
                     };
                     bot.asWriteSigner = () => bot;
+                    bot.waitForReceipt = async (tx) => {
+                        return await tryGetReceipt(bot, tx.hash, 3000, 50);
+                    };
                     bot.state = state;
                     bot.impersonateAccount({
                         address: botAddress ?? "0x22025257BeF969A81eDaC0b343ce82d777931327",
@@ -466,6 +474,9 @@ for (let i = 0; i < testData.length; i++) {
                         return await estimateGasCost(bot, tx);
                     };
                     bot.asWriteSigner = () => bot;
+                    bot.waitForReceipt = async (tx) => {
+                        return await tryGetReceipt(bot, tx.hash, 3000, 50);
+                    };
                     bot.state = state;
                     bot.impersonateAccount({
                         address: botAddress ?? "0x22025257BeF969A81eDaC0b343ce82d777931327",
@@ -835,6 +846,9 @@ for (let i = 0; i < testData.length; i++) {
                         return await estimateGasCost(bot, tx);
                     };
                     bot.asWriteSigner = () => bot;
+                    bot.waitForReceipt = async (tx) => {
+                        return await tryGetReceipt(bot, tx.hash, 3000, 50);
+                    };
                     bot.state = state;
                     bot.impersonateAccount({
                         address: botAddress ?? "0x22025257BeF969A81eDaC0b343ce82d777931327",
@@ -1230,6 +1244,9 @@ for (let i = 0; i < testData.length; i++) {
                         return await estimateGasCost(bot, tx);
                     };
                     bot.asWriteSigner = () => bot;
+                    bot.waitForReceipt = async (tx) => {
+                        return await tryGetReceipt(bot, tx.hash, 3000, 50);
+                    };
                     bot.state = state;
                     bot.impersonateAccount({
                         address: botAddress ?? "0x22025257BeF969A81eDaC0b343ce82d777931327",
@@ -1630,6 +1647,9 @@ for (let i = 0; i < testData.length; i++) {
                         return await estimateGasCost(bot, tx);
                     };
                     bot.asWriteSigner = () => bot;
+                    bot.waitForReceipt = async (tx) => {
+                        return await tryGetReceipt(bot, tx.hash, 3000, 50);
+                    };
                     bot.state = state;
                     bot.impersonateAccount({
                         address: botAddress ?? "0x22025257BeF969A81eDaC0b343ce82d777931327",
@@ -1914,6 +1934,9 @@ for (let i = 0; i < testData.length; i++) {
                         return await estimateGasCost(bot, tx);
                     };
                     bot.asWriteSigner = () => bot;
+                    bot.waitForReceipt = async (tx) => {
+                        return await tryGetReceipt(bot, tx.hash, 3000, 50);
+                    };
                     bot.state = state;
                     bot.impersonateAccount({
                         address: botAddress ?? "0x22025257BeF969A81eDaC0b343ce82d777931327",
@@ -2212,6 +2235,9 @@ for (let i = 0; i < testData.length; i++) {
                         return await estimateGasCost(bot, tx);
                     };
                     bot.asWriteSigner = () => bot;
+                    bot.waitForReceipt = async (tx) => {
+                        return await tryGetReceipt(bot, tx.hash, 3000, 50);
+                    };
                     bot.state = state;
                     bot.impersonateAccount({
                         address: botAddress ?? "0x22025257BeF969A81eDaC0b343ce82d777931327",
@@ -2595,6 +2621,9 @@ for (let i = 0; i < testData.length; i++) {
                         return await estimateGasCost(bot, tx);
                     };
                     bot.asWriteSigner = () => bot;
+                    bot.waitForReceipt = async (tx) => {
+                        return await tryGetReceipt(bot, tx.hash, 3000, 50);
+                    };
                     bot.state = state;
                     bot.impersonateAccount({
                         address: botAddress ?? "0x22025257BeF969A81eDaC0b343ce82d777931327",
@@ -2984,6 +3013,9 @@ for (let i = 0; i < testData.length; i++) {
                         return await estimateGasCost(bot, tx);
                     };
                     bot.asWriteSigner = () => bot;
+                    bot.waitForReceipt = async (tx) => {
+                        return await tryGetReceipt(bot, tx.hash, 3000, 50);
+                    };
                     bot.state = state;
                     bot.impersonateAccount({
                         address: botAddress ?? "0x22025257BeF969A81eDaC0b343ce82d777931327",
@@ -3413,6 +3445,9 @@ for (let i = 0; i < testData.length; i++) {
                         return await estimateGasCost(bot, tx);
                     };
                     bot.asWriteSigner = () => bot;
+                    bot.waitForReceipt = async (tx) => {
+                        return await tryGetReceipt(bot, tx.hash, 3000, 50);
+                    };
                     bot.state = state;
                     bot.impersonateAccount({
                         address: botAddress ?? "0x22025257BeF969A81eDaC0b343ce82d777931327",


### PR DESCRIPTION
<!-- Thanks for your Pull Request, please read the contributing guidelines before submitting. -->

## Motivation
This Pr updates the tx receipt polling logic for `RainSolverSigner` class.
By implementing our own logic for polling receipts, this PR prepares the ground for implementing a gasPrice tracker logic that can track time it takes for each tx to get mined and use as the parameters needed to adjust gasPrice during runtime.

SIDE NOTE: default viem `waitForTransactionReceipt` leaks memory:
https://github.com/wevm/viem/issues/3515

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## Checks
<!-- It's important you've done these, or your PR will not be considered for review -->
By submitting this for review, I'm confirming I've done the following:
- [x] made this PR as small as possible
- [x] unit-tested any new functionality
- [ ] linked any relevant issues or PRs
- [ ] included screenshots (if this involves a front-end change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added waitForReceipt API for reliably awaiting transaction receipts.
  - Introduced tryGetReceipt helper with timeout and polling support.

- Refactor
  - Unified receipt handling across wallet operations (fund, sweep, general transactions) to use waitForReceipt, removing manual confirmations/timeouts.

- Bug Fixes
  - Improved gas price estimation on special L2 networks by fetching the correct L1 base fee source.

- Developer Improvements
  - Enhanced type safety for promise utilities to better preserve resolved value types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->