### PR TITLE
ci: adopt rainix nix-cachix-setup composite in report-downtime, drop deprecated DeterminateSystems nix installer

### DIFF
--- a/.github/workflows/report-downtime.yaml
+++ b/.github/workflows/report-downtime.yaml
@@ -14,12 +14,11 @@ jobs:
           submodules: recursive
           fetch-depth: 0
 
-      - name: Install Nix 1/2
-        uses: DeterminateSystems/nix-installer-action@main
+      - name: Install Nix
+        uses: rainlanguage/rainix/.github/actions/nix-cachix-setup@main
         with:
-          determinate: true
-      - name: Install Nix 2/2
-        uses: DeterminateSystems/flakehub-cache-action@main
+          checkout: 'false'
+          cachix-auth-token: ${{ secrets.CACHIX_AUTH_TOKEN }}
 
       - name: Prepare Sushi Lib
         run: ./prep-sushi.sh


### PR DESCRIPTION
Closes #459

## What

Replaces the deprecated `DeterminateSystems/nix-installer-action@main` (+ `flakehub-cache-action@main`) in `.github/workflows/report-downtime.yaml` with the org-standard shared composite `rainlanguage/rainix/.github/actions/nix-cachix-setup@main`, which bundles nix-quick-install + Cachix + `cache-nix-action` and pins every third-party action to an exact SHA (single source of truth — "rainix owns shared CI"). The pre-existing `actions/checkout@v4` (submodules recursive, fetch-depth 0) is kept, so the composite is called with `checkout: 'false'`.

This also removes the `@main` floating-ref supply-chain risk the roh-scan signal called out (the composite pins every third-party action to an exact SHA).

This is the same swap already applied and green on the pilot PRs rainlanguage/rain.chainlink#11, rainlanguage/rain.tier.interface#8, and rainlanguage/assemblyscript-cbor#5.

## QA

CI-infrastructure-only change: it touches a single GitHub Actions workflow file and no source or test code, so there is no behavioral code surface to mutation-test.

- **Scope honesty:** `report-downtime.yaml` is a **scheduled** workflow (`cron`, once/7 days), so this PR's own CI does not exercise it — there is no PR-triggered run to observe. The change is validated by equivalence to the established pattern rather than by a PR-CI run, and I flag that explicitly here rather than implying a green run proves it.
- **Independent confirmation:** the identical installer → composite swap is already green on the pilots rain.chainlink#11 / rain.tier.interface#8 / assemblyscript-cbor#5; the composite's input contract (`checkout`, `cachix-auth-token`) matches `nix-cachix-setup/action.yml` on `rainix@main`.
- **Equivalence:** the composite provides the same capabilities the two removed steps did (Nix install + a flake/store cache) plus the org's pinned-SHA hardening. `checkout: 'false'` preserves the existing checkout (submodules recursive, fetch-depth 0). All downstream steps (`prep-sushi.sh`, `nix develop -c npm install`, the `nix develop -c npx ts-node scripts/downtime.ts` report step and its `SUBGRAPHS`/`DURATION`/`THRESHOLD`/`TG_*` env) are untouched. An empty `CACHIX_AUTH_TOKEN` degrades to a read-only Cachix pull (the composite's documented default).
- **Category check:** issue asks to replace the deprecated installer (`report-downtime.yaml:18`) with the org-standard install (preferred: adopt the shared composite) — done → Closes #459.

Co-Authored-By: Claude <noreply@anthropic.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the downtime reporting workflow’s Nix setup and caching configuration.
  * Streamlined environment preparation for more consistent automated runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->