### PR TITLE
fix Alice/bob signed context for `clear3()`

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -4,14 +4,21 @@
     rainix.url = "github:rainprotocol/rainix";
   };
 
-  outputs = { self, flake-utils, rainix }:
+  outputs =
+    {
+      self,
+      flake-utils,
+      rainix,
+    }:
 
-  flake-utils.lib.eachDefaultSystem (system:
-    let
-      pkgs = rainix.pkgs.${system};
-    in rec {
-      # For `nix develop`:
-      devShells.default = pkgs.mkShell {
+    flake-utils.lib.eachDefaultSystem (
+      system:
+      let
+        pkgs = rainix.pkgs.${system};
+      in
+      rec {
+        # For `nix develop`:
+        devShells.default = pkgs.mkShell {
           nativeBuildInputs = [
             rainix.node-build-inputs.${system}
             rainix.sol-build-inputs.${system}
@@ -22,6 +29,6 @@
             curl -sS -o ./chains.json "https://chainlist.org/rpcs.json"
           '';
         };
-    }
-  );
+      }
+    );
 }

--- a/src/core/modes/intra/simulation.test.ts
+++ b/src/core/modes/intra/simulation.test.ts
@@ -665,8 +665,8 @@ describe("Test IntraOrderbookTradeSimulator", () => {
                         aliceBountyVaultId: simulator.inputBountyVaultId,
                         bobBountyVaultId: simulator.outputBountyVaultId,
                     },
-                    simulator.tradeArgs.orderDetails.takeOrder.struct.signedContext,
                     simulator.tradeArgs.counterpartyOrderDetails.struct.signedContext,
+                    simulator.tradeArgs.orderDetails.takeOrder.struct.signedContext,
                 ],
             });
             expect(encodeFunctionData).toHaveBeenNthCalledWith(4, {

--- a/src/core/modes/intra/simulation.ts
+++ b/src/core/modes/intra/simulation.ts
@@ -311,8 +311,8 @@ export class IntraOrderbookTradeSimulator extends TradeSimulatorBase {
                     aliceBountyVaultId: this.inputBountyVaultId,
                     bobBountyVaultId: this.outputBountyVaultId,
                 },
-                this.tradeArgs.orderDetails.takeOrder.struct.signedContext,
-                this.tradeArgs.counterpartyOrderDetails.struct.signedContext,
+                this.tradeArgs.counterpartyOrderDetails.struct.signedContext, // bob's signedContext for alice
+                this.tradeArgs.orderDetails.takeOrder.struct.signedContext, // alice's signedContext for bob
             ],
         });
         return encodeFunctionData({
@@ -369,8 +369,8 @@ export class IntraOrderbookTradeSimulator extends TradeSimulatorBase {
                     aliceBountyVaultId: this.inputBountyVaultId,
                     bobBountyVaultId: this.outputBountyVaultId,
                 },
-                this.tradeArgs.orderDetails.takeOrder.struct.signedContext,
-                this.tradeArgs.counterpartyOrderDetails.struct.signedContext,
+                this.tradeArgs.counterpartyOrderDetails.struct.signedContext, // bob's signedContext for alice
+                this.tradeArgs.orderDetails.takeOrder.struct.signedContext, // alice's signedContext for bob
             ],
         });
         return encodeFunctionData({


### PR DESCRIPTION
<!-- Thanks for your Pull Request, please read the contributing guidelines before submitting. -->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## Checks
<!-- It's important you've done these, or your PR will not be considered for review -->
By submitting this for review, I'm confirming I've done the following:
- [x] made this PR as small as possible
- [x] unit-tested any new functionality
- [ ] linked any relevant issues or PRs
- [ ] included screenshots (if this involves a front-end change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the order of signed order data used during orderbook simulation, so “clear” calls now match the expected input format.
  * Updated test expectations to reflect the corrected argument order.
* **Chores**
  * Reformatted the Nix flake configuration without functional changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->