### PR TITLE
test: mutation-harden router.ts unit coverage

### DIFF
--- a/src/router/router.test.ts
+++ b/src/router/router.test.ts
@@ -992,6 +992,203 @@ describe("RainSolverRouter", () => {
             expect(result).toEqual([]);
         });
     });
+
+    // ---- mutation-hardening: cache mechanism ----
+    describe("test cache mechanism", () => {
+        const mockParams: RainSolverRouterQuoteParams = {
+            fromToken: mockTokenIn,
+            toToken: mockTokenOut,
+            amountIn: mockSwapAmount,
+            gasPrice,
+        };
+
+        function setupSushiOk() {
+            const sushiSpy = vi.spyOn(mockSushiRouter, "getMarketPrice");
+            sushiSpy.mockResolvedValue(Result.ok({ price: "1" }) as any);
+            const tryQuoteSpy = vi.spyOn(mockSushiRouter, "tryQuote");
+            tryQuoteSpy.mockResolvedValue(
+                Result.ok({
+                    type: RouterType.Sushi,
+                    status: RouteStatus.Success,
+                    price: 1n,
+                    amountOut: 1n,
+                }) as any,
+            );
+            const bestSpy = vi.spyOn(mockSushiRouter, "findBestRoute");
+            bestSpy.mockResolvedValue(
+                Result.ok({
+                    type: RouterType.Sushi,
+                    status: RouteStatus.Success,
+                    price: 1n,
+                    amountOut: 1n,
+                }) as any,
+            );
+            const tradeSpy = vi.spyOn(mockSushiRouter, "getTradeParams");
+            tradeSpy.mockResolvedValue(
+                Result.ok({
+                    type: RouterType.Sushi,
+                    quote: {
+                        type: RouterType.Sushi,
+                        status: RouteStatus.Success,
+                        price: 1n,
+                        amountOut: 1n,
+                    },
+                    routeVisual: [],
+                    takeOrdersConfigStruct: {} as any,
+                }) as any,
+            );
+        }
+
+        function cacheCount(): number | undefined {
+            // key is stable per fromToken so there is exactly one entry
+            return [...router.cache.values()][0];
+        }
+
+        it("getMarketPrice increments cache count per call and caps at 4", async () => {
+            setupSushiOk();
+            const seen: (number | undefined)[] = [];
+            for (let i = 0; i < 6; i++) {
+                await router.getMarketPrice(mockParams);
+                seen.push(cacheCount());
+            }
+            // first call sets 1, then +1 each call, capped at 4
+            expect(seen).toEqual([1, 2, 3, 4, 4, 4]);
+            // exactly one cache entry (key only depends on fromToken)
+            expect(router.cache.size).toBe(1);
+        });
+
+        it("tryQuote increments cache count per call and caps at 4", async () => {
+            setupSushiOk();
+            const seen: (number | undefined)[] = [];
+            for (let i = 0; i < 6; i++) {
+                await router.tryQuote(mockParams);
+                seen.push(cacheCount());
+            }
+            expect(seen).toEqual([1, 2, 3, 4, 4, 4]);
+            expect(router.cache.size).toBe(1);
+        });
+
+        it("findBestRoute increments cache count per call and caps at 4", async () => {
+            setupSushiOk();
+            const seen: (number | undefined)[] = [];
+            for (let i = 0; i < 6; i++) {
+                await router.findBestRoute(mockParams);
+                seen.push(cacheCount());
+            }
+            expect(seen).toEqual([1, 2, 3, 4, 4, 4]);
+            expect(router.cache.size).toBe(1);
+        });
+
+        it("getTradeParams increments cache count per call and caps at 4", async () => {
+            setupSushiOk();
+            const args = {
+                state: { appOptions: { maxRatio: true }, watchedTokens: new Map() },
+                maximumInput: mockSwapAmount,
+                orderDetails: { takeOrder: { struct: {} } },
+                toToken: mockTokenOut,
+                fromToken: mockTokenIn,
+                signer: { account: { address: "0xsigner" } },
+                isPartial: false,
+            } as any;
+            const seen: (number | undefined)[] = [];
+            for (let i = 0; i < 6; i++) {
+                await router.getTradeParams(args);
+                seen.push(cacheCount());
+            }
+            expect(seen).toEqual([1, 2, 3, 4, 4, 4]);
+            expect(router.cache.size).toBe(1);
+        });
+
+        it("reset clears router, balancer and stabull caches but not sushi cache", () => {
+            // attach real caches to mocks to observe clear behaviour
+            (router.cache as Map<string, number>).set("a", 3);
+            (router.balancer as any).cache = new Map([["b", {} as any]]);
+            (router.stabull as any).cache = new Map([["c", {} as any]]);
+            (router.sushi as any).cache = new Map([["d", {} as any]]);
+
+            router.reset();
+
+            expect(router.cache.size).toBe(0);
+            expect((router.balancer as any).cache.size).toBe(0);
+            expect((router.stabull as any).cache.size).toBe(0);
+            // reset intentionally does NOT clear sushi cache
+            expect((router.sushi as any).cache.size).toBe(1);
+        });
+    });
+
+    // ---- mutation-hardening: getError classification + underlying error propagation ----
+    describe("test getError classification", () => {
+        const mockParams: RainSolverRouterQuoteParams = {
+            fromToken: mockTokenIn,
+            toToken: mockTokenOut,
+            amountIn: mockSwapAmount,
+            gasPrice,
+        };
+
+        it("classifies mixed NoRouteFound + FetchFailed as FetchFailed (not NoRouteFound)", async () => {
+            const sushiErr = new SushiRouterError("sushi nrf", SushiRouterErrorType.NoRouteFound);
+            const balancerErr = new BalancerRouterError(
+                "balancer fetch",
+                BalancerRouterErrorType.FetchFailed,
+            );
+            const stabullErr = new StabullRouterError(
+                "stabull nrf",
+                StabullRouterErrorType.NoRouteFound,
+            );
+
+            vi.spyOn(mockSushiRouter, "findBestRoute").mockResolvedValue(
+                Result.err(sushiErr) as any,
+            );
+            vi.spyOn(mockBalancerRouter, "findBestRoute").mockResolvedValue(
+                Result.err(balancerErr) as any,
+            );
+            vi.spyOn(mockStabullRouter, "findBestRoute").mockResolvedValue(
+                Result.err(stabullErr) as any,
+            );
+
+            const result = await router.findBestRoute(mockParams);
+
+            assert(result.isErr());
+            // one of the three is FetchFailed -> overall must be FetchFailed
+            expect(result.error.typ).toBe(RainSolverRouterErrorType.FetchFailed);
+        });
+
+        it("propagates each underlying error and concatenates their messages", async () => {
+            const sushiErr = new SushiRouterError("sushi boom", SushiRouterErrorType.NoRouteFound);
+            const balancerErr = new BalancerRouterError(
+                "balancer boom",
+                BalancerRouterErrorType.NoRouteFound,
+            );
+            const stabullErr = new StabullRouterError(
+                "stabull boom",
+                StabullRouterErrorType.NoRouteFound,
+            );
+
+            vi.spyOn(mockSushiRouter, "findBestRoute").mockResolvedValue(
+                Result.err(sushiErr) as any,
+            );
+            vi.spyOn(mockBalancerRouter, "findBestRoute").mockResolvedValue(
+                Result.err(balancerErr) as any,
+            );
+            vi.spyOn(mockStabullRouter, "findBestRoute").mockResolvedValue(
+                Result.err(stabullErr) as any,
+            );
+
+            const result = await router.findBestRoute(mockParams);
+
+            assert(result.isErr());
+            expect(result.error.typ).toBe(RainSolverRouterErrorType.NoRouteFound);
+            // exact underlying errors are carried through in the correct slots
+            expect(result.error.sushiError).toBe(sushiErr);
+            expect(result.error.balancerError).toBe(balancerErr);
+            expect(result.error.stabullError).toBe(stabullErr);
+            // and their messages are concatenated into the top-level message
+            expect(result.error.message).toContain("Failed to find best route");
+            expect(result.error.message).toContain("SushiRouterError: sushi boom");
+            expect(result.error.message).toContain("BalancerRouterError: balancer boom");
+            expect(result.error.message).toContain("StabullRouterError: stabull boom");
+        });
+    });
 });
 
 // Helper functions to create mock objects

