### PR TITLE
test: mutation-harden protection unit coverage

### DIFF
--- a/src/order/protection.test.ts
+++ b/src/order/protection.test.ts
@@ -115,3 +115,171 @@ describe("Test downscaleProtection", () => {
         expect(ownerProfile?.limit).toBeGreaterThanOrEqual(1);
     });
 });
+
+/**
+ * Discriminating tests that pin the exact arithmetic of the limit-divide
+ * calculation in downscaleProtection: the per-owner-per-token ratio percent,
+ * the 4-segment divide factor, the cuts averaging across tokens, the per-vault
+ * balance averaging, and the final `max(round(limit/avgCut), 1)`.
+ *
+ * Each test builds fresh maps so the in-place mutation of `limit` cannot leak
+ * across tests.
+ */
+describe("Test downscaleProtection limit-divide arithmetic", () => {
+    // builds a fresh owners-profile map with a single owner whose limit is `limit`
+    function makeOwnersProfileMap(limit: number): OrderbooksOwnersProfileMap {
+        const ownerProfile = { orders: new Map(), limit } as any as OwnerProfile;
+        return new Map([["orderbook1", new Map([["owner1", ownerProfile]])]]);
+    }
+
+    // builds a vaults map for owner1 with the given token -> balances entries
+    function makeVaultsMap(tokenBalances: Record<string, bigint[]>): OrderbookOwnerTokenVaultsMap {
+        const tokenVaultMap = new Map(
+            Object.entries(tokenBalances).map(([token, balances]) => [
+                token,
+                new Map(balances.map((balance, i) => [BigInt(i), { id: BigInt(i), balance }])),
+            ]),
+        );
+        return new Map([["orderbook1", new Map([["owner1", tokenVaultMap]])]]) as any;
+    }
+
+    // mock readContract resolving the orderbook token balance keyed by token address
+    function mockObBalances(balances: Record<string, bigint>) {
+        (mockPublicClient.readContract as Mock).mockImplementation(
+            async (params: any) => balances[params.address],
+        );
+    }
+
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    // ratio percent => segment => divide factor, exercising every segment:
+    //   [0,25)->4   [25,50)->3   [50,75)->2   [75,100)->1   >=100->1
+    // single vault so avgBalance == ownerTotalBalance, single token so
+    // avgCut == that single factor, initial limit chosen so round() is exact.
+    it.each([
+        // ownerBal, obBal, otherOwners, pct, factor, initialLimit, expected
+        { ownerBal: 100n, obBal: 1000n, pct: 11n, factor: 4, limit: 12, expected: 3 }, // round(3)
+        { ownerBal: 300n, obBal: 1300n, pct: 30n, factor: 3, limit: 12, expected: 4 }, // round(4)
+        { ownerBal: 600n, obBal: 1600n, pct: 60n, factor: 2, limit: 12, expected: 6 }, // round(6)
+        { ownerBal: 800n, obBal: 1800n, pct: 80n, factor: 1, limit: 12, expected: 12 }, // round(12)
+        { ownerBal: 2000n, obBal: 3000n, pct: 200n, factor: 1, limit: 7, expected: 7 }, // >=100 -> 1
+    ])(
+        "computes divide factor $factor at ratio ~$pct% (limit $limit -> $expected)",
+        async ({ ownerBal, obBal, limit, expected }) => {
+            const ownersProfileMap = makeOwnersProfileMap(limit);
+            const vaults = makeVaultsMap({ "0xToken1": [ownerBal] });
+            mockObBalances({ "0xToken1": obBal });
+
+            await downscaleProtection(ownersProfileMap, vaults, mockPublicClient);
+
+            expect(ownersProfileMap.get("orderbook1")?.get("owner1")?.limit).toBe(expected);
+        },
+    );
+
+    // otherOwnersBalances === 0n short-circuits ratio percent to 100n -> factor 1,
+    // so the limit is left unchanged (round(limit/1) === limit). ownerTotal == obBal.
+    it("treats ratio as 100% (factor 1, unchanged limit) when no other-owner balance", async () => {
+        const ownersProfileMap = makeOwnersProfileMap(9);
+        const vaults = makeVaultsMap({ "0xToken1": [500n] });
+        mockObBalances({ "0xToken1": 500n }); // otherOwnersBalances = 500 - 500 = 0
+
+        await downscaleProtection(ownersProfileMap, vaults, mockPublicClient);
+
+        expect(ownersProfileMap.get("orderbook1")?.get("owner1")?.limit).toBe(9);
+    });
+
+    // averages vault balances: two vaults [200n, 400n] -> total 600, avg 300.
+    // ob = 1200 => otherOwners = 1200 - 600 = 600 => pct = (300*100)/600 = 50 => factor 2.
+    // If avg used the *sum* (600) instead, pct = (600*100)/600 = 100 => factor 1 => limit 8.
+    it("averages multiple vault balances (total/count) before computing the ratio", async () => {
+        const ownersProfileMap = makeOwnersProfileMap(8);
+        const vaults = makeVaultsMap({ "0xToken1": [200n, 400n] });
+        mockObBalances({ "0xToken1": 1200n });
+
+        await downscaleProtection(ownersProfileMap, vaults, mockPublicClient);
+
+        // factor 2 => round(8/2) = 4 (sum-instead-of-avg bug would give factor 1 => 8)
+        expect(ownersProfileMap.get("orderbook1")?.get("owner1")?.limit).toBe(4);
+    });
+
+    // averages the per-token divide factors:
+    //   token1: ownerBal 100, ob 1000 => pct 11 => factor 4
+    //   token2: ownerBal 800, ob 1800 => pct 80 => factor 1
+    //   avgCut = (4 + 1) / 2 = 2.5 => round(10 / 2.5) = 4
+    // If cuts were not averaged (e.g. last factor 1 only) limit would be 10;
+    // if summed (5) => round(10/5) = 2.
+    it("averages divide factors across an owner's tokens", async () => {
+        const ownersProfileMap = makeOwnersProfileMap(10);
+        const vaults = makeVaultsMap({
+            "0xToken1": [100n],
+            "0xToken2": [800n],
+        });
+        mockObBalances({ "0xToken1": 1000n, "0xToken2": 1800n });
+
+        await downscaleProtection(ownersProfileMap, vaults, mockPublicClient);
+
+        expect(ownersProfileMap.get("orderbook1")?.get("owner1")?.limit).toBe(4);
+    });
+
+    // enforces the minimum limit of 1: limit 1 / factor 4 = 0.25 => round = 0 => max(0,1) = 1.
+    it("clamps the reduced limit to a minimum of 1", async () => {
+        const ownersProfileMap = makeOwnersProfileMap(1);
+        const vaults = makeVaultsMap({ "0xToken1": [100n] }); // factor 4
+        mockObBalances({ "0xToken1": 1000n });
+
+        await downscaleProtection(ownersProfileMap, vaults, mockPublicClient);
+
+        expect(ownersProfileMap.get("orderbook1")?.get("owner1")?.limit).toBe(1);
+    });
+
+    // rounds (not truncates) the reduced limit: limit 10 / factor 4 = 2.5 => round = 3.
+    // truncation would give 2.
+    it("rounds the reduced limit to the nearest integer", async () => {
+        const ownersProfileMap = makeOwnersProfileMap(10);
+        const vaults = makeVaultsMap({ "0xToken1": [100n] }); // factor 4
+        mockObBalances({ "0xToken1": 1000n });
+
+        await downscaleProtection(ownersProfileMap, vaults, mockPublicClient);
+
+        expect(ownersProfileMap.get("orderbook1")?.get("owner1")?.limit).toBe(3);
+    });
+
+    // owners whose limit is admin-configured (case-insensitive key) are skipped
+    // entirely: no readContract, limit untouched even with a low-balance vault.
+    it("skips owners with an admin-configured limit (case-insensitive)", async () => {
+        const ownersProfileMap = makeOwnersProfileMap(25);
+        const vaults = makeVaultsMap({ "0xToken1": [100n] });
+        mockObBalances({ "0xToken1": 1000n });
+
+        await downscaleProtection(ownersProfileMap, vaults, mockPublicClient, { owner1: 5 });
+
+        expect(ownersProfileMap.get("orderbook1")?.get("owner1")?.limit).toBe(25);
+        expect(mockPublicClient.readContract as Mock).not.toHaveBeenCalled();
+    });
+
+    // when the orderbook token balance read fails (undefined), that token is
+    // skipped so it contributes no cut; with only that token the limit is unchanged.
+    it("skips a token whose orderbook balance read fails", async () => {
+        const ownersProfileMap = makeOwnersProfileMap(13);
+        const vaults = makeVaultsMap({ "0xToken1": [100n] });
+        (mockPublicClient.readContract as Mock).mockRejectedValue(new Error("rpc down"));
+
+        await downscaleProtection(ownersProfileMap, vaults, mockPublicClient);
+
+        expect(ownersProfileMap.get("orderbook1")?.get("owner1")?.limit).toBe(13);
+    });
+
+    // caches the orderbook token balance per (orderbook, token): two vaults of the
+    // same token trigger only a single readContract call.
+    it("reads each (orderbook, token) balance only once", async () => {
+        const ownersProfileMap = makeOwnersProfileMap(10);
+        const vaults = makeVaultsMap({ "0xToken1": [200n, 400n] });
+        mockObBalances({ "0xToken1": 1200n });
+
+        await downscaleProtection(ownersProfileMap, vaults, mockPublicClient);
+
+        expect(mockPublicClient.readContract as Mock).toHaveBeenCalledTimes(1);
+    });
+});

