### PR TITLE
Cross-assign signed context for intra clear3

### DIFF
--- a/src/core/modes/intra/simulation.test.ts
+++ b/src/core/modes/intra/simulation.test.ts
@@ -608,10 +608,36 @@ describe("Test IntraOrderbookTradeSimulator", () => {
         });
     });
 
+    describe("Test getClearSignedContexts method", () => {
+        it("cross-assigns signed context for clear3", () => {
+            const primaryContext = [
+                {
+                    signer: "0x0000000000000000000000000000000000000001",
+                    context: ["0x01"],
+                    signature: "0xsig1",
+                },
+            ];
+            const counterpartyContext = [
+                {
+                    signer: "0x0000000000000000000000000000000000000002",
+                    context: ["0x02"],
+                    signature: "0xsig2",
+                },
+            ];
+            simulator.tradeArgs.orderDetails.takeOrder.struct.signedContext = primaryContext;
+            simulator.tradeArgs.counterpartyOrderDetails.struct.signedContext = counterpartyContext;
+
+            expect(simulator.getClearSignedContexts()).toEqual([
+                counterpartyContext,
+                primaryContext,
+            ]);
+        });
+    });
+
     describe("Test getCalldataForV4Order method", () => {
         it("should return for pair v4", () => {
             simulator.tradeArgs.orderDetails.takeOrder.struct.order.type = Order.Type.V4;
-            simulator.tradeArgs.orderDetails.takeOrder.struct.signedContext = ["alice"];
+            simulator.tradeArgs.orderDetails.takeOrder.struct.signedContext = ["alice"] as any;
             (maxFloat as Mock).mockReturnValue("0x1234");
             (encodeFunctionData as Mock)
                 .mockReturnValue("default")
@@ -665,8 +691,7 @@ describe("Test IntraOrderbookTradeSimulator", () => {
                         aliceBountyVaultId: simulator.inputBountyVaultId,
                         bobBountyVaultId: simulator.outputBountyVaultId,
                     },
-                    simulator.tradeArgs.orderDetails.takeOrder.struct.signedContext,
-                    simulator.tradeArgs.counterpartyOrderDetails.struct.signedContext,
+                    ...simulator.getClearSignedContexts(),
                 ],
             });
             expect(encodeFunctionData).toHaveBeenNthCalledWith(4, {

--- a/src/core/modes/intra/simulation.ts
+++ b/src/core/modes/intra/simulation.ts
@@ -3,6 +3,7 @@ import { ONE18 } from "../../../math";
 import { errorSnapshot } from "../../../error";
 import { RainSolverSigner } from "../../../signer";
 import { Pair, TakeOrderDetails } from "../../../order";
+import { SignedContextV2 } from "../../../order/types/v4";
 import { TradeType, FailedSimulation, TaskType } from "../../types";
 import { Result, ABI, RawTransaction, maxFloat } from "../../../common";
 import { SimulationHaltReason, TradeSimulatorBase } from "../simulator";
@@ -167,6 +168,17 @@ export class IntraOrderbookTradeSimulator extends TradeSimulatorBase {
         return Result.ok(void 0);
     }
 
+    /**
+     * Raindex clear2/clear3 cross-assign signed context: alice's eval reads
+     * bobSignedContext and bob's eval reads aliceSignedContext.
+     */
+    getClearSignedContexts(): [SignedContextV2[], SignedContextV2[]] {
+        const aliceSignedContext =
+            this.tradeArgs.counterpartyOrderDetails.struct.signedContext ?? [];
+        const bobSignedContext = this.tradeArgs.orderDetails.takeOrder.struct.signedContext ?? [];
+        return [aliceSignedContext, bobSignedContext];
+    }
+
     estimateProfit(): bigint {
         const orderMaxInput =
             (this.tradeArgs.orderDetails.takeOrder.quote!.maxOutput *
@@ -311,8 +323,7 @@ export class IntraOrderbookTradeSimulator extends TradeSimulatorBase {
                     aliceBountyVaultId: this.inputBountyVaultId,
                     bobBountyVaultId: this.outputBountyVaultId,
                 },
-                this.tradeArgs.orderDetails.takeOrder.struct.signedContext,
-                this.tradeArgs.counterpartyOrderDetails.struct.signedContext,
+                ...this.getClearSignedContexts(),
             ],
         });
         return encodeFunctionData({
@@ -369,8 +380,7 @@ export class IntraOrderbookTradeSimulator extends TradeSimulatorBase {
                     aliceBountyVaultId: this.inputBountyVaultId,
                     bobBountyVaultId: this.outputBountyVaultId,
                 },
-                this.tradeArgs.orderDetails.takeOrder.struct.signedContext,
-                this.tradeArgs.counterpartyOrderDetails.struct.signedContext,
+                ...this.getClearSignedContexts(),
             ],
         });
         return encodeFunctionData({


### PR DESCRIPTION
## Summary

- Fixes oracle `clear3` reverts (`panic 0x32`) on RaindexV6 by cross-assigning signed context when building intra-orderbook calldata.
- PR #456 stopped passing empty `[], []` but still wired each order's context into the same-named calldata slot; Raindex actually evaluates alice with `bobSignedContext` and bob with `aliceSignedContext`.
- Adds `getClearSignedContexts()` and uses it for both V5 and V6 `clear3` calldata builders.

## Context

For a clear where the oracle order is bob (`0x571b97e3…`), oracle context must land in `aliceSignedContext`. With #456's direct assignment it ended up in `bobSignedContext`, so bob's eval saw an empty array and reverted on `signed-context<0 0>()`.

## Test plan

- [x] Unit test for `getClearSignedContexts()` cross-assignment
- [x] Updated `getCalldataForV4Order` test to expect swapped context args
- [ ] CI `test` job

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved consistency when building trade-related calldata so signed context data is passed in the correct order, with safer fallback handling when it’s unavailable.
* **Tests**
  * Added coverage for signed-context ordering and updated existing expectations to match the new shared handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->