### PR TITLE
strict max owner profile check config

### DIFF
--- a/config.env.yaml
+++ b/config.env.yaml
@@ -39,6 +39,7 @@ gasPriceMultiplier: $GAS_PRICE_MULTIPLIER
 txTimeThreshold: $TX_TIME_THRESHOLD
 blockTime: $BLOCK_TIME
 routerPartialFallback: $ROUTER_PARTIAL_FALLBACK
+strictMaxOwnerProfileCheck: $STRICT_MAX_OWNER_PROFILE_CHECK
 gasBoostProfitThreshold: $GAS_BOOST_PROFIT_THRESHOLD
 gasBoostMultiplier: $GAS_BOOST_MULTIPLIER
 gasBoostUsdThreshold: $GAS_BOOST_USD_THRESHOLD

--- a/config.env.yaml
+++ b/config.env.yaml
@@ -50,6 +50,7 @@ maxRatio: $MAX_RATIO
 maxConcurrency: $MAX_CONCURRENCY
 skipSweep: $SKIP_SWEEP
 ownerProfile: $OWNER_PROFILE
+defaultOwnerLimit: $DEFAULT_OWNER_LIMIT
 selfFundVaults: $SELF_FUND_ORDERS
 sweepWalletTime: $SWEEP_WALLET_TIME
 convertToGasTime: $CONVERT_TO_GAS_TIME

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -175,6 +175,9 @@ ownerProfile:
   - "0x1234...5678": 100
   - "0x1234...7890": max
 
+# The default limit for owners that have no configured owner profile, default is 5
+defaultOwnerLimit: 5
+
 # Optional list of vaults to self-fund when vault balance falls below specified threshold
 # example for env: token=0xabcd...def,vaultId=0x123...456,orderbook="0x123...456",threshold=0.5,topupAmount=10,...
 selfFundVaults:

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -128,6 +128,9 @@ blockTime: 2000
 # Enables the halving backoff retries for router mode partial trades that get rejected onchain, default is true
 routerPartialFallback: true
 
+# When true, zero output balance pairs of max profile owners go to round processing, when false, all zero output balance pairs are skipped, default is false
+strictMaxOwnerProfileCheck: false
+
 # Time (in minutes) to to check the operating wallet balances, 0 means dont ever check wallet balance, default is 15 mins
 checkWalletBalanceTime: 15
 

--- a/src/cli/commands/sweep.ts
+++ b/src/cli/commands/sweep.ts
@@ -129,6 +129,7 @@ export async function sweepFunds(opts: SweepOptions) {
         convertToGasTime: 0,
         rotateMultiWallet: false,
         checkWalletBalanceTime: 0,
+        defaultOwnerLimit: 5,
     };
 
     // prepare state config fields

