### PR TITLE
test: mutation-harden math unit coverage

### DIFF
--- a/src/math/index.test.ts
+++ b/src/math/index.test.ts
@@ -76,13 +76,13 @@ describe("Test math functions", () => {
     });
 
     it("should convert a bigint to its 18-decimal float number", async function () {
-        // exactly one ether -> 1 (pins the 18-decimals divisor: any other decimals shifts the value)
+        // Exactly one ether scales by the 18-decimals divisor to 1.
         assert.strictEqual(toNumber(ONE18), 1);
 
-        // fractional value -> retains the fractional part (rules out integer-only truncation)
+        // A fractional value retains its fractional part.
         assert.strictEqual(toNumber(1_500_000_000_000_000_000n), 1.5);
 
-        // larger whole multiple of one ether (pins exact scaling, not just "non-zero")
+        // A whole multiple of one ether scales to that multiple.
         assert.strictEqual(toNumber(123n * ONE18), 123);
 
         // zero maps to zero
@@ -91,45 +91,44 @@ describe("Test math functions", () => {
 
     describe("Test isBigNumberish", () => {
         it("should accept integer numbers but reject non-integer numbers", async function () {
-            // integer number -> true (kills `value % 1 === 0` -> `!== 0`)
+            // An integer number is numberish.
             assert.strictEqual(isBigNumberish(5), true);
             assert.strictEqual(isBigNumberish(0), true);
-            // non-integer number -> false (kills relaxing the modulo check / dropping it)
+            // A non-integer number is not numberish.
             assert.strictEqual(isBigNumberish(5.5), false);
             assert.strictEqual(isBigNumberish(0.1), false);
         });
 
         it("should accept all-digit strings (optionally signed) but reject other strings", async function () {
-            // all-digit string -> true (kills regex branch removal)
+            // An all-digit string is numberish.
             assert.strictEqual(isBigNumberish("123"), true);
-            // leading-minus all-digit string -> true (pins the `-?` regex prefix)
+            // A leading-minus all-digit string is numberish.
             assert.strictEqual(isBigNumberish("-123"), true);
-            // decimal string -> false (kills an over-broad regex that would allow a dot)
+            // A string containing a decimal point is not numberish.
             assert.strictEqual(isBigNumberish("12.3"), false);
-            // non-numeric string -> false
+            // A non-numeric string is not numberish.
             assert.strictEqual(isBigNumberish("abc"), false);
-            // empty string -> false (no digits to match)
+            // An empty string is not numberish.
             assert.strictEqual(isBigNumberish(""), false);
         });
 
         it("should accept hex strings via the isHex branch", async function () {
-            // hex string with letters -> only the isHex branch can accept it
-            // (the digit regex rejects the `x` and letters, it is not a bigint/bytes)
+            // A hex string is numberish via the isHex branch.
             assert.strictEqual(isBigNumberish("0xabcdef"), true);
         });
 
         it("should accept bigint and byte-array values", async function () {
-            // bigint -> true (kills `typeof value === "bigint"` branch removal)
+            // A bigint is numberish.
             assert.strictEqual(isBigNumberish(7n), true);
-            // byte array -> true (kills isBytes branch removal)
+            // A byte array is numberish via the isBytes branch.
             assert.strictEqual(isBigNumberish(new Uint8Array([1, 2, 3])), true);
         });
 
         it("should reject nullish and non-numberish values", async function () {
-            // null/undefined -> false (kills the `value != null` guard -> `== null`)
+            // null and undefined are not numberish.
             assert.strictEqual(isBigNumberish(null), false);
             assert.strictEqual(isBigNumberish(undefined), false);
-            // plain object -> false (none of the branches match)
+            // A plain object is not numberish.
             assert.strictEqual(isBigNumberish({}), false);
         });
     });

--- a/src/math/index.test.ts
+++ b/src/math/index.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, assert } from "vitest";
-import { scaleTo18, scaleFrom18, calculatePrice18, ONE18 } from ".";
+import { scaleTo18, scaleFrom18, calculatePrice18, toNumber, isBigNumberish, ONE18 } from ".";
 import { maxUint256 } from "viem";
 
 describe("Test math functions", () => {
@@ -73,5 +73,64 @@ describe("Test math functions", () => {
 
         // Expected: 1 * 1e18 / 1 = 1e18 (price of 1 in 18 decimal fixed point)
         assert.deepEqual(priceSmall, ONE18);
+    });
+
+    it("should convert a bigint to its 18-decimal float number", async function () {
+        // exactly one ether -> 1 (pins the 18-decimals divisor: any other decimals shifts the value)
+        assert.strictEqual(toNumber(ONE18), 1);
+
+        // fractional value -> retains the fractional part (rules out integer-only truncation)
+        assert.strictEqual(toNumber(1_500_000_000_000_000_000n), 1.5);
+
+        // larger whole multiple of one ether (pins exact scaling, not just "non-zero")
+        assert.strictEqual(toNumber(123n * ONE18), 123);
+
+        // zero maps to zero
+        assert.strictEqual(toNumber(0n), 0);
+    });
+
+    describe("Test isBigNumberish", () => {
+        it("should accept integer numbers but reject non-integer numbers", async function () {
+            // integer number -> true (kills `value % 1 === 0` -> `!== 0`)
+            assert.strictEqual(isBigNumberish(5), true);
+            assert.strictEqual(isBigNumberish(0), true);
+            // non-integer number -> false (kills relaxing the modulo check / dropping it)
+            assert.strictEqual(isBigNumberish(5.5), false);
+            assert.strictEqual(isBigNumberish(0.1), false);
+        });
+
+        it("should accept all-digit strings (optionally signed) but reject other strings", async function () {
+            // all-digit string -> true (kills regex branch removal)
+            assert.strictEqual(isBigNumberish("123"), true);
+            // leading-minus all-digit string -> true (pins the `-?` regex prefix)
+            assert.strictEqual(isBigNumberish("-123"), true);
+            // decimal string -> false (kills an over-broad regex that would allow a dot)
+            assert.strictEqual(isBigNumberish("12.3"), false);
+            // non-numeric string -> false
+            assert.strictEqual(isBigNumberish("abc"), false);
+            // empty string -> false (no digits to match)
+            assert.strictEqual(isBigNumberish(""), false);
+        });
+
+        it("should accept hex strings via the isHex branch", async function () {
+            // hex string with letters -> only the isHex branch can accept it
+            // (the digit regex rejects the `x` and letters, it is not a bigint/bytes)
+            assert.strictEqual(isBigNumberish("0xabcdef"), true);
+        });
+
+        it("should accept bigint and byte-array values", async function () {
+            // bigint -> true (kills `typeof value === "bigint"` branch removal)
+            assert.strictEqual(isBigNumberish(7n), true);
+            // byte array -> true (kills isBytes branch removal)
+            assert.strictEqual(isBigNumberish(new Uint8Array([1, 2, 3])), true);
+        });
+
+        it("should reject nullish and non-numberish values", async function () {
+            // null/undefined -> false (kills the `value != null` guard -> `== null`)
+            assert.strictEqual(isBigNumberish(null), false);
+            assert.strictEqual(isBigNumberish(undefined), false);
+            // plain object -> false (none of the branches match)
+            assert.strictEqual(isBigNumberish({}), false);
+        });
     });
 });


### PR DESCRIPTION
## Module hardened

`src/math/index.ts` — selected as the weakest qualifying module from `vitest run --coverage` over the in-scope modules (excluding `order/`, `router/`, `gas/`, the core solve loop, `index`, and `config`). It had the lowest **branch** coverage (73.33%), driven entirely by two exported functions that had **zero** test coverage: `toNumber` and `isBigNumberish`. Every mutant planted in them survived the existing suite.

This PR is **tests-only** — no source line changed (`git diff` touches only `src/math/index.test.ts`).

## Mutation matrix

Each mutation was applied to the exact source line, the math suite re-run, then the line restored.

### Pre-existing coverage — already killed by existing tests (audited, left as-is)
| Behavior | Mutation | Result |
|---|---|---|
| `scaleTo18` down-branch | `value / 10^(d-18)` → `* ` | KILLED |
| `scaleTo18` up-branch | `value * 10^(18-d)` → `/ ` | KILLED |
| `scaleTo18` operand | `repeat(d-18)` → `repeat(18-d)` | KILLED |
| `scaleFrom18` up-branch | `* ` → `/ ` | KILLED |
| `scaleFrom18` down-branch | `/ ` → `* ` | KILLED |
| `calculatePrice18` zero guard | `amountIn === 0n` → `!== 0n` | KILLED |
| `calculatePrice18` numerator | `out18 * ONE18` → `out18 / ONE18` | KILLED |
| `calculatePrice18` denominator | `/ amountIn18` → `* amountIn18` | KILLED |
| `calculatePrice18` out decimals | `decimalsOut` → `decimalsIn` | KILLED |
| `calculatePrice18` in decimals | `decimalsIn` → `decimalsOut` | KILLED |

### New coverage — mutants that SURVIVED before, now KILLED by added tests
| Behavior | Mutation | Before | After |
|---|---|---|---|
| `toNumber` scaling | `formatUnits(v, 18)` → `17` | SURVIVED | KILLED |
| `toNumber` scaling | `formatUnits(v, 18)` → `19` | SURVIVED | KILLED |
| `isBigNumberish` int check | `value % 1 === 0` → `!== 0` | SURVIVED | KILLED |
| `isBigNumberish` number branch | drop branch (→ false) | SURVIVED | KILLED |
| `isBigNumberish` string branch | drop branch (→ false) | SURVIVED | KILLED |
| `isBigNumberish` regex sign | `/^-?[0-9]+$/` → drop `-?` | SURVIVED | KILLED |
| `isBigNumberish` regex dot | `/^-?[0-9]+$/` → allow `.` | SURVIVED | KILLED |
| `isBigNumberish` isHex branch | drop `isHex(value)` | SURVIVED | KILLED |
| `isBigNumberish` bigint branch | drop `typeof === "bigint"` | SURVIVED | KILLED |
| `isBigNumberish` isBytes branch | drop `isBytes(value)` | SURVIVED | KILLED |
| `isBigNumberish` null guard | `value != null` → `== null` | SURVIVED | KILLED |

## Gaps checklist
- [x] `toNumber` — fully covered (4 discriminating values pinning the 18-decimal scale).
- [x] `isBigNumberish` — every OR-branch independently pinned by a discriminating case.
- [x] `scaleTo18` / `scaleFrom18` / `calculatePrice18` — pre-existing tests audited, all mutants killed.
- [ ] `scaleTo18` / `scaleFrom18` boundary `> 18` → `>= 18`: **equivalent mutant** (at exactly 18 decimals both branches compute `value * 1 == value / 1 == value`); no test can distinguish — left uncovered intentionally.

## Verification
- `tsc -p tsconfig.check.json` clean.
- `eslint` clean on the changed test file.
- Full vitest unit suite green: **847 tests passed** (was 841; +6 new tests), 59 files.
- `e2e fork test` jobs are a pre-existing environmental red (RPC/secrets), out of scope and not touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)