### PR TITLE
Add `signedContext` to `clear3/4`

### DIFF
--- a/src/core/modes/intra/simulation.test.ts
+++ b/src/core/modes/intra/simulation.test.ts
@@ -104,7 +104,7 @@ describe("Test IntraOrderbookTradeSimulator", () => {
                 struct: {
                     inputIOIndex: 0,
                     outputIOIndex: 1,
-                    signedContext: [],
+                    signedContext: ["bob"],
                 } as any,
             },
             inputBalance: 2n,
@@ -611,7 +611,7 @@ describe("Test IntraOrderbookTradeSimulator", () => {
     describe("Test getCalldataForV4Order method", () => {
         it("should return for pair v4", () => {
             simulator.tradeArgs.orderDetails.takeOrder.struct.order.type = Order.Type.V4;
-            simulator.tradeArgs.orderDetails.takeOrder.struct.signedContext = [];
+            simulator.tradeArgs.orderDetails.takeOrder.struct.signedContext = ["alice"];
             (maxFloat as Mock).mockReturnValue("0x1234");
             (encodeFunctionData as Mock)
                 .mockReturnValue("default")

--- a/src/core/modes/intra/simulation.test.ts
+++ b/src/core/modes/intra/simulation.test.ts
@@ -42,7 +42,11 @@ function makeOrderDetails(ratio = ONE18): Pair {
         sellTokenDecimals: 18,
         buyTokenDecimals: 18,
         takeOrder: {
-            struct: { order: { type: Order.Type.V3 }, inputIOIndex: 1, outputIOIndex: 0 },
+            struct: {
+                order: { type: Order.Type.V3 },
+                inputIOIndex: 1,
+                outputIOIndex: 0,
+            },
             quote: { ratio },
         },
     } as Pair;
@@ -100,6 +104,7 @@ describe("Test IntraOrderbookTradeSimulator", () => {
                 struct: {
                     inputIOIndex: 0,
                     outputIOIndex: 1,
+                    signedContext: [],
                 } as any,
             },
             inputBalance: 2n,
@@ -606,6 +611,7 @@ describe("Test IntraOrderbookTradeSimulator", () => {
     describe("Test getCalldataForV4Order method", () => {
         it("should return for pair v4", () => {
             simulator.tradeArgs.orderDetails.takeOrder.struct.order.type = Order.Type.V4;
+            simulator.tradeArgs.orderDetails.takeOrder.struct.signedContext = [];
             (maxFloat as Mock).mockReturnValue("0x1234");
             (encodeFunctionData as Mock)
                 .mockReturnValue("default")
@@ -659,8 +665,8 @@ describe("Test IntraOrderbookTradeSimulator", () => {
                         aliceBountyVaultId: simulator.inputBountyVaultId,
                         bobBountyVaultId: simulator.outputBountyVaultId,
                     },
-                    [],
-                    [],
+                    simulator.tradeArgs.orderDetails.takeOrder.struct.signedContext,
+                    simulator.tradeArgs.counterpartyOrderDetails.struct.signedContext,
                 ],
             });
             expect(encodeFunctionData).toHaveBeenNthCalledWith(4, {

--- a/src/core/modes/intra/simulation.ts
+++ b/src/core/modes/intra/simulation.ts
@@ -311,8 +311,8 @@ export class IntraOrderbookTradeSimulator extends TradeSimulatorBase {
                     aliceBountyVaultId: this.inputBountyVaultId,
                     bobBountyVaultId: this.outputBountyVaultId,
                 },
-                [],
-                [],
+                this.tradeArgs.orderDetails.takeOrder.struct.signedContext,
+                this.tradeArgs.counterpartyOrderDetails.struct.signedContext,
             ],
         });
         return encodeFunctionData({
@@ -369,8 +369,8 @@ export class IntraOrderbookTradeSimulator extends TradeSimulatorBase {
                     aliceBountyVaultId: this.inputBountyVaultId,
                     bobBountyVaultId: this.outputBountyVaultId,
                 },
-                [],
-                [],
+                this.tradeArgs.orderDetails.takeOrder.struct.signedContext,
+                this.tradeArgs.counterpartyOrderDetails.struct.signedContext,
             ],
         });
         return encodeFunctionData({


### PR DESCRIPTION
<!-- Thanks for your Pull Request, please read the contributing guidelines before submitting. -->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## Checks
<!-- It's important you've done these, or your PR will not be considered for review -->
By submitting this for review, I'm confirming I've done the following:
- [x] made this PR as small as possible
- [x] unit-tested any new functionality
- [ ] linked any relevant issues or PRs
- [ ] included screenshots (if this involves a front-end change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated trade simulation to include the correct signed context for both sides of an intra-orderbook order.
  * Calldata generated for clearing orders now carries the expected order-specific context instead of empty values.
  * Improved test coverage to reflect the updated calldata and context behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->