### PR TITLE
fix: use withdraw4 for Orderbook V6 in intra-orderbook calldata

### DIFF
--- a/src/core/modes/intra/simulation.ts
+++ b/src/core/modes/intra/simulation.ts
@@ -265,7 +265,65 @@ export class IntraOrderbookTradeSimulator extends TradeSimulatorBase {
     }
 
     /**
-     * Builds the calldata for v4 order
+     * Builds the calldata for v4 order on Orderbook V6
+     * @param task - The ensure withdraw bounty task object
+     */
+    getCalldataForV4OrderV6(task: TaskType): `0x${string}` {
+        const withdrawInputCalldata = encodeFunctionData({
+            abi: ABI.Orderbook.V6.Primary.Orderbook,
+            functionName: "withdraw4",
+            args: [
+                this.tradeArgs.orderDetails.buyToken,
+                this.inputBountyVaultId,
+                maxFloat(this.tradeArgs.orderDetails.buyTokenDecimals),
+                [],
+            ],
+        });
+        const withdrawOutputCalldata = encodeFunctionData({
+            abi: ABI.Orderbook.V6.Primary.Orderbook,
+            functionName: "withdraw4",
+            args: [
+                this.tradeArgs.orderDetails.sellToken,
+                this.outputBountyVaultId,
+                maxFloat(this.tradeArgs.orderDetails.sellTokenDecimals),
+                this.tradeArgs.solver.appOptions.gasCoveragePercentage === "0" ? [] : [task],
+            ],
+        });
+        const clear3Calldata = encodeFunctionData({
+            abi: ABI.Orderbook.V6.Primary.Orderbook,
+            functionName: "clear3",
+            args: [
+                this.tradeArgs.orderDetails.takeOrder.struct.order,
+                this.tradeArgs.counterpartyOrderDetails.struct.order,
+                {
+                    aliceInputIOIndex: BigInt(
+                        this.tradeArgs.orderDetails.takeOrder.struct.inputIOIndex,
+                    ),
+                    aliceOutputIOIndex: BigInt(
+                        this.tradeArgs.orderDetails.takeOrder.struct.outputIOIndex,
+                    ),
+                    bobInputIOIndex: BigInt(
+                        this.tradeArgs.counterpartyOrderDetails.struct.inputIOIndex,
+                    ),
+                    bobOutputIOIndex: BigInt(
+                        this.tradeArgs.counterpartyOrderDetails.struct.outputIOIndex,
+                    ),
+                    aliceBountyVaultId: this.inputBountyVaultId,
+                    bobBountyVaultId: this.outputBountyVaultId,
+                },
+                [],
+                [],
+            ],
+        });
+        return encodeFunctionData({
+            abi: ABI.Orderbook.V6.Primary.Orderbook,
+            functionName: "multicall",
+            args: [[clear3Calldata, withdrawInputCalldata, withdrawOutputCalldata]],
+        });
+    }
+
+    /**
+     * Builds the calldata for v4 order on Orderbook V5
      * @param task - The ensure withdraw bounty task object
      */
     getCalldataForV4Order(task: TaskType): `0x${string}` {
@@ -329,6 +387,8 @@ export class IntraOrderbookTradeSimulator extends TradeSimulatorBase {
     getCalldata(task: TaskType): `0x${string}` {
         if (Pair.isV3(this.tradeArgs.orderDetails)) {
             return this.getCalldataForV3Order(task);
+        } else if (Pair.isV4OrderbookV6(this.tradeArgs.orderDetails)) {
+            return this.getCalldataForV4OrderV6(task);
         } else {
             return this.getCalldataForV4Order(task);
         }


### PR DESCRIPTION
## Summary
- `getCalldata` was routing all V4 orders to `getCalldataForV4Order`, which hardcodes `withdraw3` (Orderbook V5)
- Orderbook V6 replaced `withdraw3` with `withdraw4`, causing a revert in the multicall
- Added `getCalldataForV4OrderV6` using `ABI.Orderbook.V6.Primary.Orderbook` with `withdraw4` and `clear3`
- Updated dispatch to check `Pair.isV4OrderbookV6` before falling through to the V5 path
- Bumped `lib/sushiswap` submodule to [`1b2b675`](https://github.com/rainlanguage/sushiswap/commit/1b2b675effe0187889d3de66da2048e711a117e2) (rainlanguage/sushiswap#44) — adds cbBTC to Base routing bases so tokens only paired with cbBTC on Hydrex (e.g. wtMSTR) can be priced in ETH terms