### PR TITLE
update pool blacklist for `nht/wpol`

### DIFF
--- a/src/router/sushi/blacklist.ts
+++ b/src/router/sushi/blacklist.ts
@@ -4,6 +4,7 @@ export const BlackList = [
     "0xFB957DE375cc10450D7a34aB85b1F15Ef58680b4",
     "0x11E29b541AbE15984c863c10F3Ef9eCBcC078031",
     "0x59048Ff7D11ef18514163d0A860fb7A34927a452",
+    "0x461053a473248054807241adE4F988A35899A312",
 ] as const;
 
 /** Blacklisted pools as a set, used by router */


### PR DESCRIPTION
<!-- Thanks for your Pull Request, please read the contributing guidelines before submitting. -->

## Motivation
there is a `nht/wpol` with very low liquidity that we need to add to the blacklist, as it has enough liquid for 1unit price quote of `nht` for `wpol` , giving us a bad price that is needed for calculating the IO bounty to eth for covering the tx cost.

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## Checks
<!-- It's important you've done these, or your PR will not be considered for review -->
By submitting this for review, I'm confirming I've done the following:
- [x] made this PR as small as possible
- [ ] unit-tested any new functionality
- [ ] linked any relevant issues or PRs
- [ ] included screenshots (if this involves a front-end change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Configuration Updates**
  * Added a new address to the protocol's security filter list, updating address restrictions to refine filtering behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->