### PR TITLE
partial trade size fallback

### DIFF
--- a/src/core/modes/router/index.test.ts
+++ b/src/core/modes/router/index.test.ts
@@ -500,10 +500,10 @@ describe("Test findBestRouterTrade", () => {
         assert(result.isErr());
         expect(result.error.reason).toBe(SimulationHaltReason.MinimalOutputBalanceViolation);
         expect(result.error.noneNodeError).toBe("order ratio issue");
-        // 1 full + 1 partial + 6 fallbacks
-        expect(trySimulateTradeSpy).toHaveBeenCalledTimes(8);
+        // 1 full + 1 partial + 5 fallbacks
+        expect(trySimulateTradeSpy).toHaveBeenCalledTimes(5);
         expect(simulatorWithArgsSpy).toHaveBeenLastCalledWith(
-            expect.objectContaining({ maximumInputFixed: 16000n, isPartial: true }),
+            expect.objectContaining({ maximumInputFixed: 128000n, isPartial: true }),
         );
         expect(result.error.spanAttributes["full.error"]).toBe("ratio too high");
         expect(result.error.spanAttributes["partial.error"]).toContain(
@@ -512,10 +512,10 @@ describe("Test findBestRouterTrade", () => {
         expect(result.error.spanAttributes["partialFallback1.error"]).toContain(
             "MinimalOutputBalanceViolation",
         );
-        expect(result.error.spanAttributes["partialFallback6.error"]).toContain(
+        expect(result.error.spanAttributes["partialFallback3.error"]).toContain(
             "MinimalOutputBalanceViolation",
         );
-        expect(result.error.spanAttributes["partialFallback7.error"]).toBeUndefined();
+        expect(result.error.spanAttributes["partialFallback4.error"]).toBeUndefined();
     });
 
     it("should stop backoff when a step fails with an error other than MinimalOutputBalanceViolation", async () => {

--- a/src/core/modes/router/index.test.ts
+++ b/src/core/modes/router/index.test.ts
@@ -498,12 +498,11 @@ describe("Test findBestRouterTrade", () => {
         );
 
         assert(result.isErr());
-        expect(result.error.reason).toBe(SimulationHaltReason.MinimalOutputBalanceViolation);
         expect(result.error.noneNodeError).toBe("order ratio issue");
-        // 1 full + 1 partial + 5 fallbacks
-        expect(trySimulateTradeSpy).toHaveBeenCalledTimes(5);
+        // 1 full + 1 partial + 4 fallbacks
+        expect(trySimulateTradeSpy).toHaveBeenCalledTimes(6);
         expect(simulatorWithArgsSpy).toHaveBeenLastCalledWith(
-            expect.objectContaining({ maximumInputFixed: 128000n, isPartial: true }),
+            expect.objectContaining({ maximumInputFixed: 64000n, isPartial: true }),
         );
         expect(result.error.spanAttributes["full.error"]).toBe("ratio too high");
         expect(result.error.spanAttributes["partial.error"]).toContain(
@@ -512,10 +511,10 @@ describe("Test findBestRouterTrade", () => {
         expect(result.error.spanAttributes["partialFallback1.error"]).toContain(
             "MinimalOutputBalanceViolation",
         );
-        expect(result.error.spanAttributes["partialFallback3.error"]).toContain(
+        expect(result.error.spanAttributes["partialFallback4.error"]).toContain(
             "MinimalOutputBalanceViolation",
         );
-        expect(result.error.spanAttributes["partialFallback4.error"]).toBeUndefined();
+        expect(result.error.spanAttributes["partialFallback5.error"]).toBeUndefined();
     });
 
     it("should stop backoff when a step fails with an error other than MinimalOutputBalanceViolation", async () => {
@@ -555,7 +554,6 @@ describe("Test findBestRouterTrade", () => {
         );
 
         assert(result.isErr());
-        expect(result.error.reason).toBe(SimulationHaltReason.MinimalOutputBalanceViolation);
         // 1 full + 1 partial + 1 fallback, stopped early
         expect(trySimulateTradeSpy).toHaveBeenCalledTimes(3);
         expect(result.error.spanAttributes["partialFallback1.error"]).toBe("some other revert");

--- a/src/core/modes/router/index.test.ts
+++ b/src/core/modes/router/index.test.ts
@@ -500,10 +500,10 @@ describe("Test findBestRouterTrade", () => {
         assert(result.isErr());
         expect(result.error.reason).toBe(SimulationHaltReason.MinimalOutputBalanceViolation);
         expect(result.error.noneNodeError).toBe("order ratio issue");
-        // 1 full + 1 partial + 10 fallbacks
-        expect(trySimulateTradeSpy).toHaveBeenCalledTimes(12);
+        // 1 full + 1 partial + 5 fallbacks
+        expect(trySimulateTradeSpy).toHaveBeenCalledTimes(7);
         expect(simulatorWithArgsSpy).toHaveBeenLastCalledWith(
-            expect.objectContaining({ maximumInputFixed: 1000n, isPartial: true }),
+            expect.objectContaining({ maximumInputFixed: 32000n, isPartial: true }),
         );
         expect(result.error.spanAttributes["full.error"]).toBe("ratio too high");
         expect(result.error.spanAttributes["partial.error"]).toContain(
@@ -512,10 +512,10 @@ describe("Test findBestRouterTrade", () => {
         expect(result.error.spanAttributes["partialFallback1.error"]).toContain(
             "MinimalOutputBalanceViolation",
         );
-        expect(result.error.spanAttributes["partialFallback10.error"]).toContain(
+        expect(result.error.spanAttributes["partialFallback5.error"]).toContain(
             "MinimalOutputBalanceViolation",
         );
-        expect(result.error.spanAttributes["partialFallback11.error"]).toBeUndefined();
+        expect(result.error.spanAttributes["partialFallback6.error"]).toBeUndefined();
     });
 
     it("should stop backoff when a step fails with an error other than MinimalOutputBalanceViolation", async () => {

--- a/src/core/modes/router/index.test.ts
+++ b/src/core/modes/router/index.test.ts
@@ -500,10 +500,10 @@ describe("Test findBestRouterTrade", () => {
         assert(result.isErr());
         expect(result.error.reason).toBe(SimulationHaltReason.MinimalOutputBalanceViolation);
         expect(result.error.noneNodeError).toBe("order ratio issue");
-        // 1 full + 1 partial + 5 fallbacks
-        expect(trySimulateTradeSpy).toHaveBeenCalledTimes(7);
+        // 1 full + 1 partial + 6 fallbacks
+        expect(trySimulateTradeSpy).toHaveBeenCalledTimes(8);
         expect(simulatorWithArgsSpy).toHaveBeenLastCalledWith(
-            expect.objectContaining({ maximumInputFixed: 32000n, isPartial: true }),
+            expect.objectContaining({ maximumInputFixed: 16000n, isPartial: true }),
         );
         expect(result.error.spanAttributes["full.error"]).toBe("ratio too high");
         expect(result.error.spanAttributes["partial.error"]).toContain(
@@ -512,10 +512,10 @@ describe("Test findBestRouterTrade", () => {
         expect(result.error.spanAttributes["partialFallback1.error"]).toContain(
             "MinimalOutputBalanceViolation",
         );
-        expect(result.error.spanAttributes["partialFallback5.error"]).toContain(
+        expect(result.error.spanAttributes["partialFallback6.error"]).toContain(
             "MinimalOutputBalanceViolation",
         );
-        expect(result.error.spanAttributes["partialFallback6.error"]).toBeUndefined();
+        expect(result.error.spanAttributes["partialFallback7.error"]).toBeUndefined();
     });
 
     it("should stop backoff when a step fails with an error other than MinimalOutputBalanceViolation", async () => {

--- a/src/core/modes/router/index.test.ts
+++ b/src/core/modes/router/index.test.ts
@@ -415,6 +415,153 @@ describe("Test findBestRouterTrade", () => {
         );
     });
 
+    it("should backoff with halved trade sizes when partial trade fails with MinimalOutputBalanceViolation", async () => {
+        const mockFullTradeError = Result.err({
+            type: TradeType.RouteProcessor,
+            reason: SimulationHaltReason.OrderRatioGreaterThanMarketPrice,
+            spanAttributes: { error: "ratio too high" },
+            noneNodeError: "order ratio issue",
+        });
+        const mockViolationError = Result.err({
+            type: TradeType.RouteProcessor,
+            reason: SimulationHaltReason.NoOpportunity,
+            spanAttributes: {
+                error: "execution reverted: MinimalOutputBalanceViolation(0xtoken, 123)",
+            },
+        });
+        const mockFallbackSuccess = Result.ok({
+            type: TradeType.RouteProcessor,
+            spanAttributes: { foundOpp: true },
+            estimatedProfit: 25n,
+            oppBlockNumber: 123,
+        });
+
+        (trySimulateTradeSpy as Mock)
+            .mockResolvedValueOnce(mockFullTradeError) // full size
+            .mockResolvedValueOnce(mockViolationError) // partial size 1000n
+            .mockResolvedValueOnce(mockViolationError) // partialFallback1 500n
+            .mockResolvedValueOnce(mockFallbackSuccess); // partialFallback2 250n
+        (mockRainSolver.state.router.findLargestTradeSize as Mock).mockReturnValue(1000n);
+
+        const result: SimulationResult = await findBestRouterTrade.call(
+            mockRainSolver,
+            orderDetails,
+            signer,
+            ethPrice,
+            toToken,
+            fromToken,
+            blockNumber,
+        );
+
+        assert(result.isOk());
+        expect(result.value.spanAttributes).toEqual({ foundOpp: true });
+        expect(result.value.estimatedProfit).toBe(25n);
+        expect(trySimulateTradeSpy).toHaveBeenCalledTimes(4);
+        expect(simulatorWithArgsSpy).toHaveBeenNthCalledWith(
+            3,
+            expect.objectContaining({ maximumInputFixed: 500n, isPartial: true }),
+        );
+        expect(simulatorWithArgsSpy).toHaveBeenNthCalledWith(
+            4,
+            expect.objectContaining({ maximumInputFixed: 250n, isPartial: true }),
+        );
+    });
+
+    it("should return error with MinimalOutputBalanceViolation reason when all backoff steps fail", async () => {
+        const mockFullTradeError = Result.err({
+            type: TradeType.RouteProcessor,
+            reason: SimulationHaltReason.OrderRatioGreaterThanMarketPrice,
+            spanAttributes: { error: "ratio too high" },
+            noneNodeError: "order ratio issue",
+        });
+        const mockViolationError = Result.err({
+            type: TradeType.RouteProcessor,
+            reason: SimulationHaltReason.NoOpportunity,
+            spanAttributes: {
+                error: "execution reverted: MinimalOutputBalanceViolation(0xtoken, 123)",
+            },
+        });
+
+        (trySimulateTradeSpy as Mock)
+            .mockResolvedValueOnce(mockFullTradeError) // full size
+            .mockResolvedValue(mockViolationError); // partial + all fallbacks
+        (mockRainSolver.state.router.findLargestTradeSize as Mock).mockReturnValue(1024000n);
+
+        const result: SimulationResult = await findBestRouterTrade.call(
+            mockRainSolver,
+            orderDetails,
+            signer,
+            ethPrice,
+            toToken,
+            fromToken,
+            blockNumber,
+        );
+
+        assert(result.isErr());
+        expect(result.error.reason).toBe(SimulationHaltReason.MinimalOutputBalanceViolation);
+        expect(result.error.noneNodeError).toBe("order ratio issue");
+        // 1 full + 1 partial + 10 fallbacks
+        expect(trySimulateTradeSpy).toHaveBeenCalledTimes(12);
+        expect(simulatorWithArgsSpy).toHaveBeenLastCalledWith(
+            expect.objectContaining({ maximumInputFixed: 1000n, isPartial: true }),
+        );
+        expect(result.error.spanAttributes["full.error"]).toBe("ratio too high");
+        expect(result.error.spanAttributes["partial.error"]).toContain(
+            "MinimalOutputBalanceViolation",
+        );
+        expect(result.error.spanAttributes["partialFallback1.error"]).toContain(
+            "MinimalOutputBalanceViolation",
+        );
+        expect(result.error.spanAttributes["partialFallback10.error"]).toContain(
+            "MinimalOutputBalanceViolation",
+        );
+        expect(result.error.spanAttributes["partialFallback11.error"]).toBeUndefined();
+    });
+
+    it("should stop backoff when a step fails with an error other than MinimalOutputBalanceViolation", async () => {
+        const mockFullTradeError = Result.err({
+            type: TradeType.RouteProcessor,
+            reason: SimulationHaltReason.OrderRatioGreaterThanMarketPrice,
+            spanAttributes: { error: "ratio too high" },
+            noneNodeError: "order ratio issue",
+        });
+        const mockViolationError = Result.err({
+            type: TradeType.RouteProcessor,
+            reason: SimulationHaltReason.NoOpportunity,
+            spanAttributes: {
+                error: "execution reverted: MinimalOutputBalanceViolation(0xtoken, 123)",
+            },
+        });
+        const mockOtherError = Result.err({
+            type: TradeType.RouteProcessor,
+            reason: SimulationHaltReason.NoOpportunity,
+            spanAttributes: { error: "some other revert" },
+        });
+
+        (trySimulateTradeSpy as Mock)
+            .mockResolvedValueOnce(mockFullTradeError) // full size
+            .mockResolvedValueOnce(mockViolationError) // partial size
+            .mockResolvedValueOnce(mockOtherError); // partialFallback1
+        (mockRainSolver.state.router.findLargestTradeSize as Mock).mockReturnValue(1000n);
+
+        const result: SimulationResult = await findBestRouterTrade.call(
+            mockRainSolver,
+            orderDetails,
+            signer,
+            ethPrice,
+            toToken,
+            fromToken,
+            blockNumber,
+        );
+
+        assert(result.isErr());
+        expect(result.error.reason).toBe(SimulationHaltReason.MinimalOutputBalanceViolation);
+        // 1 full + 1 partial + 1 fallback, stopped early
+        expect(trySimulateTradeSpy).toHaveBeenCalledTimes(3);
+        expect(result.error.spanAttributes["partialFallback1.error"]).toBe("some other revert");
+        expect(result.error.spanAttributes["partialFallback2.error"]).toBeUndefined();
+    });
+
     it("should retry with the failing route dexes excluded when full trade dryrun fails", async () => {
         const sushiQuote = {
             route: {

--- a/src/core/modes/router/index.ts
+++ b/src/core/modes/router/index.ts
@@ -241,7 +241,7 @@ export async function tryFindBestRouterTrade(
     ) {
         reason = SimulationHaltReason.MinimalOutputBalanceViolation;
         let fallbackTradeSize = partialTradeSize;
-        for (let i = 1; i <= 5; i++) {
+        for (let i = 1; i <= 6; i++) {
             fallbackTradeSize /= 2n;
             if (fallbackTradeSize <= 0n) break;
             const partialFallbackSimulator = RouterTradeSimulator.withArgs({

--- a/src/core/modes/router/index.ts
+++ b/src/core/modes/router/index.ts
@@ -230,9 +230,9 @@ export async function tryFindBestRouterTrade(
 
     // if the partial trade size sim got rejected onchain with MinimalOutputBalanceViolation,
     // it means the offchain pool data overestimated the output for the found partial trade
-    // size, so backoff by halving the trade size at each step (max 10 steps) validated
-    // against onchain dryrun and accept the first size that passes, the backoff stops
-    // early if a step fails with any other error
+    // size, so backoff by halving the trade size at each step validated against onchain
+    // dryrun and accept the first size that passes, the backoff stops early if a step fails
+    // with any other error
     let reason = partialTradeSizeSimResult.error.reason;
     if (
         SimulationHaltReason.isMinimalOutputBalanceViolation(
@@ -241,7 +241,7 @@ export async function tryFindBestRouterTrade(
     ) {
         reason = SimulationHaltReason.MinimalOutputBalanceViolation;
         let fallbackTradeSize = partialTradeSize;
-        for (let i = 1; i <= 10; i++) {
+        for (let i = 1; i <= 5; i++) {
             fallbackTradeSize /= 2n;
             if (fallbackTradeSize <= 0n) break;
             const partialFallbackSimulator = RouterTradeSimulator.withArgs({

--- a/src/core/modes/router/index.ts
+++ b/src/core/modes/router/index.ts
@@ -241,7 +241,7 @@ export async function tryFindBestRouterTrade(
     ) {
         reason = SimulationHaltReason.MinimalOutputBalanceViolation;
         let fallbackTradeSize = partialTradeSize;
-        for (let i = 1; i <= 6; i++) {
+        for (let i = 1; i <= 3; i++) {
             fallbackTradeSize /= 2n;
             if (fallbackTradeSize <= 0n) break;
             const partialFallbackSimulator = RouterTradeSimulator.withArgs({

--- a/src/core/modes/router/index.ts
+++ b/src/core/modes/router/index.ts
@@ -227,6 +227,54 @@ export async function tryFindBestRouterTrade(
         partialTradeSizeSimResult.error.spanAttributes,
         "partial",
     );
+
+    // if the partial trade size sim got rejected onchain with MinimalOutputBalanceViolation,
+    // it means the offchain pool data overestimated the output for the found partial trade
+    // size, so backoff by halving the trade size at each step (max 10 steps) validated
+    // against onchain dryrun and accept the first size that passes, the backoff stops
+    // early if a step fails with any other error
+    let reason = partialTradeSizeSimResult.error.reason;
+    if (
+        SimulationHaltReason.isMinimalOutputBalanceViolation(
+            partialTradeSizeSimResult.error.spanAttributes["error"],
+        )
+    ) {
+        reason = SimulationHaltReason.MinimalOutputBalanceViolation;
+        let fallbackTradeSize = partialTradeSize;
+        for (let i = 1; i <= 10; i++) {
+            fallbackTradeSize /= 2n;
+            if (fallbackTradeSize <= 0n) break;
+            const partialFallbackSimulator = RouterTradeSimulator.withArgs({
+                type: TradeType.Router,
+                solver: this,
+                orderDetails,
+                fromToken,
+                toToken,
+                signer,
+                maximumInputFixed: fallbackTradeSize,
+                ethPrice,
+                isPartial: true,
+                blockNumber,
+                excludeDexes,
+            });
+            const partialFallbackSimResult = await partialFallbackSimulator.trySimulateTrade();
+            if (partialFallbackSimResult.isOk()) {
+                return { result: partialFallbackSimResult, quote };
+            }
+            extendObjectWithHeader(
+                spanAttributes,
+                partialFallbackSimResult.error.spanAttributes,
+                `partialFallback${i}`,
+            );
+            if (
+                !SimulationHaltReason.isMinimalOutputBalanceViolation(
+                    partialFallbackSimResult.error.spanAttributes["error"],
+                )
+            ) {
+                break;
+            }
+        }
+    }
     return {
         result: Result.err({
             type: fullTradeSizeSimResult.error.type,
@@ -234,6 +282,7 @@ export async function tryFindBestRouterTrade(
             noneNodeError:
                 fullTradeSizeSimResult.error.noneNodeError ??
                 partialTradeSizeSimResult.error.noneNodeError,
+            reason,
         }),
         quote,
     };

--- a/src/core/modes/router/index.ts
+++ b/src/core/modes/router/index.ts
@@ -233,15 +233,10 @@ export async function tryFindBestRouterTrade(
     // size, so backoff by halving the trade size at each step validated against onchain
     // dryrun and accept the first size that passes, the backoff stops early if a step fails
     // with any other error
-    let reason = partialTradeSizeSimResult.error.reason;
-    if (
-        SimulationHaltReason.isMinimalOutputBalanceViolation(
-            partialTradeSizeSimResult.error.spanAttributes["error"],
-        )
-    ) {
-        reason = SimulationHaltReason.MinimalOutputBalanceViolation;
+    const reason = partialTradeSizeSimResult.error.reason;
+    if (SimulationHaltReason.needsRetry(partialTradeSizeSimResult.error.spanAttributes["error"])) {
         let fallbackTradeSize = partialTradeSize;
-        for (let i = 1; i <= 3; i++) {
+        for (let i = 1; i <= 4; i++) {
             fallbackTradeSize /= 2n;
             if (fallbackTradeSize <= 0n) break;
             const partialFallbackSimulator = RouterTradeSimulator.withArgs({
@@ -267,7 +262,7 @@ export async function tryFindBestRouterTrade(
                 `partialFallback${i}`,
             );
             if (
-                !SimulationHaltReason.isMinimalOutputBalanceViolation(
+                !SimulationHaltReason.needsRetry(
                     partialFallbackSimResult.error.spanAttributes["error"],
                 )
             ) {

--- a/src/core/modes/simulator.test.ts
+++ b/src/core/modes/simulator.test.ts
@@ -620,3 +620,18 @@ describe("Test TradeSimulatorBase", () => {
         });
     });
 });
+
+describe("Test SimulationHaltReason namespace", () => {
+    it("should detect MinimalOutputBalanceViolation in the given text", () => {
+        expect(
+            SimulationHaltReason.isMinimalOutputBalanceViolation(
+                'execution reverted: MinimalOutputBalanceViolation(0xtoken, 123)"',
+            ),
+        ).toBe(true);
+        expect(SimulationHaltReason.isMinimalOutputBalanceViolation("some other error")).toBe(
+            false,
+        );
+        expect(SimulationHaltReason.isMinimalOutputBalanceViolation(undefined)).toBe(false);
+        expect(SimulationHaltReason.isMinimalOutputBalanceViolation(123)).toBe(false);
+    });
+});

--- a/src/core/modes/simulator.test.ts
+++ b/src/core/modes/simulator.test.ts
@@ -624,14 +624,18 @@ describe("Test TradeSimulatorBase", () => {
 describe("Test SimulationHaltReason namespace", () => {
     it("should detect MinimalOutputBalanceViolation in the given text", () => {
         expect(
-            SimulationHaltReason.isMinimalOutputBalanceViolation(
+            SimulationHaltReason.needsRetry(
                 'execution reverted: MinimalOutputBalanceViolation(0xtoken, 123)"',
             ),
         ).toBe(true);
-        expect(SimulationHaltReason.isMinimalOutputBalanceViolation("some other error")).toBe(
-            false,
+        expect(SimulationHaltReason.needsRetry('execution reverted: minimumSenderOutput"')).toBe(
+            true,
         );
-        expect(SimulationHaltReason.isMinimalOutputBalanceViolation(undefined)).toBe(false);
-        expect(SimulationHaltReason.isMinimalOutputBalanceViolation(123)).toBe(false);
+        expect(SimulationHaltReason.needsRetry('execution reverted: minimum sender output"')).toBe(
+            true,
+        );
+        expect(SimulationHaltReason.needsRetry("some other error")).toBe(false);
+        expect(SimulationHaltReason.needsRetry(undefined)).toBe(false);
+        expect(SimulationHaltReason.needsRetry(123)).toBe(false);
     });
 });

--- a/src/core/modes/simulator.ts
+++ b/src/core/modes/simulator.ts
@@ -27,12 +27,20 @@ export enum SimulationHaltReason {
 }
 export namespace SimulationHaltReason {
     /**
-     * Returns true if the given input contains the sushi RouteProcessor
-     * contract MinimalOutputBalanceViolation error selector name
+     * Returns true if the given input contains errors that justify a retry
+     * Errors include:
+     * - the sushi RouteProcessor contract "MinimalOutputBalanceViolation" error selector name
+     * - Raindex task": "minimum sender output"
+     * - Raindex task: "minimumSenderOutput"
      * @param text - The text to search in
      */
-    export function isMinimalOutputBalanceViolation(text: unknown): boolean {
-        return typeof text === "string" && text.includes("MinimalOutputBalanceViolation");
+    export function needsRetry(text: unknown): boolean {
+        return (
+            typeof text === "string" &&
+            (text.includes("MinimalOutputBalanceViolation") ||
+                text.includes("minimum sender output") ||
+                text.includes("minimumSenderOutput"))
+        );
     }
 }
 

--- a/src/core/modes/simulator.ts
+++ b/src/core/modes/simulator.ts
@@ -23,6 +23,17 @@ export enum SimulationHaltReason {
     OrderRatioGreaterThanMarketPrice,
     FailedToGetTaskBytecode,
     UndefinedTradeDestinationAddress,
+    MinimalOutputBalanceViolation,
+}
+export namespace SimulationHaltReason {
+    /**
+     * Returns true if the given input contains the sushi RouteProcessor
+     * contract MinimalOutputBalanceViolation error selector name
+     * @param text - The text to search in
+     */
+    export function isMinimalOutputBalanceViolation(text: unknown): boolean {
+        return typeof text === "string" && text.includes("MinimalOutputBalanceViolation");
+    }
 }
 
 export type SimulateTradeArgs =


### PR DESCRIPTION
<!-- Thanks for your Pull Request, please read the contributing guidelines before submitting. -->

## Motivation
Tries fallback method to find partial trade size when `MinimalOutputBalanceViolation` is the cause of the initial partial trade size finder, which halves the trade size at each step until a pass or steps run out.
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## Checks
<!-- It's important you've done these, or your PR will not be considered for review -->
By submitting this for review, I'm confirming I've done the following:
- [x] made this PR as small as possible
- [x] unit-tested any new functionality
- [ ] linked any relevant issues or PRs
- [ ] included screenshots (if this involves a front-end change)
