### PR TITLE
trade size under update

### DIFF
--- a/src/core/modes/router/index.test.ts
+++ b/src/core/modes/router/index.test.ts
@@ -144,33 +144,18 @@ describe("Test findBestRouterTrade", () => {
         assert(result.isErr());
         expect(result.error.noneNodeError).toBe("no route available");
         expect(result.error.type).toBe("router");
-        expect(result.error.spanAttributes).toEqual({
-            "full.route": "no-way",
-            "partial.error": "no viable partial trade size found",
-        });
-        expect(extendObjectWithHeader).toHaveBeenCalledWith(
-            expect.any(Object),
-            { route: "no-way" },
-            "full",
-        );
+        // the single sim's span attributes are merged directly without a header
+        expect(result.error.spanAttributes).toEqual({ route: "no-way" });
     });
 
-    it("should try partial trade if full trade fails with non-NoRoute reason", async () => {
-        const mockFullTradeError = Result.err({
-            reason: SimulationHaltReason.OrderRatioGreaterThanMarketPrice,
-            spanAttributes: { error: "ratio too high" },
-            noneNodeError: "order ratio issue",
-        });
-        const mockPartialTradeSuccess = Result.ok({
+    it("should simulate the most profitable trade size when found", async () => {
+        const mockSuccessResult = Result.ok({
             type: "routeProcessor",
             spanAttributes: { foundOpp: true },
             estimatedProfit: 50n,
             oppBlockNumber: 123,
         });
-
-        (trySimulateTradeSpy as Mock)
-            .mockResolvedValueOnce(mockFullTradeError)
-            .mockResolvedValueOnce(mockPartialTradeSuccess);
+        (trySimulateTradeSpy as Mock).mockResolvedValue(mockSuccessResult);
         (mockRainSolver.state.router.findLargestTradeSize as Mock).mockReturnValue(500n);
 
         const result: SimulationResult = await findBestRouterTrade.call(
@@ -197,7 +182,7 @@ describe("Test findBestRouterTrade", () => {
             false,
             undefined,
         );
-        expect(trySimulateTradeSpy).toHaveBeenCalledTimes(2);
+        expect(trySimulateTradeSpy).toHaveBeenCalledTimes(1);
         expect(simulatorWithArgsSpy).toHaveBeenLastCalledWith({
             type: TradeType.Router,
             solver: mockRainSolver,
@@ -212,23 +197,15 @@ describe("Test findBestRouterTrade", () => {
         });
     });
 
-    it("should try partial trade if full trade fails with NoRoute reason", async () => {
-        const mockFullTradeError = Result.err({
-            reason: SimulationHaltReason.NoRoute,
-            spanAttributes: { error: "no route" },
-            noneNodeError: "no route for pair trade size",
-        });
-        const mockPartialTradeSuccess = Result.ok({
+    it("should simulate with isPartial false when the most profitable trade size is the full size", async () => {
+        const mockSuccessResult = Result.ok({
             type: "routeProcessor",
             spanAttributes: { foundOpp: true },
-            estimatedProfit: 50n,
+            estimatedProfit: 80n,
             oppBlockNumber: 123,
         });
-
-        (trySimulateTradeSpy as Mock)
-            .mockResolvedValueOnce(mockFullTradeError)
-            .mockResolvedValueOnce(mockPartialTradeSuccess);
-        (mockRainSolver.state.router.findLargestTradeSize as Mock).mockReturnValue(500n);
+        (trySimulateTradeSpy as Mock).mockResolvedValue(mockSuccessResult);
+        (mockRainSolver.state.router.findLargestTradeSize as Mock).mockReturnValue(1000n);
 
         const result: SimulationResult = await findBestRouterTrade.call(
             mockRainSolver,
@@ -241,43 +218,20 @@ describe("Test findBestRouterTrade", () => {
         );
 
         assert(result.isOk());
-        expect(result.value.spanAttributes).toEqual({ foundOpp: true });
-        expect(result.value.estimatedProfit).toBe(50n);
-        expect(result.value.type).toBe("routeProcessor");
-        expect(mockRainSolver.state.router.findLargestTradeSize).toHaveBeenCalledWith(
-            orderDetails,
-            toToken,
-            fromToken,
-            1000n,
-            100n,
-            undefined,
-            false,
-            undefined,
+        expect(trySimulateTradeSpy).toHaveBeenCalledTimes(1);
+        expect(simulatorWithArgsSpy).toHaveBeenLastCalledWith(
+            expect.objectContaining({ maximumInputFixed: 1000n, isPartial: false }),
         );
-        expect(trySimulateTradeSpy).toHaveBeenCalledTimes(2);
-        expect(simulatorWithArgsSpy).toHaveBeenLastCalledWith({
-            type: TradeType.Router,
-            solver: mockRainSolver,
-            orderDetails,
-            fromToken,
-            toToken,
-            signer,
-            maximumInputFixed: 500n,
-            ethPrice,
-            isPartial: true,
-            blockNumber: 123n,
-        });
     });
 
-    it("should return error if partial trade size cannot be found", async () => {
-        const mockFullTradeError = Result.err({
+    it("should fall back to full trade size when no profitable trade size is found", async () => {
+        const mockErrorResult = Result.err({
             type: TradeType.Router,
             reason: SimulationHaltReason.OrderRatioGreaterThanMarketPrice,
             spanAttributes: { error: "ratio too high" },
             noneNodeError: "order ratio issue",
         });
-
-        (trySimulateTradeSpy as Mock).mockResolvedValue(mockFullTradeError);
+        (trySimulateTradeSpy as Mock).mockResolvedValue(mockErrorResult);
         (mockRainSolver.state.router.findLargestTradeSize as Mock).mockReturnValue(undefined);
 
         const result: SimulationResult = await findBestRouterTrade.call(
@@ -293,81 +247,23 @@ describe("Test findBestRouterTrade", () => {
         assert(result.isErr());
         expect(result.error.noneNodeError).toBe("order ratio issue");
         expect(result.error.type).toBe("router");
-        expect(result.error.spanAttributes).toEqual({
-            "full.error": "ratio too high",
-            "partial.error": "no viable partial trade size found",
-        });
-        expect(extendObjectWithHeader).toHaveBeenCalledWith(
-            expect.any(Object),
-            { error: "ratio too high" },
-            "full",
+        expect(result.error.reason).toBe(SimulationHaltReason.OrderRatioGreaterThanMarketPrice);
+        // the single sim's span attributes are merged directly without a header
+        expect(result.error.spanAttributes).toEqual({ error: "ratio too high" });
+        expect(trySimulateTradeSpy).toHaveBeenCalledTimes(1);
+        expect(simulatorWithArgsSpy).toHaveBeenLastCalledWith(
+            expect.objectContaining({ maximumInputFixed: 1000n, isPartial: false }),
         );
     });
 
-    it("should return error if partial trade simulation also fails", async () => {
-        const mockFullTradeError = Result.err({
-            type: TradeType.Balancer,
-            reason: SimulationHaltReason.OrderRatioGreaterThanMarketPrice,
-            spanAttributes: { error: "ratio too high" },
-            noneNodeError: "order ratio issue",
-        });
-        const mockPartialTradeError = Result.err({
+    it("should return error when simulation of the found trade size fails", async () => {
+        const mockErrorResult = Result.err({
             type: TradeType.RouteProcessor,
             reason: SimulationHaltReason.NoOpportunity,
             spanAttributes: { error: "no opportunity" },
-            noneNodeError: "partial failed",
+            noneNodeError: "sim failed",
         });
-
-        (trySimulateTradeSpy as Mock)
-            .mockResolvedValueOnce(mockFullTradeError)
-            .mockResolvedValueOnce(mockPartialTradeError);
-        (mockRainSolver.state.router.findLargestTradeSize as Mock).mockReturnValue(1500n);
-
-        const result: SimulationResult = await findBestRouterTrade.call(
-            mockRainSolver,
-            orderDetails,
-            signer,
-            ethPrice,
-            toToken,
-            fromToken,
-            blockNumber,
-        );
-
-        assert(result.isErr());
-        expect(result.error.noneNodeError).toBe("order ratio issue"); // from full trade error
-        expect(result.error.type).toBe("balancer");
-        expect(result.error.spanAttributes).toEqual({
-            "full.error": "ratio too high",
-            "partial.error": "no opportunity",
-        });
-        expect(extendObjectWithHeader).toHaveBeenCalledWith(
-            expect.any(Object),
-            { error: "ratio too high" },
-            "full",
-        );
-        expect(extendObjectWithHeader).toHaveBeenCalledWith(
-            expect.any(Object),
-            { error: "no opportunity" },
-            "partial",
-        );
-    });
-
-    it("should return success result if partial trade simulation succeeds", async () => {
-        const mockFullTradeError = Result.err({
-            reason: SimulationHaltReason.OrderRatioGreaterThanMarketPrice,
-            spanAttributes: { error: "ratio too high" },
-            noneNodeError: "order ratio issue",
-        });
-        const mockPartialTradeSuccess = Result.ok({
-            type: "routeProcessor",
-            spanAttributes: { foundOpp: true },
-            estimatedProfit: 75n,
-            oppBlockNumber: 123,
-        });
-
-        (trySimulateTradeSpy as Mock)
-            .mockResolvedValueOnce(mockFullTradeError)
-            .mockResolvedValueOnce(mockPartialTradeSuccess);
+        (trySimulateTradeSpy as Mock).mockResolvedValue(mockErrorResult);
         (mockRainSolver.state.router.findLargestTradeSize as Mock).mockReturnValue(500n);
 
         const result: SimulationResult = await findBestRouterTrade.call(
@@ -380,48 +276,17 @@ describe("Test findBestRouterTrade", () => {
             blockNumber,
         );
 
-        assert(result.isOk());
-        expect(result.value.spanAttributes).toEqual({ foundOpp: true });
-        expect(result.value.estimatedProfit).toBe(75n);
-        expect(result.value.oppBlockNumber).toBe(123);
-        expect(result.value.type).toBe("routeProcessor");
-        expect(mockRainSolver.state.router.findLargestTradeSize).toHaveBeenCalledWith(
-            orderDetails,
-            toToken,
-            fromToken,
-            1000n,
-            100n,
-            undefined,
-            false,
-            undefined,
-        );
-        expect(trySimulateTradeSpy).toHaveBeenCalledTimes(2);
-        expect(simulatorWithArgsSpy).toHaveBeenLastCalledWith({
-            type: TradeType.Router,
-            solver: mockRainSolver,
-            orderDetails,
-            fromToken,
-            toToken,
-            signer,
-            maximumInputFixed: 500n,
-            ethPrice,
-            isPartial: true,
-            blockNumber: 123n,
-        });
-        expect(extendObjectWithHeader).toHaveBeenCalledWith(
-            expect.any(Object),
-            { error: "ratio too high" },
-            "full",
+        assert(result.isErr());
+        expect(result.error.noneNodeError).toBe("sim failed");
+        expect(result.error.type).toBe("routeProcessor");
+        expect(result.error.spanAttributes).toEqual({ error: "no opportunity" });
+        expect(trySimulateTradeSpy).toHaveBeenCalledTimes(1);
+        expect(simulatorWithArgsSpy).toHaveBeenLastCalledWith(
+            expect.objectContaining({ maximumInputFixed: 500n, isPartial: true }),
         );
     });
 
-    it("should backoff with halved trade sizes when partial trade fails with MinimalOutputBalanceViolation", async () => {
-        const mockFullTradeError = Result.err({
-            type: TradeType.RouteProcessor,
-            reason: SimulationHaltReason.OrderRatioGreaterThanMarketPrice,
-            spanAttributes: { error: "ratio too high" },
-            noneNodeError: "order ratio issue",
-        });
+    it("should backoff with halved trade sizes when the trade fails with MinimalOutputBalanceViolation", async () => {
         const mockViolationError = Result.err({
             type: TradeType.RouteProcessor,
             reason: SimulationHaltReason.NoOpportunity,
@@ -437,10 +302,9 @@ describe("Test findBestRouterTrade", () => {
         });
 
         (trySimulateTradeSpy as Mock)
-            .mockResolvedValueOnce(mockFullTradeError) // full size
-            .mockResolvedValueOnce(mockViolationError) // partial size 1000n
-            .mockResolvedValueOnce(mockViolationError) // partialFallback1 500n
-            .mockResolvedValueOnce(mockFallbackSuccess); // partialFallback2 250n
+            .mockResolvedValueOnce(mockViolationError) // found size 1000n
+            .mockResolvedValueOnce(mockViolationError) // fallback1 500n
+            .mockResolvedValueOnce(mockFallbackSuccess); // fallback2 250n
         (mockRainSolver.state.router.findLargestTradeSize as Mock).mockReturnValue(1000n);
 
         const result: SimulationResult = await findBestRouterTrade.call(
@@ -456,35 +320,28 @@ describe("Test findBestRouterTrade", () => {
         assert(result.isOk());
         expect(result.value.spanAttributes).toEqual({ foundOpp: true });
         expect(result.value.estimatedProfit).toBe(25n);
-        expect(trySimulateTradeSpy).toHaveBeenCalledTimes(4);
+        expect(trySimulateTradeSpy).toHaveBeenCalledTimes(3);
         expect(simulatorWithArgsSpy).toHaveBeenNthCalledWith(
-            3,
+            2,
             expect.objectContaining({ maximumInputFixed: 500n, isPartial: true }),
         );
         expect(simulatorWithArgsSpy).toHaveBeenNthCalledWith(
-            4,
+            3,
             expect.objectContaining({ maximumInputFixed: 250n, isPartial: true }),
         );
     });
 
     it("should return error with MinimalOutputBalanceViolation reason when all backoff steps fail", async () => {
-        const mockFullTradeError = Result.err({
-            type: TradeType.RouteProcessor,
-            reason: SimulationHaltReason.OrderRatioGreaterThanMarketPrice,
-            spanAttributes: { error: "ratio too high" },
-            noneNodeError: "order ratio issue",
-        });
         const mockViolationError = Result.err({
             type: TradeType.RouteProcessor,
             reason: SimulationHaltReason.NoOpportunity,
             spanAttributes: {
                 error: "execution reverted: MinimalOutputBalanceViolation(0xtoken, 123)",
             },
+            noneNodeError: "min output violation",
         });
 
-        (trySimulateTradeSpy as Mock)
-            .mockResolvedValueOnce(mockFullTradeError) // full size
-            .mockResolvedValue(mockViolationError); // partial + all fallbacks
+        (trySimulateTradeSpy as Mock).mockResolvedValue(mockViolationError); // found size + all fallbacks
         (mockRainSolver.state.router.findLargestTradeSize as Mock).mockReturnValue(1024000n);
 
         const result: SimulationResult = await findBestRouterTrade.call(
@@ -498,32 +355,23 @@ describe("Test findBestRouterTrade", () => {
         );
 
         assert(result.isErr());
-        expect(result.error.noneNodeError).toBe("order ratio issue");
-        // 1 full + 1 partial + 4 fallbacks
-        expect(trySimulateTradeSpy).toHaveBeenCalledTimes(6);
+        expect(result.error.noneNodeError).toBe("min output violation");
+        // 1 found size + 4 fallbacks
+        expect(trySimulateTradeSpy).toHaveBeenCalledTimes(5);
         expect(simulatorWithArgsSpy).toHaveBeenLastCalledWith(
             expect.objectContaining({ maximumInputFixed: 64000n, isPartial: true }),
         );
-        expect(result.error.spanAttributes["full.error"]).toBe("ratio too high");
-        expect(result.error.spanAttributes["partial.error"]).toContain(
+        expect(result.error.spanAttributes["error"]).toContain("MinimalOutputBalanceViolation");
+        expect(result.error.spanAttributes["fallback1.error"]).toContain(
             "MinimalOutputBalanceViolation",
         );
-        expect(result.error.spanAttributes["partialFallback1.error"]).toContain(
+        expect(result.error.spanAttributes["fallback4.error"]).toContain(
             "MinimalOutputBalanceViolation",
         );
-        expect(result.error.spanAttributes["partialFallback4.error"]).toContain(
-            "MinimalOutputBalanceViolation",
-        );
-        expect(result.error.spanAttributes["partialFallback5.error"]).toBeUndefined();
+        expect(result.error.spanAttributes["fallback5.error"]).toBeUndefined();
     });
 
     it("should stop backoff when a step fails with an error other than MinimalOutputBalanceViolation", async () => {
-        const mockFullTradeError = Result.err({
-            type: TradeType.RouteProcessor,
-            reason: SimulationHaltReason.OrderRatioGreaterThanMarketPrice,
-            spanAttributes: { error: "ratio too high" },
-            noneNodeError: "order ratio issue",
-        });
         const mockViolationError = Result.err({
             type: TradeType.RouteProcessor,
             reason: SimulationHaltReason.NoOpportunity,
@@ -538,9 +386,8 @@ describe("Test findBestRouterTrade", () => {
         });
 
         (trySimulateTradeSpy as Mock)
-            .mockResolvedValueOnce(mockFullTradeError) // full size
-            .mockResolvedValueOnce(mockViolationError) // partial size
-            .mockResolvedValueOnce(mockOtherError); // partialFallback1
+            .mockResolvedValueOnce(mockViolationError) // found size
+            .mockResolvedValueOnce(mockOtherError); // fallback1
         (mockRainSolver.state.router.findLargestTradeSize as Mock).mockReturnValue(1000n);
 
         const result: SimulationResult = await findBestRouterTrade.call(
@@ -554,10 +401,10 @@ describe("Test findBestRouterTrade", () => {
         );
 
         assert(result.isErr());
-        // 1 full + 1 partial + 1 fallback, stopped early
-        expect(trySimulateTradeSpy).toHaveBeenCalledTimes(3);
-        expect(result.error.spanAttributes["partialFallback1.error"]).toBe("some other revert");
-        expect(result.error.spanAttributes["partialFallback2.error"]).toBeUndefined();
+        // 1 found size + 1 fallback, stopped early
+        expect(trySimulateTradeSpy).toHaveBeenCalledTimes(2);
+        expect(result.error.spanAttributes["fallback1.error"]).toBe("some other revert");
+        expect(result.error.spanAttributes["fallback2.error"]).toBeUndefined();
     });
 
     it("should retry with the failing route dexes excluded when full trade dryrun fails", async () => {
@@ -615,7 +462,18 @@ describe("Test findBestRouterTrade", () => {
             blockNumber: 123n,
             excludeDexes: new Set(["Hydrex"]),
         });
-        expect(mockRainSolver.state.router.findLargestTradeSize).not.toHaveBeenCalled();
+        // trade size is searched for both attempts, secondary with excluded dexes
+        expect(mockRainSolver.state.router.findLargestTradeSize).toHaveBeenCalledTimes(2);
+        expect(mockRainSolver.state.router.findLargestTradeSize).toHaveBeenLastCalledWith(
+            orderDetails,
+            toToken,
+            fromToken,
+            1000n,
+            100n,
+            undefined,
+            false,
+            new Set(["Hydrex"]),
+        );
     });
 
     it("should return error when retry attempt also fails", async () => {
@@ -661,26 +519,16 @@ describe("Test findBestRouterTrade", () => {
         expect(result.error.noneNodeError).toBe("full failed");
         expect(result.error.type).toBe(TradeType.RouteProcessor);
         expect(result.error.spanAttributes).toEqual({
-            "full.error": "dryrun failed",
-            "secondary.full.error": "retry dryrun failed",
+            error: "dryrun failed",
+            "secondary.error": "retry dryrun failed",
         });
         expect(simulatorWithArgsSpy).toHaveBeenCalledTimes(2);
         expect(extendObjectWithHeader).toHaveBeenCalledWith(
             expect.any(Object),
-            { error: "dryrun failed" },
-            "full",
-        );
-        expect(extendObjectWithHeader).toHaveBeenCalledWith(
-            expect.any(Object),
             { error: "retry dryrun failed" },
-            "full",
-        );
-        expect(extendObjectWithHeader).toHaveBeenCalledWith(
-            expect.any(Object),
-            expect.any(Object),
             "secondary",
         );
-        expect(mockRainSolver.state.router.findLargestTradeSize).not.toHaveBeenCalled();
+        expect(mockRainSolver.state.router.findLargestTradeSize).toHaveBeenCalledTimes(2);
     });
 
     it("should return early if ethPrice is unknown", async () => {

--- a/src/core/modes/router/index.ts
+++ b/src/core/modes/router/index.ts
@@ -14,8 +14,10 @@ import { Result, extendObjectWithHeader } from "../../../common";
 export type RouterTradeAttempt = {
     /** The simulation result of the attempt */
     result: SimulationResult;
-    /** The quote of the attempt's full trade size simulation */
+    /** The quote of the attempt's trade size simulation */
     quote?: RouterTradeSimulator["quote"];
+    /** The trade size (in 18 decimals) that the attempt succeeded with */
+    tradeSize?: bigint;
 };
 
 /**
@@ -91,8 +93,10 @@ export async function findBestRouterTrade(
 
 /**
  * Tries to find a trade against rain router (balancer and sushi) for the given order,
- * it will try to simulate a trade for full trade size (order's max output)
- * and if it was not successful it will try again with partial trade size
+ * it first finds the most profitable trade size offchain (full trade size included as
+ * a candidate) and simulates that single trade size, then if the simulation gets
+ * rejected onchain due to offchain pool data overestimation, it backs off by halving
+ * the trade size validated against onchain dryrun until one passes
  * @param this - RainSolver instance
  * @param orderDetails - The details of the order to be processed
  * @param signer - The signer to be used for the trade
@@ -140,51 +144,10 @@ export async function tryFindBestRouterTrade(
 
     const maximumInput = orderDetails.takeOrder.quote!.maxOutput;
 
-    // try simulation for full trade size and return if succeeds
-    const fullTradeSimulator = RouterTradeSimulator.withArgs({
-        type: TradeType.Router,
-        solver: this,
-        orderDetails,
-        fromToken,
-        toToken,
-        signer,
-        maximumInputFixed: maximumInput,
-        ethPrice,
-        isPartial: false,
-        blockNumber,
-        excludeDexes,
-    });
-    const fullTradeSizeSimResult = await fullTradeSimulator.trySimulateTrade();
-    let quote = fullTradeSimulator.quote;
-    if (fullTradeSizeSimResult.isOk()) {
-        return { result: fullTradeSizeSimResult, quote };
-    }
-    extendObjectWithHeader(spanAttributes, fullTradeSizeSimResult.error.spanAttributes, "full");
-
-    // return early if dryrun failed
-    // in other words only try partial trade size if the full trade size failed due
-    // to order ratio being greater than market price or there was no route for full
-    // trade size, that's because if for example for a pair there is only 1 pool and that
-    // pool has certain amount of reserves that cant cover the full trade size but can
-    // cover partial, we still need to try it
-    if (
-        fullTradeSizeSimResult.error.reason !== SimulationHaltReason.NoRoute &&
-        fullTradeSizeSimResult.error.reason !==
-            SimulationHaltReason.OrderRatioGreaterThanMarketPrice
-    ) {
-        return {
-            result: Result.err({
-                type: fullTradeSizeSimResult.error.type,
-                spanAttributes,
-                noneNodeError: fullTradeSizeSimResult.error.noneNodeError,
-                reason: fullTradeSizeSimResult.error.reason,
-            }),
-            quote,
-        };
-    }
-
-    // try simulation for partial trade size
-    const partialTradeSize = this.state.router.findLargestTradeSize(
+    // find the most profitable trade size offchain, the full trade size is
+    // included as a candidate in the search so the winner competes among all
+    // viable sizes including the full size
+    const mostProfitableTradeSize = this.state.router.findLargestTradeSize(
         orderDetails,
         toToken,
         fromToken,
@@ -194,53 +157,46 @@ export async function tryFindBestRouterTrade(
         false,
         excludeDexes,
     );
-    if (!partialTradeSize) {
-        spanAttributes["partial.error"] = "no viable partial trade size found";
-        return {
-            result: Result.err({
-                type: fullTradeSizeSimResult.error.type,
-                spanAttributes,
-                noneNodeError: fullTradeSizeSimResult.error.noneNodeError,
-            }),
-            quote,
-        };
-    }
-    const partialTradeSimulator = RouterTradeSimulator.withArgs({
+
+    // fall back to the full trade size when no profitable size was found, ie
+    // when the order ratio is above the sushi market price or sushi has no
+    // route at all, since the size finder only knows sushi liquidity, while
+    // the simulation still quotes balancer and stabull routes as well
+    const tradeSize = mostProfitableTradeSize ?? maximumInput;
+
+    // simulate the trade for the determined trade size
+    const simulator = RouterTradeSimulator.withArgs({
         type: TradeType.Router,
         solver: this,
         orderDetails,
         fromToken,
         toToken,
         signer,
-        maximumInputFixed: partialTradeSize,
+        maximumInputFixed: tradeSize,
         ethPrice,
-        isPartial: true,
+        isPartial: tradeSize < maximumInput,
         blockNumber,
         excludeDexes,
     });
-    const partialTradeSizeSimResult = await partialTradeSimulator.trySimulateTrade();
-    quote = partialTradeSimulator.quote ?? quote;
-    if (partialTradeSizeSimResult.isOk()) {
-        return { result: partialTradeSizeSimResult, quote };
+    const simResult = await simulator.trySimulateTrade();
+    const quote = simulator.quote;
+    if (simResult.isOk()) {
+        return { result: simResult, quote, tradeSize };
     }
-    extendObjectWithHeader(
-        spanAttributes,
-        partialTradeSizeSimResult.error.spanAttributes,
-        "partial",
-    );
+    Object.assign(spanAttributes, simResult.error.spanAttributes);
+    const reason = simResult.error.reason;
 
-    // if the partial trade size sim got rejected onchain with MinimalOutputBalanceViolation,
-    // it means the offchain pool data overestimated the output for the found partial trade
-    // size, so backoff by halving the trade size at each step validated against onchain
-    // dryrun and accept the first size that passes, the backoff stops early if a step fails
-    // with any other error
-    const reason = partialTradeSizeSimResult.error.reason;
-    if (SimulationHaltReason.needsRetry(partialTradeSizeSimResult.error.spanAttributes["error"])) {
-        let fallbackTradeSize = partialTradeSize;
+    // if the trade sim got rejected onchain with MinimalOutputBalanceViolation,
+    // it means the offchain pool data overestimated the output for the found
+    // trade size, so backoff by halving the trade size at each step validated
+    // against onchain dryrun and accept the first size that passes, the backoff
+    // stops early if a step fails with any other error
+    if (SimulationHaltReason.needsRetry(simResult.error.spanAttributes["error"])) {
+        let fallbackTradeSize = tradeSize;
         for (let i = 1; i <= 4; i++) {
             fallbackTradeSize /= 2n;
             if (fallbackTradeSize <= 0n) break;
-            const partialFallbackSimulator = RouterTradeSimulator.withArgs({
+            const fallbackSimulator = RouterTradeSimulator.withArgs({
                 type: TradeType.Router,
                 solver: this,
                 orderDetails,
@@ -253,31 +209,25 @@ export async function tryFindBestRouterTrade(
                 blockNumber,
                 excludeDexes,
             });
-            const partialFallbackSimResult = await partialFallbackSimulator.trySimulateTrade();
-            if (partialFallbackSimResult.isOk()) {
-                return { result: partialFallbackSimResult, quote };
+            const fallbackSimResult = await fallbackSimulator.trySimulateTrade();
+            if (fallbackSimResult.isOk()) {
+                return { result: fallbackSimResult, quote, tradeSize: fallbackTradeSize };
             }
             extendObjectWithHeader(
                 spanAttributes,
-                partialFallbackSimResult.error.spanAttributes,
-                `partialFallback${i}`,
+                fallbackSimResult.error.spanAttributes,
+                `fallback${i}`,
             );
-            if (
-                !SimulationHaltReason.needsRetry(
-                    partialFallbackSimResult.error.spanAttributes["error"],
-                )
-            ) {
+            if (!SimulationHaltReason.needsRetry(fallbackSimResult.error.spanAttributes["error"])) {
                 break;
             }
         }
     }
     return {
         result: Result.err({
-            type: fullTradeSizeSimResult.error.type,
+            type: simResult.error.type,
             spanAttributes,
-            noneNodeError:
-                fullTradeSizeSimResult.error.noneNodeError ??
-                partialTradeSizeSimResult.error.noneNodeError,
+            noneNodeError: simResult.error.noneNodeError,
             reason,
         }),
         quote,

--- a/src/router/sushi/index.test.ts
+++ b/src/router/sushi/index.test.ts
@@ -1,4 +1,4 @@
-import { ONE18 } from "../../math";
+import { ONE18, scaleTo18 } from "../../math";
 import { Token } from "sushi/currency";
 import { SharedState } from "../../state";
 import { Dispair, Result } from "../../common";
@@ -1034,10 +1034,16 @@ describe("test SushiRouter methods", () => {
             expect(result).toBeUndefined();
         });
 
-        it("should return the largest valid trade size when some routes are valid", () => {
-            (Router.findBestRoute as Mock).mockImplementation(() => {
-                return { status: "OK", amountOutBI: 4n * ONE18 };
-            });
+        it("should return the most profitable trade size instead of the largest viable one", () => {
+            // concave route output: doubles the input up to a cap of 8, so with
+            // ratio of 1 the estimated profit (out - in * ratio) peaks at input
+            // of 4, while the largest viable (zero profit) size would be 8
+            (Router.findBestRoute as Mock).mockImplementation(
+                (_pcMap: any, _chainId: any, _fromToken: any, amountIn: bigint) => ({
+                    status: "OK",
+                    amountOutBI: amountIn * 2n > 8n * ONE18 ? 8n * ONE18 : amountIn * 2n,
+                }),
+            );
 
             const orderDetails = makeOrderDetails(1n * ONE18);
 
@@ -1049,8 +1055,83 @@ describe("test SushiRouter methods", () => {
                 gasPrice,
             );
 
-            expect(typeof result).toBe("bigint");
-            expect(result).toBe(3999999761581420898n);
+            assert(typeof result === "bigint");
+            // should converge near the profit peak at 4,
+            // far below the largest viable size of ~8
+            expect(result).toBeGreaterThan((35n * ONE18) / 10n);
+            expect(result).toBeLessThan((45n * ONE18) / 10n);
+        });
+
+        it("should return the exact full trade size when profit peaks at the full size", () => {
+            // profit strictly increases with size, so the full size is the most
+            // profitable, it is probed as an explicit candidate since the ternary
+            // search itself never probes the range boundaries
+            (Router.findBestRoute as Mock).mockImplementation(
+                (_pcMap: any, _chainId: any, _fromToken: any, amountIn: bigint) => ({
+                    status: "OK",
+                    amountOutBI: amountIn * 2n,
+                }),
+            );
+
+            const result = router.findLargestTradeSize(
+                makeOrderDetails(1n * ONE18),
+                toToken,
+                fromToken,
+                maximumInputFixed,
+                gasPrice,
+            );
+
+            expect(result).toBe(maximumInputFixed);
+        });
+
+        it("should return the given full size as is for low decimal tokens with sub-precision dust", () => {
+            fromToken = { address: "0xFrom", decimals: 6 } as any;
+            // full size carries dust below the 6 decimal token precision, when
+            // the full size wins it must be returned as given so it does not
+            // wrongly read as a partial size after scaling truncation
+            maximumInputFixed = 10n * ONE18 + 123n;
+            (Router.findBestRoute as Mock).mockImplementation(
+                (_pcMap: any, _chainId: any, _fromToken: any, amountIn: bigint) => ({
+                    status: "OK",
+                    amountOutBI: scaleTo18(amountIn, 6) * 2n,
+                }),
+            );
+
+            const result = router.findLargestTradeSize(
+                makeOrderDetails(1n * ONE18),
+                toToken,
+                fromToken,
+                maximumInputFixed,
+                gasPrice,
+            );
+
+            expect(result).toBe(maximumInputFixed);
+        });
+
+        it("should return the largest size below price impact tolerance in absolute mode", () => {
+            // price impact crosses the default tolerance (2.5) above input size of 5
+            (Router.findBestRoute as Mock).mockImplementation(
+                (_pcMap: any, _chainId: any, _fromToken: any, amountIn: bigint) => ({
+                    status: "OK",
+                    amountOutBI: amountIn,
+                    priceImpact: amountIn > 5n * ONE18 ? 3 : 1,
+                }),
+            );
+
+            const result = router.findLargestTradeSize(
+                makeOrderDetails(1n * ONE18),
+                toToken,
+                fromToken,
+                maximumInputFixed,
+                gasPrice,
+                "single",
+                true, // absolute mode
+            );
+
+            assert(typeof result === "bigint");
+            // bisection converges to the largest size below the impact threshold at 5
+            expect(result).toBeGreaterThan((49n * ONE18) / 10n);
+            expect(result).toBeLessThanOrEqual(5n * ONE18);
         });
 
         it("should return undefined if all OK routes have price < ratio", () => {

--- a/src/router/sushi/index.ts
+++ b/src/router/sushi/index.ts
@@ -6,7 +6,7 @@ import { MultiRoute, RouteLeg } from "sushi/tines";
 import { BlackListSet, poolFilter } from "./blacklist";
 import { TakeOrdersConfigType } from "../../order/types";
 import { SushiRouterError, SushiRouterErrorType } from "./error";
-import { calculatePrice18, scaleFrom18, scaleTo18 } from "../../math";
+import { calculatePrice18, scaleFrom18, scaleTo18, ONE18 } from "../../math";
 import { ChainId, LiquidityProviders, PoolCode, RainDataFetcher, Router } from "sushi";
 import { Chain, Account, Transport, formatUnits, PublicClient, encodeAbiParameters } from "viem";
 import {
@@ -501,9 +501,14 @@ export class SushiRouter extends RainSolverRouterBase {
     }
 
     /**
-     * Calculates the largest possible partial trade size for rp clear, returns undefined if
-     * it cannot be determined due to the fact that order's ratio being higher than market
-     * price
+     * Finds the most profitable partial trade size for rp clear, that is the trade
+     * size that yields the highest estimated profit at quoted prices rather than
+     * simply the largest size that clears the order ratio, since a smaller size
+     * with a bigger price difference can yield more profit than a bigger size
+     * with a smaller price difference, returns undefined if no trade size with
+     * any profit can be found, ie when order's ratio is above the market price,
+     * in absolute mode, it instead finds the largest trade size that stays below
+     * the default price impact tolerance
      * @param orderDetails - The order details
      * @param toToken - The token to trade to
      * @param fromToken - The token to trade from
@@ -521,20 +526,15 @@ export class SushiRouter extends RainSolverRouterBase {
         absolute = false,
         excludeDexes?: Set<string>,
     ): bigint | undefined {
-        const result: bigint[] = [];
         const gasPrice = Number(gasPriceBI);
-        const ratio = orderDetails.takeOrder.quote!.ratio;
         const liquidityProviders = this.getFilteredLiquidityProviders(excludeDexes);
         const pcMap = this.dataFetcher.getCurrentPoolCodeMap(fromToken, toToken);
-        const initAmount = scaleFrom18(maximumInputFixed, fromToken.decimals) / 2n;
-        let maximumInput = initAmount;
-        for (let i = 1n; i < 26n; i++) {
-            const maxInput18 = scaleTo18(maximumInput, fromToken.decimals);
-            const route = Router.findBestRoute(
+        const findRoute = (amountIn: bigint) =>
+            Router.findBestRoute(
                 pcMap,
                 this.chainId as ChainId,
                 fromToken,
-                maximumInput,
+                amountIn,
                 toToken,
                 gasPrice,
                 liquidityProviders,
@@ -543,41 +543,85 @@ export class SushiRouter extends RainSolverRouterBase {
                 routeType,
             );
 
-            if (route.status == "NoWay") {
-                maximumInput = maximumInput - initAmount / 2n ** i;
-            } else if (absolute) {
+        // absolute mode keeps the bisection for the largest trade
+        // size that stays below the price impact tolerance
+        if (absolute) {
+            const result: bigint[] = [];
+            const initAmount = scaleFrom18(maximumInputFixed, fromToken.decimals) / 2n;
+            let maximumInput = initAmount;
+            for (let i = 1n; i < 26n; i++) {
+                const maxInput18 = scaleTo18(maximumInput, fromToken.decimals);
+                const route = findRoute(maximumInput);
                 if (
-                    typeof route.priceImpact === "undefined" ||
-                    route.priceImpact < DEFAULT_PRICE_IMPACT_TOLERANCE
+                    route.status !== "NoWay" &&
+                    (typeof route.priceImpact === "undefined" ||
+                        route.priceImpact < DEFAULT_PRICE_IMPACT_TOLERANCE)
                 ) {
                     result.unshift(maxInput18);
                     maximumInput = maximumInput + initAmount / 2n ** i;
                 } else {
                     maximumInput = maximumInput - initAmount / 2n ** i;
                 }
-            } else {
-                // realized average execution price of the simulated swap, this already
-                // includes the route's price impact, same as the trade simulation gate
-                const effectivePrice = calculatePrice18(
-                    maximumInput,
-                    route.amountOutBI,
-                    fromToken.decimals,
-                    toToken.decimals,
-                );
-                if (effectivePrice < ratio) {
-                    maximumInput = maximumInput - initAmount / 2n ** i;
-                } else {
-                    result.unshift(maxInput18);
-                    maximumInput = maximumInput + initAmount / 2n ** i;
-                }
             }
+            return result.length ? result[0] : undefined;
         }
 
-        if (result.length) {
-            return result[0];
-        } else {
-            return undefined;
+        // estimated profit at quoted prices for the given trade size, that is the
+        // route output minus what the order takes for that size, undefined if the
+        // route has no way
+        const ratio = orderDetails.takeOrder.quote!.ratio;
+        const estimateProfit = (amountIn: bigint): bigint | undefined => {
+            if (amountIn <= 0n) return undefined;
+            const route = findRoute(amountIn);
+            if (route.status == "NoWay") return undefined;
+            const amountIn18 = scaleTo18(amountIn, fromToken.decimals);
+            const amountOut18 = scaleTo18(route.amountOutBI, toToken.decimals);
+            return amountOut18 - (amountIn18 * ratio) / ONE18;
+        };
+
+        // the estimated profit as a function of trade size is concave, it rises
+        // while the route marginal price beats the order ratio and falls after,
+        // so a ternary search over the size range converges on the trade size
+        // with the highest estimated profit, unlike a simple bisection for the
+        // largest viable size which by definition converges on the size where
+        // the profit approaches zero, NoWay routes count as lowest profit
+        const NO_WAY_PROFIT = -(1n << 255n);
+        const fullSize = scaleFrom18(maximumInputFixed, fromToken.decimals);
+        let low = 0n;
+        let high = fullSize;
+        let best: { size: bigint; profit: bigint } | undefined = undefined;
+        // evaluate the exact full trade size as the first candidate so that
+        // it competes with the interior sizes probed by the ternary search,
+        // as the search itself never probes the range boundaries
+        const fullSizeProfit = estimateProfit(fullSize);
+        if (typeof fullSizeProfit === "bigint" && fullSizeProfit > 0n) {
+            best = { size: fullSize, profit: fullSizeProfit };
         }
+        for (let i = 0; i < 12; i++) {
+            const third = (high - low) / 3n;
+            if (third <= 0n) break;
+            const mid1 = low + third;
+            const mid2 = high - third;
+            const profit1 = estimateProfit(mid1);
+            const profit2 = estimateProfit(mid2);
+            if (typeof profit1 === "bigint" && profit1 > 0n && (!best || profit1 > best.profit)) {
+                best = { size: mid1, profit: profit1 };
+            }
+            if (typeof profit2 === "bigint" && profit2 > 0n && (!best || profit2 > best.profit)) {
+                best = { size: mid2, profit: profit2 };
+            }
+            if ((profit1 ?? NO_WAY_PROFIT) < (profit2 ?? NO_WAY_PROFIT)) {
+                low = mid1;
+            } else {
+                high = mid2;
+            }
+        }
+        if (!best) return undefined;
+        // return the given full size as is when it won, since scaling it down
+        // to token units truncates sub-precision dust for tokens with fewer
+        // than 18 decimals and the result would wrongly read as a partial size
+        if (best.size === fullSize) return maximumInputFixed;
+        return scaleTo18(best.size, fromToken.decimals);
     }
 
     /**


### PR DESCRIPTION
<!-- Thanks for your Pull Request, please read the contributing guidelines before submitting. -->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## Checks
<!-- It's important you've done these, or your PR will not be considered for review -->
By submitting this for review, I'm confirming I've done the following:
- [x] made this PR as small as possible
- [x] unit-tested any new functionality
- [ ] linked any relevant issues or PRs
- [ ] included screenshots (if this involves a front-end change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Router trade sizing now searches for the most profitable input amount instead of always prioritizing the full trade size.
  - Full-size trades remain available when they provide the best result.
  - Improved support for routes with low-decimal tokens and price-impact limits.

- **Bug Fixes**
  - Improved retry handling when a trade exceeds available output balance.
  - Dry-run retries now recalculate the best trade size while excluding previously failed routes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->