### PR TITLE
Implement partial quote size for sushi market price

### DIFF
--- a/src/router/router.test.ts
+++ b/src/router/router.test.ts
@@ -929,6 +929,7 @@ describe("RainSolverRouter", () => {
                 mockSwapAmount,
                 mockGasPrice,
                 "single",
+                false,
             );
 
             sushiSpy.mockRestore();

--- a/src/router/router.ts
+++ b/src/router/router.ts
@@ -290,6 +290,7 @@ export class RainSolverRouter extends RainSolverRouterBase {
         maximumInputFixed: bigint,
         gasPriceBI: bigint,
         routeType: "single" | "multi" = "single",
+        absolute = false,
     ): bigint | undefined {
         return this.sushi?.findLargestTradeSize(
             orderDetails,
@@ -298,6 +299,7 @@ export class RainSolverRouter extends RainSolverRouterBase {
             maximumInputFixed,
             gasPriceBI,
             routeType,
+            absolute,
         );
     }
 

--- a/src/router/sushi/index.ts
+++ b/src/router/sushi/index.ts
@@ -482,6 +482,7 @@ export class SushiRouter extends RainSolverRouterBase {
         maximumInputFixed: bigint,
         gasPriceBI: bigint,
         routeType: "single" | "multi" = "single",
+        absolute = false,
     ): bigint | undefined {
         const result: bigint[] = [];
         const gasPrice = Number(gasPriceBI);
@@ -506,6 +507,9 @@ export class SushiRouter extends RainSolverRouterBase {
 
             if (route.status == "NoWay") {
                 maximumInput = maximumInput - initAmount / 2n ** i;
+            } else if (absolute) {
+                result.unshift(maxInput18);
+                maximumInput = maximumInput + initAmount / 2n ** i;
             } else {
                 const price = calculatePrice18(
                     maximumInput,

--- a/src/state/index.test.ts
+++ b/src/state/index.test.ts
@@ -441,7 +441,7 @@ describe("Test SharedState", () => {
             );
         });
 
-        it("should call getMarketPrice with correct params for partial size uhappy all", async () => {
+        it("should call getMarketPrice with correct params for partial size unhappy all", async () => {
             (sharedState.router.getMarketPrice as Mock)
                 .mockResolvedValueOnce(Result.err("error1"))
                 .mockResolvedValueOnce(Result.err("error2"));

--- a/src/state/index.test.ts
+++ b/src/state/index.test.ts
@@ -259,6 +259,7 @@ describe("Test SharedState", () => {
             initL1GasPrice: 0n,
             router: {
                 getMarketPrice: vi.fn(),
+                findLargestTradeSize: vi.fn(),
             },
             appOptions: { route: "multi" },
             gasManager: {
@@ -335,20 +336,29 @@ describe("Test SharedState", () => {
     });
 
     describe("Test getMarketPrice method", () => {
-        it("should call getMarketPrice with correct params", () => {
-            const token1 = new Token({
-                chainId: 1,
-                address: `0x${"1".repeat(40)}`,
-                symbol: "TKN1",
-                decimals: 18,
-            });
-            const token2 = new Token({
-                chainId: 1,
-                address: `0x${"2".repeat(40)}`,
-                symbol: "TKN2",
-                decimals: 18,
-            });
-            sharedState.getMarketPrice(token1, token2, 12345n);
+        const token1 = new Token({
+            chainId: 1,
+            address: `0x${"1".repeat(40)}`,
+            symbol: "TKN1",
+            decimals: 18,
+        });
+        const token2 = new Token({
+            chainId: 1,
+            address: `0x${"2".repeat(40)}`,
+            symbol: "TKN2",
+            decimals: 18,
+        });
+
+        it("should call getMarketPrice with correct params for 1 unit size happy", async () => {
+            (sharedState.router.getMarketPrice as Mock).mockResolvedValueOnce(
+                Result.ok({ price: 1n }),
+            );
+            const result = await sharedState.getMarketPrice(token1, token2, 12345n);
+
+            assert(result.isOk());
+            expect(result.value).toEqual({ price: 1n });
+            expect(sharedState.router.getMarketPrice).toHaveBeenCalledTimes(1);
+            expect(sharedState.router.findLargestTradeSize).not.toHaveBeenCalled();
             expect(sharedState.router.getMarketPrice).toHaveBeenCalledWith({
                 fromToken: token1,
                 toToken: token2,
@@ -358,6 +368,119 @@ describe("Test SharedState", () => {
                 amountIn: 1000000000000000000n,
                 sushiRouteType: sharedState.appOptions.route,
             });
+        });
+
+        it("should call getMarketPrice with correct params for partial size unhappy", async () => {
+            (sharedState.router.getMarketPrice as Mock).mockResolvedValueOnce(Result.err("error"));
+            (sharedState.router.findLargestTradeSize as Mock).mockReturnValueOnce(undefined);
+            const result = await sharedState.getMarketPrice(token1, token2, 12345n);
+
+            assert(result.isErr());
+            expect(result.error).toBe("error");
+            expect(sharedState.router.getMarketPrice).toHaveBeenCalledTimes(1);
+            expect(sharedState.router.findLargestTradeSize).toHaveBeenCalledTimes(1);
+            expect(sharedState.router.getMarketPrice).toHaveBeenCalledWith({
+                fromToken: token1,
+                toToken: token2,
+                blockNumber: 12345n,
+                skipFetch: false,
+                gasPrice: sharedState.gasPrice,
+                amountIn: 1000000000000000000n,
+                sushiRouteType: sharedState.appOptions.route,
+            });
+            expect(sharedState.router.findLargestTradeSize).toHaveBeenCalledWith(
+                { takeOrder: { quote: { ratio: 0n } } } as any,
+                token2,
+                token1,
+                1000000000000000000n,
+                sharedState.gasPrice,
+                sharedState.appOptions.route,
+                true,
+            );
+        });
+
+        it("should call getMarketPrice with correct params for partial size happy", async () => {
+            (sharedState.router.getMarketPrice as Mock)
+                .mockResolvedValueOnce(Result.err("error"))
+                .mockResolvedValueOnce(Result.ok({ price: 1n }));
+            (sharedState.router.findLargestTradeSize as Mock).mockReturnValueOnce(
+                500000000000000000n,
+            );
+            const result = await sharedState.getMarketPrice(token1, token2, 12345n);
+
+            assert(result.isOk());
+            expect(result.value).toEqual({ price: 1n });
+            expect(sharedState.router.getMarketPrice).toHaveBeenCalledTimes(2);
+            expect(sharedState.router.findLargestTradeSize).toHaveBeenCalledTimes(1);
+            expect(sharedState.router.getMarketPrice).toHaveBeenNthCalledWith(1, {
+                fromToken: token1,
+                toToken: token2,
+                blockNumber: 12345n,
+                skipFetch: false,
+                gasPrice: sharedState.gasPrice,
+                amountIn: 1000000000000000000n,
+                sushiRouteType: sharedState.appOptions.route,
+            });
+            expect(sharedState.router.getMarketPrice).toHaveBeenNthCalledWith(2, {
+                fromToken: token1,
+                toToken: token2,
+                blockNumber: 12345n,
+                skipFetch: false,
+                gasPrice: sharedState.gasPrice,
+                amountIn: 500000000000000000n,
+                sushiRouteType: sharedState.appOptions.route,
+            });
+            expect(sharedState.router.findLargestTradeSize).toHaveBeenCalledWith(
+                { takeOrder: { quote: { ratio: 0n } } } as any,
+                token2,
+                token1,
+                1000000000000000000n,
+                sharedState.gasPrice,
+                sharedState.appOptions.route,
+                true,
+            );
+        });
+
+        it("should call getMarketPrice with correct params for partial size uhappy all", async () => {
+            (sharedState.router.getMarketPrice as Mock)
+                .mockResolvedValueOnce(Result.err("error1"))
+                .mockResolvedValueOnce(Result.err("error2"));
+            (sharedState.router.findLargestTradeSize as Mock).mockReturnValueOnce(
+                500000000000000000n,
+            );
+            const result = await sharedState.getMarketPrice(token1, token2, 12345n);
+
+            assert(result.isErr());
+            expect(result.error).toBe("error1");
+            expect(sharedState.router.getMarketPrice).toHaveBeenCalledTimes(2);
+            expect(sharedState.router.findLargestTradeSize).toHaveBeenCalledTimes(1);
+            expect(sharedState.router.getMarketPrice).toHaveBeenNthCalledWith(1, {
+                fromToken: token1,
+                toToken: token2,
+                blockNumber: 12345n,
+                skipFetch: false,
+                gasPrice: sharedState.gasPrice,
+                amountIn: 1000000000000000000n,
+                sushiRouteType: sharedState.appOptions.route,
+            });
+            expect(sharedState.router.getMarketPrice).toHaveBeenNthCalledWith(2, {
+                fromToken: token1,
+                toToken: token2,
+                blockNumber: 12345n,
+                skipFetch: false,
+                gasPrice: sharedState.gasPrice,
+                amountIn: 500000000000000000n,
+                sushiRouteType: sharedState.appOptions.route,
+            });
+            expect(sharedState.router.findLargestTradeSize).toHaveBeenCalledWith(
+                { takeOrder: { quote: { ratio: 0n } } } as any,
+                token2,
+                token1,
+                1000000000000000000n,
+                sharedState.gasPrice,
+                sharedState.appOptions.route,
+                true,
+            );
         });
     });
 });

--- a/src/state/index.ts
+++ b/src/state/index.ts
@@ -330,13 +330,13 @@ export class SharedState {
             return result;
         }
         const partialAmountIn = this.router.findLargestTradeSize(
-            { takeOrder: { quote: { ratio: 0n } } } as any, // mocked as its unused
+            { takeOrder: { quote: { ratio: 0n } } } as any, // ratio unused when absolute
             toToken,
             fromToken,
             amountIn,
             this.gasPrice,
             this.appOptions.route,
-            true,
+            true, // absolute
         );
         if (typeof partialAmountIn !== "bigint") {
             return result;

--- a/src/state/index.ts
+++ b/src/state/index.ts
@@ -310,15 +310,49 @@ export class SharedState {
      * @param skipFetch - (optional) Skips a fresh onchain call to fetch pools
      * @returns The market price for the token pair or undefined if no route were found
      */
-    getMarketPrice(fromToken: Token, toToken: Token, blockNumber?: bigint, skipFetch?: boolean) {
-        return this.router.getMarketPrice({
+    async getMarketPrice(
+        fromToken: Token,
+        toToken: Token,
+        blockNumber?: bigint,
+        skipFetch?: boolean,
+    ) {
+        const amountIn = parseUnits("1", fromToken.decimals);
+        const result = await this.router.getMarketPrice({
             fromToken,
             toToken,
             blockNumber,
             gasPrice: this.gasPrice,
-            amountIn: parseUnits("1", fromToken.decimals),
+            amountIn,
             sushiRouteType: this.appOptions.route,
             skipFetch: !!skipFetch,
         });
+        if (result.isOk()) {
+            return result;
+        }
+        const partialAmountIn = this.router.findLargestTradeSize(
+            { takeOrder: { quote: { ratio: 0n } } } as any, // mocked as its unused
+            toToken,
+            fromToken,
+            amountIn,
+            this.gasPrice,
+            this.appOptions.route,
+            true,
+        );
+        if (typeof partialAmountIn !== "bigint") {
+            return result;
+        }
+        const partialResult = await this.router.getMarketPrice({
+            fromToken,
+            toToken,
+            blockNumber,
+            gasPrice: this.gasPrice,
+            amountIn: partialAmountIn,
+            sushiRouteType: this.appOptions.route,
+            skipFetch: !!skipFetch,
+        });
+        if (partialResult.isOk()) {
+            return partialResult;
+        }
+        return result;
     }
 }


### PR DESCRIPTION
<!-- Thanks for your Pull Request, please read the contributing guidelines before submitting. -->

## Motivation
This PR updates the logic for getting market price quote, where if the unit quote size (1 unit token) fails to give any valid result, partial sizes are also tried.
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## Checks
<!-- It's important you've done these, or your PR will not be considered for review -->
By submitting this for review, I'm confirming I've done the following:
- [x] made this PR as small as possible
- [x] unit-tested any new functionality
- [ ] linked any relevant issues or PRs
- [ ] included screenshots (if this involves a front-end change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Fallback market-price flow: if an initial price lookup fails, an alternative trade-size-based lookup is attempted.
  * Added an option to treat computed trade sizes as absolute, influencing how fallback sizes are chosen.

* **Bug Fixes**
  * Improved price-retrieval robustness by attempting a secondary, size-aware price check when the primary attempt fails.

* **Tests**
  * Expanded tests covering single-size, partial-size (happy/unhappy) and fallback scenarios.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->