--- a/src/order/protection.test.ts
+++ b/src/order/protection.test.ts
@@ -122,8 +122,7 @@ describe("Test downscaleProtection", () => {
  * the 4-segment divide factor, the cuts averaging across tokens, the per-vault
  * balance averaging, and the final `max(round(limit/avgCut), 1)`.
  *
- * Each test builds fresh maps so the in-place mutation of `limit` cannot leak
- * across tests.
+ * Each test builds fresh maps, so each runs against its own isolated `limit`.
  */
 describe("Test downscaleProtection limit-divide arithmetic", () => {
     // builds a fresh owners-profile map with a single owner whose limit is `limit`
@@ -192,7 +191,6 @@ describe("Test downscaleProtection limit-divide arithmetic", () => {
 
     // averages vault balances: two vaults [200n, 400n] -> total 600, avg 300.
     // ob = 1200 => otherOwners = 1200 - 600 = 600 => pct = (300*100)/600 = 50 => factor 2.
-    // If avg used the *sum* (600) instead, pct = (600*100)/600 = 100 => factor 1 => limit 8.
     it("averages multiple vault balances (total/count) before computing the ratio", async () => {
         const ownersProfileMap = makeOwnersProfileMap(8);
         const vaults = makeVaultsMap({ "0xToken1": [200n, 400n] });
@@ -200,7 +198,7 @@ describe("Test downscaleProtection limit-divide arithmetic", () => {
 
         await downscaleProtection(ownersProfileMap, vaults, mockPublicClient);
 
-        // factor 2 => round(8/2) = 4 (sum-instead-of-avg bug would give factor 1 => 8)
+        // factor 2 => round(8/2) = 4
         expect(ownersProfileMap.get("orderbook1")?.get("owner1")?.limit).toBe(4);
     });
 
@@ -208,8 +206,6 @@ describe("Test downscaleProtection limit-divide arithmetic", () => {
     //   token1: ownerBal 100, ob 1000 => pct 11 => factor 4
     //   token2: ownerBal 800, ob 1800 => pct 80 => factor 1
     //   avgCut = (4 + 1) / 2 = 2.5 => round(10 / 2.5) = 4
-    // If cuts were not averaged (e.g. last factor 1 only) limit would be 10;
-    // if summed (5) => round(10/5) = 2.
     it("averages divide factors across an owner's tokens", async () => {
         const ownersProfileMap = makeOwnersProfileMap(10);
         const vaults = makeVaultsMap({
@@ -234,8 +230,7 @@ describe("Test downscaleProtection limit-divide arithmetic", () => {
         expect(ownersProfileMap.get("orderbook1")?.get("owner1")?.limit).toBe(1);
     });
 
-    // rounds (not truncates) the reduced limit: limit 10 / factor 4 = 2.5 => round = 3.
-    // truncation would give 2.
+    // rounds the reduced limit to the nearest integer: limit 10 / factor 4 = 2.5 => round = 3.
     it("rounds the reduced limit to the nearest integer", async () => {
         const ownersProfileMap = makeOwnersProfileMap(10);
         const vaults = makeVaultsMap({ "0xToken1": [100n] }); // factor 4


### PR DESCRIPTION
## Module hardened

`src/order/protection.ts` — `downscaleProtection`, the owner spam-protection that reduces each owner's per-round order limit by comparing the owner's average vault balance of a token against the rest of the orderbook's balance of that token. It was the weakest-covered qualifying module in `src/order/**` (branch coverage 68.75%, only 3 tests for 100 lines of dense limit-divide arithmetic and owner/token/vault grouping).

This PR is **tests-only** — no change to `src/order/protection.ts` (verified `git diff src/order/protection.ts` empty). It adds a `downscaleProtection limit-divide arithmetic` block with 13 discriminating cases that pin each intermediate of the calculation to an exact value.

## Mutation matrix

Each behavior's source line was mutated and the protection suite re-run. The pre-existing 3 tests left **9 of 13** mutants alive; the new tests kill all 13.

| # | Mutation (behavior) | Pre-existing 3 tests | With new tests |
|---|---|---|---|
| 1 | `Math.max(round(limit/avgCut), 1)` → drop `max` (min-1 clamp) | KILLED | KILLED |
| 2 | `Math.round` → `Math.trunc` (rounding) | KILLED | KILLED |
| 3 | `cuts.reduce(+)/cuts.length` → drop `/length` (per-token cut averaging) | **SURVIVED** | KILLED |
| 4 | `reduce((a,b)=>a+b)` → `(a,b)=>a` (cut sum) | KILLED | KILLED |
| 5 | `ownerTotal / BigInt(vaults.length)` → drop divide (per-vault avg) | **SURVIVED** | KILLED |
| 6 | `obTokenBalance - ownerTotal` → `+` (other-owners balance) | **SURVIVED** | KILLED |
| 7 | `=== 0n ? 100n` → `? 1n` (zero-balance ratio short-circuit) | **SURVIVED** | KILLED |
| 8 | `avgBalance * 100n` → `* 50n` (ratio percent scaling) | **SURVIVED** | KILLED |
| 9 | `Math.min(., 3)` → `min(., 2)` (segment cap) | **SURVIVED** | KILLED |
| 10 | `- 4` → `- 5` (segment offset) | KILLED | KILLED |
| 11 | `/ 25n` → `/ 20n` (segment width) | **SURVIVED** | KILLED |
| 12 | admin-limit `continue` → disabled (skip admin-set owners) | **SURVIVED** | KILLED |
| 13 | `obTokenBalance === undefined) continue` → disabled (skip failed read) | **SURVIVED** | KILLED |

## Gaps checklist (behaviors now pinned)

- [x] 4-segment divide factor across every band: `[0,25)→4`, `[25,50)→3`, `[50,75)→2`, `[75,100)→1`, `≥100→1` (parametrized)
- [x] zero other-owner balance short-circuits ratio to 100% → factor 1 → limit unchanged
- [x] per-vault balance averaging (`total/count`, not sum) before the ratio
- [x] per-token divide-factor averaging (`avgCut = sum(cuts)/count`)
- [x] `max(round(limit/avgCut), 1)` — both the rounding (2.5→3, not 2) and the min-of-1 clamp
- [x] admin-configured owners skipped entirely (no `readContract`, limit untouched)
- [x] token whose orderbook balance read fails is skipped (contributes no cut)
- [x] orderbook token balance cached per `(orderbook, token)` — one `readContract` for two vaults of the same token

## Verification

- `tsc -p tsconfig.check.json` clean; `eslint src/order/protection.test.ts` clean.
- Order suite: 8 files, **92 tests** pass (was 79; +13).
- Full vitest unit suite: 59 files, **854 tests** pass.
- The `e2e fork test` jobs are a pre-existing **environmental** red (RPC/secrets), unrelated to this change; no e2e/fork tests touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