--- a/src/cli/commands/sweep.ts
+++ b/src/cli/commands/sweep.ts
@@ -108,6 +108,7 @@ export async function sweepFunds(opts: SweepOptions) {
         txTimeThreshold: 2_500,
         blockTime: 5_000,
         routerPartialFallback: true,
+        strictMaxOwnerProfileCheck: false,
         timeout: 15_000,
 
         // unused fields but need to be defined

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -500,7 +500,7 @@ export class RainSolverCli {
                     async (span) => {
                         const record = this.state.writeRpc!.metrics[rpc];
                         span.setAttributes({
-                            "isWriteRpc:": true,
+                            "isWriteRpc:": "true",
                             "rpc-url": rpc,
                             "request-count": record.req,
                             "success-count": record.success,

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -500,6 +500,7 @@ export class RainSolverCli {
                     async (span) => {
                         const record = this.state.writeRpc!.metrics[rpc];
                         span.setAttributes({
+                            "isWriteRpc:": true,
                             "rpc-url": rpc,
                             "request-count": record.req,
                             "success-count": record.success,

--- a/src/config/yaml.test.ts
+++ b/src/config/yaml.test.ts
@@ -53,6 +53,7 @@ skipSweep:
     - "0x8888888888888888888888888888888888888888"
     - "0x9999999999999999999999999999999999999999"
 ownerProfile: $OWNER_PROFILE
+defaultOwnerLimit: 10
 selfFundVaults:
   - token: "0x6666666666666666666666666666666666666666"
     vaultId: "1"
@@ -129,6 +130,7 @@ orderbookTradeTypes:
                 "0x4444444444444444444444444444444444444444": 100,
                 "0x5555555555555555555555555555555555555555": Number.MAX_SAFE_INTEGER,
             },
+            defaultOwnerLimit: 10,
             selfFundVaults: [
                 {
                     token: "0x6666666666666666666666666666666666666666",
@@ -365,6 +367,7 @@ orderbookTradeTypes:
         assert.equal(result.routerPartialFallback, true); // should be default true
         assert.equal(result.strictMaxOwnerProfileCheck, false); // should be default false
         assert.equal(result.checkWalletBalanceTime, 15); // should be default 15
+        assert.equal(result.defaultOwnerLimit, 5); // should be default 5
         assert.equal(result.wsRpc, undefined); // no ws rpc when unset
         assert.equal(result.gasBoostProfitThreshold, undefined); // no boost when unset
         assert.equal(result.gasBoostMultiplier, undefined); // no boost when unset

--- a/src/config/yaml.test.ts
+++ b/src/config/yaml.test.ts
@@ -40,6 +40,7 @@ gasPriceMultiplier: 150
 txTimeThreshold: 4000
 blockTime: 3000
 routerPartialFallback: false
+strictMaxOwnerProfileCheck: true
 checkWalletBalanceTime: 30
 gasBoostProfitThreshold: 7
 gasBoostMultiplier: 3.5
@@ -168,6 +169,7 @@ orderbookTradeTypes:
             convertToGasTime: 0,
             rotateMultiWallet: false,
             routerPartialFallback: false,
+            strictMaxOwnerProfileCheck: true,
             checkWalletBalanceTime: 30,
             gasBoostProfitThreshold: 7,
             gasBoostMultiplier: 3.5,
@@ -361,6 +363,7 @@ orderbookTradeTypes:
         assert.equal(result.convertToGasTime, 2);
         assert.equal(result.rotateMultiWallet, true);
         assert.equal(result.routerPartialFallback, true); // should be default true
+        assert.equal(result.strictMaxOwnerProfileCheck, false); // should be default false
         assert.equal(result.checkWalletBalanceTime, 15); // should be default 15
         assert.equal(result.wsRpc, undefined); // no ws rpc when unset
         assert.equal(result.gasBoostProfitThreshold, undefined); // no boost when unset

--- a/src/config/yaml.ts
+++ b/src/config/yaml.ts
@@ -101,6 +101,8 @@ export type AppOptions = {
     selfFundVaults?: SelfFundVault[];
     /** Option that specifies the owner limit in form of key/value */
     ownerProfile?: Record<string, number>;
+    /** The default limit for owners that have no configured owner profile, default is 5 */
+    defaultOwnerLimit: number;
     /** Optional filters for inc/exc orders, owner and orderbooks */
     sgFilter?: SgFilter;
     /** List of contract addresses required for solving */
@@ -200,6 +202,18 @@ export namespace AppOptions {
                 liquidityProviders: Validator.resolveLiquidityProviders(input.liquidityProviders),
                 route: Validator.resolveRouteType(input.route),
                 ownerProfile: Validator.resolveOwnerProfile(input.ownerProfile),
+                defaultOwnerLimit: Validator.resolveNumericValue(
+                    input.defaultOwnerLimit,
+                    INT_PATTERN,
+                    "invalid defaultOwnerLimit value, must be an integer greater than 0",
+                    "5",
+                    undefined,
+                    (defaultOwnerLimit) =>
+                        assert(
+                            defaultOwnerLimit > 0,
+                            "invalid defaultOwnerLimit value, must be an integer greater than 0",
+                        ),
+                ),
                 selfFundVaults: Validator.resolveSelfFundVaults(input.selfFundVaults),
                 sgFilter: Validator.resolveSgFilters(input.sgFilter),
                 maxRatio: Validator.resolveBool(

--- a/src/config/yaml.ts
+++ b/src/config/yaml.ts
@@ -125,6 +125,8 @@ export type AppOptions = {
     blockTime: number;
     /** Enables the halving backoff retries for router mode partial trades that get rejected onchain, default is true */
     routerPartialFallback: boolean;
+    /** When true, zero output balance pairs of max profile owners go to round processing, when false, all zero output balance pairs are skipped, default is false */
+    strictMaxOwnerProfileCheck: boolean;
     /** Time (in minutes) to to check the operating wallet balances, 0 means dont ever check wallet balance, default is 15 mins */
     checkWalletBalanceTime: number;
     /** Optional threshold as the min expected bounty multiple that the estimated profit must exceed to boost the tx gas price, no boost applies if unset */
@@ -385,6 +387,11 @@ export namespace AppOptions {
                     input.routerPartialFallback,
                     "expected a boolean value for routerPartialFallback",
                     true,
+                ),
+                strictMaxOwnerProfileCheck: Validator.resolveBool(
+                    input.strictMaxOwnerProfileCheck,
+                    "expected a boolean value for strictMaxOwnerProfileCheck",
+                    false,
                 ),
                 checkWalletBalanceTime: Validator.resolveNumericValue(
                     input.checkWalletBalanceTime,

--- a/src/order/config.ts
+++ b/src/order/config.ts
@@ -1,15 +1,20 @@
 import { AppOptions } from "../config";
 
+/** The default owner limit */
+export const DEFAULT_OWNER_LIMIT = 5 as const;
+
 /** Configuration required for instantiating OrderManager */
 export type OrderManagerConfig = {
     quoteGas: bigint;
     ownerLimits: Record<string, number>;
+    defaultOwnerLimit: number;
 };
 export namespace OrderManagerConfig {
     export function tryFromAppOptions(options: AppOptions) {
         return {
             quoteGas: options.quoteGas,
             ownerLimits: options.ownerProfile ?? {},
+            defaultOwnerLimit: options.defaultOwnerLimit,
         };
     }
 }

--- a/src/order/index.test.ts
+++ b/src/order/index.test.ts
@@ -703,6 +703,47 @@ describe("Test OrderManager", () => {
         expect(ownerProfileMap?.get("0xadmin")?.limit).toBe(75); // admin set limit should not reset
     });
 
+    it("should use the configured default owner limit for owners without a profile", async () => {
+        (state as any).orderManagerConfig = {
+            quoteGas: 1000000n,
+            ownerLimits: {
+                "0xadmin": 75,
+            },
+            defaultOwnerLimit: 7, // configured default owner limit
+        };
+        orderManager = new OrderManager(state, subgraphManager);
+        const mockOrder = {
+            owner: "0xowner",
+            orderHash: "0xhash",
+            orderbook: { id: "0xorderbook" },
+            orderBytes: "0xbytes",
+            outputs: [{ token: { address: "0xoutput", symbol: "OUT" }, balance: 1n }],
+            inputs: [{ token: { address: "0xinput", symbol: "IN" }, balance: 1n }],
+        };
+        const adminOrder = {
+            owner: "0xadmin",
+            orderHash: "0xadmin",
+            orderbook: { id: "0xorderbook" },
+            orderBytes: "0xadminBytes",
+            outputs: [{ token: { address: "0xoutput", symbol: "OUT" }, balance: 1n }],
+            inputs: [{ token: { address: "0xinput", symbol: "IN" }, balance: 1n }],
+        };
+        await orderManager.addOrder(mockOrder as any);
+        await orderManager.addOrder(adminOrder as any);
+
+        // new owner profile gets the configured default limit,
+        // the admin configured limit stays untouched
+        const ownerProfileMap = orderManager.ownersMap.get("0xorderbook");
+        expect(ownerProfileMap?.get("0xowner")?.limit).toBe(7);
+        expect(ownerProfileMap?.get("0xadmin")?.limit).toBe(75);
+
+        // reset also uses the configured default limit
+        ownerProfileMap!.get("0xowner")!.limit = 1;
+        await orderManager.resetLimits();
+        expect(ownerProfileMap?.get("0xowner")?.limit).toBe(7);
+        expect(ownerProfileMap?.get("0xadmin")?.limit).toBe(75);
+    });
+
     it("getOrderPairs should return all valid input/output v3 pairs", async () => {
         const orderStruct = {
             type: Order.Type.V3,

--- a/src/order/index.test.ts
+++ b/src/order/index.test.ts
@@ -615,6 +615,68 @@ describe("Test OrderManager", () => {
         expect(Array.isArray(takeOrder.struct.signedContext)).toBe(true);
     });
 
+    it("should put zero output balance pair of max owner in zeroOutput list by default", async () => {
+        (state as any).appOptions = {
+            ownerProfile: { "0xowner": Number.MAX_SAFE_INTEGER },
+        };
+        const mockOrder = {
+            orderHash: "0xhash",
+            orderbook: { id: "0xorderbook" },
+            orderBytes: "0xbytes",
+            outputs: [{ token: { address: "0xoutput", symbol: "OUT" }, balance: 0n }],
+            inputs: [{ token: { address: "0xinput", symbol: "IN" }, balance: 2n }],
+        };
+        await orderManager.addOrder(mockOrder as any);
+
+        const result = orderManager.getNextRoundOrders();
+
+        expect(result.nonZeroOutput.length).toBe(0);
+        expect(result.zeroOutput.length).toBe(1);
+        expect(result.zeroOutput[0].takeOrder.id).toBe("0xhash");
+    });
+
+    it("should put zero output balance pair of max owner in nonZeroOutput list when enabled", async () => {
+        (state as any).appOptions = {
+            strictMaxOwnerProfileCheck: true,
+            ownerProfile: { "0xowner": Number.MAX_SAFE_INTEGER },
+        };
+        const mockOrder = {
+            orderHash: "0xhash",
+            orderbook: { id: "0xorderbook" },
+            orderBytes: "0xbytes",
+            outputs: [{ token: { address: "0xoutput", symbol: "OUT" }, balance: 0n }],
+            inputs: [{ token: { address: "0xinput", symbol: "IN" }, balance: 2n }],
+        };
+        await orderManager.addOrder(mockOrder as any);
+
+        const result = orderManager.getNextRoundOrders();
+
+        expect(result.zeroOutput.length).toBe(0);
+        expect(result.nonZeroOutput.length).toBe(1);
+        expect(result.nonZeroOutput[0].takeOrder.id).toBe("0xhash");
+    });
+
+    it("should keep zero output balance pair of non max owner in zeroOutput list when enabled", async () => {
+        (state as any).appOptions = {
+            strictMaxOwnerProfileCheck: true,
+            ownerProfile: { "0xowner": 100 }, // not max profile
+        };
+        const mockOrder = {
+            orderHash: "0xhash",
+            orderbook: { id: "0xorderbook" },
+            orderBytes: "0xbytes",
+            outputs: [{ token: { address: "0xoutput", symbol: "OUT" }, balance: 0n }],
+            inputs: [{ token: { address: "0xinput", symbol: "IN" }, balance: 2n }],
+        };
+        await orderManager.addOrder(mockOrder as any);
+
+        const result = orderManager.getNextRoundOrders();
+
+        expect(result.nonZeroOutput.length).toBe(0);
+        expect(result.zeroOutput.length).toBe(1);
+        expect(result.zeroOutput[0].takeOrder.id).toBe("0xhash");
+    });
+
     it("should reset limits to default", async () => {
         const mockOrder = {
             owner: "0xowner",

--- a/src/order/index.ts
+++ b/src/order/index.ts
@@ -497,9 +497,14 @@ export class OrderManager {
                                 ),
                             )?.balance ?? pair.buyTokenVaultBalance;
 
+                    // zero output balance pairs are skipped, unless they belong to a max
+                    // profile owner and including them is explicitly enabled by config
                     if (
                         pair.sellTokenVaultBalance <= 0n &&
-                        !AppOptions.isMaxOwnerProfile(owner, this.state.appOptions.ownerProfile)
+                        !(
+                            this.state.appOptions.strictMaxOwnerProfileCheck &&
+                            AppOptions.isMaxOwnerProfile(owner, this.state.appOptions.ownerProfile)
+                        )
                     ) {
                         result.zeroOutput.push(pair);
                     } else {

--- a/src/order/index.ts
+++ b/src/order/index.ts
@@ -28,7 +28,7 @@ export * from "./error";
 export * from "./config";
 
 /** The default owner limit */
-export const DEFAULT_OWNER_LIMIT = 25 as const;
+export const DEFAULT_OWNER_LIMIT = 5 as const;
 
 /**
  * OrderManager is responsible for managing orders state for Rainsolver during runtime, it

--- a/src/order/index.ts
+++ b/src/order/index.ts
@@ -1,5 +1,6 @@
 import { erc20Abi } from "viem";
 import { syncOrders } from "./sync";
+import { DEFAULT_OWNER_LIMIT } from "./config";
 import { SgOrder } from "../subgraph";
 import { SharedState } from "../state";
 import { errorSnapshot } from "../error";
@@ -27,9 +28,6 @@ export * from "./quote";
 export * from "./error";
 export * from "./config";
 
-/** The default owner limit */
-export const DEFAULT_OWNER_LIMIT = 5 as const;
-
 /**
  * OrderManager is responsible for managing orders state for Rainsolver during runtime, it
  * extends SubgraphManager to fetch and sync order details from subgraphs as well as providing
@@ -40,6 +38,8 @@ export class OrderManager {
     readonly quoteGas: bigint;
     /** Owner limits per round */
     readonly ownerLimits: Record<string, number>;
+    /** The default limit for owners without a configured profile */
+    readonly defaultOwnerLimit: number;
     /** Shared state instance */
     readonly state: SharedState;
     /** Subgraph manager instance */
@@ -93,6 +93,7 @@ export class OrderManager {
         this.ownerTokenVaultMap = new Map();
         this.quoteGas = state.orderManagerConfig.quoteGas;
         this.ownerLimits = state.orderManagerConfig.ownerLimits;
+        this.defaultOwnerLimit = state.orderManagerConfig.defaultOwnerLimit ?? DEFAULT_OWNER_LIMIT;
         this.subgraphManager = subgraphManager ?? new SubgraphManager(state.subgraphConfig);
     }
 
@@ -176,7 +177,7 @@ export class OrderManager {
                 takeOrders: pairs as any,
             };
             orderbookOwnerProfileItem.set(orderStruct.owner, {
-                limit: this.ownerLimits[orderStruct.owner] ?? DEFAULT_OWNER_LIMIT,
+                limit: this.ownerLimits[orderStruct.owner] ?? this.defaultOwnerLimit,
                 orders: new Map([[orderHash, order]]),
                 lastIndex: 0,
             });
@@ -535,7 +536,7 @@ export class OrderManager {
                 ownersProfileMap.forEach((ownerProfile, owner) => {
                     // skip if owner limit is set by bot admin
                     if (typeof this.ownerLimits[owner] === "number") return;
-                    ownerProfile.limit = DEFAULT_OWNER_LIMIT;
+                    ownerProfile.limit = this.defaultOwnerLimit;
                 });
             }
         });

--- a/src/order/quote.ts
+++ b/src/order/quote.ts
@@ -50,6 +50,7 @@ export async function quoteSingleOrderV3(
                 args: [TakeOrder.getQuoteConfig(orderDetails.takeOrder.struct)],
             }),
             gas,
+            blockTag: "pending",
         })
         .catch((error) => {
             orderDetails.takeOrder.quote = undefined;
@@ -94,6 +95,7 @@ export async function quoteSingleOrderV4(
                 args: [TakeOrder.getQuoteConfig(orderDetails.takeOrder.struct)],
             }),
             gas,
+            blockTag: "pending",
         })
         .catch((error) => {
             orderDetails.takeOrder.quote = undefined;

--- a/src/signer/actions.test.ts
+++ b/src/signer/actions.test.ts
@@ -220,7 +220,7 @@ describe("Test estimateGasCost", () => {
     it("should calculate basic gas cost non-L2 chains", async () => {
         const result = await estimateGasCost(mockSigner, mockTx);
 
-        expect(mockSigner.estimateGas).toHaveBeenCalledWith(mockTx);
+        expect(mockSigner.estimateGas).toHaveBeenCalledWith({ ...mockTx, blockTag: "pending" });
         expect(result).toEqual({
             gas: 100000n,
             gasPrice: 20000000000n, // 20 gwei * 110%

--- a/src/signer/actions.ts
+++ b/src/signer/actions.ts
@@ -199,7 +199,7 @@ export async function estimateGasCost(
     tx: EstimateGasParameters<Chain>,
 ): Promise<EstimateGasCostResult> {
     const gasPrice = signer.state.gasPrice;
-    const gas = await signer.estimateGas(tx);
+    const gas = await signer.estimateGas({ ...tx, blockTag: "pending" } as any);
     const result: EstimateGasCostResult = {
         gas,
         gasPrice,


### PR DESCRIPTION
<!-- Thanks for your Pull Request, please read the contributing guidelines before submitting. -->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## Checks
<!-- It's important you've done these, or your PR will not be considered for review -->
By submitting this for review, I'm confirming I've done the following:
- [x] made this PR as small as possible
- [x] unit-tested any new functionality
- [ ] linked any relevant issues or PRs
- [ ] included screenshots (if this involves a front-end change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added configuration for strict owner-profile checks and customizable default owner limits.
  - Owners without configured profiles now use the configured default limit, including after limit resets.
  - Added clearer write-operation details to RPC telemetry.

- **Bug Fixes**
  - Improved handling of zero-output pairs for owners at their maximum profile limit.
  - Updated quote and gas estimation requests to use the pending block, improving accuracy for current network state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->