--- a/src/router/router.test.ts
+++ b/src/router/router.test.ts
@@ -993,7 +993,7 @@ describe("RainSolverRouter", () => {
         });
     });
 
-    // ---- mutation-hardening: cache mechanism ----
+    // The router caches a per-fromToken call count, capped at 4, shared across quote methods.
     describe("test cache mechanism", () => {
         const mockParams: RainSolverRouterQuoteParams = {
             fromToken: mockTokenIn,
@@ -1116,7 +1116,7 @@ describe("RainSolverRouter", () => {
         });
     });
 
-    // ---- mutation-hardening: getError classification + underlying error propagation ----
+    // getError classifies the combined error type and propagates each underlying router error.
     describe("test getError classification", () => {
         const mockParams: RainSolverRouterQuoteParams = {
             fromToken: mockTokenIn,


### PR DESCRIPTION
## Module hardened
`src/router/router.ts` — `RainSolverRouter` (route selection / quote aggregation module).

Adversarial mutation-test pass on the **unit** suite (`src/router/router.test.ts`). Tests-only: `src/router/router.ts` is unchanged. Adds 7 tests (30 → 37), all mutation-validated — each new test passes on clean source and fails under a targeted source mutation.

## Gaps found (previously surviving mutants)
The existing suite exercised the create/sort/selection happy paths but never inspected the router's runtime cache, never called `reset()`, and only exercised the `getError` classifier with uniform error types. Probed on the **clean** suite, these mutants survived:

- [x] `getMarketPrice` cache cap `value < 4` → `value <= 4` — **survived** (no test read `router.cache`)
- [x] `getError` mixed-type classification (drop the balancer NoRouteFound clause) — **survived** (only uniform all-NoRouteFound / all-FetchFailed cases existed)

## Mutation matrix (all KILLED by the new tests)
| # | Location | Mutation | Result |
|---|----------|----------|--------|
| A | getMarketPrice L146 | `value < 4` → `<= 4` | KILLED |
| C1 | tryQuote L186 | `value < 4` → `<= 4` | KILLED |
| C2 | findBestRoute L224 | `value < 4` → `<= 4` | KILLED |
| C3 | getTradeParams L258 | `value < 4` → `<= 4` | KILLED |
| D | getMarketPrice L146 | drop `++value` (`set(key, value)`) | KILLED |
| E | getMarketPrice L145 | `typeof value === "number"` → `!==` | KILLED |
| F1 | reset L316 | drop `this.cache.clear()` | KILLED |
| F2 | reset L317 | drop `this.balancer?.cache.clear()` | KILLED |
| F3 | reset L318 | drop `this.stabull?.cache.clear()` | KILLED |
| F4 | reset L318 | **add** `this.sushi?.cache.clear()` (negative) | KILLED |
| B | getError L334 | balancer NoRouteFound clause → `true` | KILLED |
| G | getError L329 | default `FetchFailed` → `NoRouteFound` | KILLED |
| H | getError L347/348 | swap `balancerError`/`stabullError` ctor args | KILLED |

13/13 targeted mutants killed; source restored pristine after each (`git diff src/router/router.ts` empty).

## Behaviours now covered
- **Per-pair query cache** across all four query methods: first call records `1`, each subsequent call increments, capped at `4` (`1,2,3,4,4,4`); exactly one cache entry per `fromToken`.
- **`reset()`** clears the router, balancer and stabull caches and intentionally leaves the sushi cache untouched.
- **`getError()`**: a mixed `NoRouteFound + FetchFailed` result set classifies as `FetchFailed` (not `NoRouteFound`); each underlying router error is carried into its correct slot (`sushiError`/`balancerError`/`stabullError`) and concatenated into the top-level message.

## Verification
- `vitest run src/router/router.test.ts` → 37/37 pass.
- Full unit suite (`vitest run --exclude ./src/logger/index.test.ts`) → **59 files / 848 tests pass**.
- `tsc -p tsconfig.check.json` clean; `eslint src/router/router.test.ts` clean.
- The `e2e fork test` jobs are a pre-existing environmental red (require RPC/secrets) and are unrelated to this change.

## Note (not fixed here — tests-only)
The cache key in all four methods reads `params.toToken.address.toLowerCase` without invoking it (missing `()`), so the key depends only on `fromToken`. Behaviour is deterministic (the bad fragment is constant), so the cache still functions per-`fromToken`; surfaced here for visibility but left untouched per the tests-only scope of this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)