### PR TITLE
partial fallback concurrency

### DIFF
--- a/config.env.yaml
+++ b/config.env.yaml
@@ -39,6 +39,8 @@ gasPriceMultiplier: $GAS_PRICE_MULTIPLIER
 txTimeThreshold: $TX_TIME_THRESHOLD
 blockTime: $BLOCK_TIME
 routerPartialFallback: $ROUTER_PARTIAL_FALLBACK
+routerPartialFallbackSteps: $ROUTER_PARTIAL_FALLBACK_STEPS
+routerSecondaryRouteTry: $ROUTER_SECONDARY_ROUTE_TRY
 strictMaxOwnerProfileCheck: $STRICT_MAX_OWNER_PROFILE_CHECK
 strictMaxOwnerProfilePartialTradeSizeCheck: $STRICT_MAX_OWNER_PROFILE_PARTIAL_TRADE_SIZE_CHECK
 gasBoostProfitThreshold: $GAS_BOOST_PROFIT_THRESHOLD

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -128,6 +128,13 @@ blockTime: 2000
 # Enables the halving backoff retries for router mode partial trades that get rejected onchain, default is true
 routerPartialFallback: true
 
+# The number of halving backoff steps to run concurrently for router mode partial trades that get rejected onchain, default is 4
+routerPartialFallbackSteps: 4
+
+# Sets which orders get a secondary router mode try with the failing route dexes excluded after an onchain rejection,
+# "all" for every order, "max" for orders of max profile owners only, "off" for none, default is "max"
+routerSecondaryRouteTry: max
+
 # When true, zero output balance pairs of max profile owners go to round processing, when false, all zero output balance pairs are skipped, default is false
 strictMaxOwnerProfileCheck: false
 

--- a/src/cli/commands/sweep.ts
+++ b/src/cli/commands/sweep.ts
@@ -108,6 +108,8 @@ export async function sweepFunds(opts: SweepOptions) {
         txTimeThreshold: 2_500,
         blockTime: 5_000,
         routerPartialFallback: true,
+        routerPartialFallbackSteps: 4,
+        routerSecondaryRouteTry: "max",
         strictMaxOwnerProfileCheck: false,
         strictMaxOwnerProfilePartialTradeSizeCheck: false,
         timeout: 15_000,

--- a/src/common/utils.test.ts
+++ b/src/common/utils.test.ts
@@ -1,8 +1,10 @@
 import { vi, describe, it, expect, beforeEach, afterEach, assert } from "vitest";
+import { Result } from "./result";
 import {
     sleep,
     toFloat,
     iterRandom,
+    raceFirstOk,
     shuffleArray,
     promiseTimeout,
     normalizeFloat,
@@ -315,6 +317,57 @@ describe("Test iterRandom function", () => {
         });
 
         expect(iterRandomTime).toBeLessThan(iterShuffleArrayTime);
+    });
+});
+
+describe("Test raceFirstOk", () => {
+    const delayed = <T>(ms: number, value: T): Promise<T> =>
+        new Promise((resolve) => setTimeout(() => resolve(value), ms));
+
+    it("should resolve with the first ok result", async () => {
+        const winner: Result<string, string> = Result.ok("fast");
+        const result = await raceFirstOk<string, string>([
+            Promise.resolve(Result.err("error")),
+            Promise.resolve(winner),
+            delayed<Result<string, string>>(20, Result.ok("slow")),
+        ]);
+
+        expect(result).toBe(winner);
+    });
+
+    it("should resolve with a late ok result when earlier ones are err", async () => {
+        const winner: Result<string, string> = Result.ok("slow but ok");
+        const result = await raceFirstOk<string, string>([
+            Promise.resolve(Result.err("error1")),
+            Promise.resolve(Result.err("error2")),
+            delayed(10, winner),
+        ]);
+
+        expect(result).toBe(winner);
+    });
+
+    it("should resolve undefined when all results are err", async () => {
+        const result = await raceFirstOk<string, string>([
+            Promise.resolve(Result.err("error1")),
+            delayed(10, Result.err("error2")),
+        ]);
+
+        expect(result).toBeUndefined();
+    });
+
+    it("should resolve undefined for an empty list", async () => {
+        const result = await raceFirstOk<string, string>([]);
+
+        expect(result).toBeUndefined();
+    });
+
+    it("should reject when a promise rejects", async () => {
+        await expect(
+            raceFirstOk<string, string>([
+                Promise.resolve(Result.err("error")),
+                Promise.reject(new Error("boom")),
+            ]),
+        ).rejects.toThrow("boom");
     });
 });
 

--- a/src/common/utils.ts
+++ b/src/common/utils.ts
@@ -58,6 +58,32 @@ export async function promiseTimeout<T>(
 }
 
 /**
+ * Races the given promises of Result values and resolves with the first one
+ * that resolves ok, a rejecting result (err) does not end the race, it only
+ * ends the race when it is the last one remaining, in which case the race
+ * resolves with undefined meaning all results settled with err, a rejected
+ * promise rejects the race itself
+ * @param promises - The promises of Result values to race
+ * @returns The first ok Result, or undefined when all of them are err
+ */
+export async function raceFirstOk<V, E>(
+    promises: Promise<Result<V, E>>[],
+): Promise<Result<V, E> | undefined> {
+    return await new Promise((resolve, reject) => {
+        if (!promises.length) return resolve(undefined);
+        let remaining = promises.length;
+        const settle = (result: Result<V, E>) => {
+            if (result.isOk()) {
+                resolve(result); // first ok wins the race
+            } else if (--remaining === 0) {
+                resolve(undefined); // all settled with err
+            }
+        };
+        promises.forEach((promise) => promise.then(settle, reject));
+    });
+}
+
+/**
  * Json serializer function for handling bigint type
  */
 export function withBigintSerializer(_k: string, v: any) {

--- a/src/config/validators.test.ts
+++ b/src/config/validators.test.ts
@@ -274,6 +274,39 @@ describe("Test yaml Validator methods", async function () {
         );
     });
 
+    it("test Validator resolveRouterSecondaryRouteTry", async function () {
+        // happy
+        let input: any = "all";
+        let result = Validator.resolveRouterSecondaryRouteTry(input);
+        assert.equal(result, "all");
+
+        input = "MAX";
+        result = Validator.resolveRouterSecondaryRouteTry(input);
+        assert.equal(result, "max");
+
+        input = "off";
+        result = Validator.resolveRouterSecondaryRouteTry(input);
+        assert.equal(result, "off");
+
+        // default
+        input = undefined;
+        result = Validator.resolveRouterSecondaryRouteTry(input);
+        assert.equal(result, "max");
+
+        // happy from env
+        process.env.INPUT = "all";
+        input = "$INPUT";
+        result = Validator.resolveRouterSecondaryRouteTry(input);
+        assert.equal(result, "all");
+
+        // unhappy
+        input = "some";
+        assert.throws(
+            () => Validator.resolveRouterSecondaryRouteTry(input),
+            /expected either of all, max or off for routerSecondaryRouteTry/,
+        );
+    });
+
     it("test Validator resolveRouteType", async function () {
         // happy
         let input: any = "full";

--- a/src/config/validators.ts
+++ b/src/config/validators.ts
@@ -207,6 +207,16 @@ export namespace Validator {
         else return route;
     }
 
+    /** Resolves config's router secondary route try mode */
+    export function resolveRouterSecondaryRouteTry(input: any): "all" | "max" | "off" {
+        const mode = (readValue(input).value || "max")?.toLowerCase();
+        assert(
+            typeof mode === "string" && (mode === "all" || mode === "max" || mode === "off"),
+            validationError("expected either of all, max or off for routerSecondaryRouteTry"),
+        );
+        return mode;
+    }
+
     /** Resolves config's rpcs */
     export function resolveRpc<isOptional extends boolean = false>(
         input: any,

--- a/src/config/yaml.test.ts
+++ b/src/config/yaml.test.ts
@@ -40,6 +40,8 @@ gasPriceMultiplier: 150
 txTimeThreshold: 4000
 blockTime: 3000
 routerPartialFallback: false
+routerPartialFallbackSteps: 6
+routerSecondaryRouteTry: all
 strictMaxOwnerProfileCheck: true
 strictMaxOwnerProfilePartialTradeSizeCheck: true
 checkWalletBalanceTime: 30
@@ -172,6 +174,8 @@ orderbookTradeTypes:
             convertToGasTime: 0,
             rotateMultiWallet: false,
             routerPartialFallback: false,
+            routerPartialFallbackSteps: 6,
+            routerSecondaryRouteTry: "all",
             strictMaxOwnerProfileCheck: true,
             strictMaxOwnerProfilePartialTradeSizeCheck: true,
             checkWalletBalanceTime: 30,
@@ -367,6 +371,8 @@ orderbookTradeTypes:
         assert.equal(result.convertToGasTime, 2);
         assert.equal(result.rotateMultiWallet, true);
         assert.equal(result.routerPartialFallback, true); // should be default true
+        assert.equal(result.routerPartialFallbackSteps, 4); // should be default 4
+        assert.equal(result.routerSecondaryRouteTry, "max"); // should be default max
         assert.equal(result.strictMaxOwnerProfileCheck, false); // should be default false
         assert.equal(result.strictMaxOwnerProfilePartialTradeSizeCheck, false); // should be default false
         assert.equal(result.checkWalletBalanceTime, 15); // should be default 15

--- a/src/config/yaml.ts
+++ b/src/config/yaml.ts
@@ -127,6 +127,10 @@ export type AppOptions = {
     blockTime: number;
     /** Enables the halving backoff retries for router mode partial trades that get rejected onchain, default is true */
     routerPartialFallback: boolean;
+    /** The number of halving backoff steps to run concurrently for router mode partial trades that get rejected onchain, default is 4 */
+    routerPartialFallbackSteps: number;
+    /** Sets which orders get a secondary router mode try with the failing route dexes excluded after an onchain rejection, "all" for every order, "max" for orders of max profile owners only, "off" for none, default is "max" */
+    routerSecondaryRouteTry: "all" | "max" | "off";
     /** When true, zero output balance pairs of max profile owners go to round processing, when false, all zero output balance pairs are skipped, default is false */
     strictMaxOwnerProfileCheck: boolean;
     /** When true, the router mode fallback partial trade backoff runs on any partial sim failure for orders of max profile owners, default is false */
@@ -214,6 +218,18 @@ export namespace AppOptions {
                         assert(
                             defaultOwnerLimit > 0,
                             "invalid defaultOwnerLimit value, must be an integer greater than 0",
+                        ),
+                ),
+                routerPartialFallbackSteps: Validator.resolveNumericValue(
+                    input.routerPartialFallbackSteps,
+                    INT_PATTERN,
+                    "invalid routerPartialFallbackSteps value, must be an integer greater than 0",
+                    "4",
+                    undefined,
+                    (routerPartialFallbackSteps) =>
+                        assert(
+                            routerPartialFallbackSteps > 0,
+                            "invalid routerPartialFallbackSteps value, must be an integer greater than 0",
                         ),
                 ),
                 selfFundVaults: Validator.resolveSelfFundVaults(input.selfFundVaults),
@@ -403,6 +419,9 @@ export namespace AppOptions {
                     input.routerPartialFallback,
                     "expected a boolean value for routerPartialFallback",
                     true,
+                ),
+                routerSecondaryRouteTry: Validator.resolveRouterSecondaryRouteTry(
+                    input.routerSecondaryRouteTry,
                 ),
                 strictMaxOwnerProfileCheck: Validator.resolveBool(
                     input.strictMaxOwnerProfileCheck,

--- a/src/core/modes/router/index.test.ts
+++ b/src/core/modes/router/index.test.ts
@@ -508,7 +508,8 @@ describe("Test findBestRouterTrade", () => {
             .mockResolvedValueOnce(mockFullTradeError) // full size
             .mockResolvedValueOnce(mockViolationError) // partial size 1000n
             .mockResolvedValueOnce(mockViolationError) // partialFallback1 500n
-            .mockResolvedValueOnce(mockFallbackSuccess); // partialFallback2 250n
+            .mockResolvedValueOnce(mockFallbackSuccess) // partialFallback2 250n
+            .mockResolvedValue(mockViolationError); // remaining fallbacks
         (mockRainSolver.state.router.findLargestTradeSize as Mock).mockReturnValue({
             status: TradeSizeStatus.Found,
             size: 1000n,
@@ -524,10 +525,11 @@ describe("Test findBestRouterTrade", () => {
             blockNumber,
         );
 
+        // all 4 fallback sims launch concurrently and the successful one wins
         assert(result.isOk());
         expect(result.value.spanAttributes).toEqual({ foundOpp: true });
         expect(result.value.estimatedProfit).toBe(25n);
-        expect(trySimulateTradeSpy).toHaveBeenCalledTimes(4);
+        expect(trySimulateTradeSpy).toHaveBeenCalledTimes(6);
         expect(simulatorWithArgsSpy).toHaveBeenNthCalledWith(
             3,
             expect.objectContaining({ maximumInputFixed: 500n, isPartial: true }),
@@ -535,6 +537,14 @@ describe("Test findBestRouterTrade", () => {
         expect(simulatorWithArgsSpy).toHaveBeenNthCalledWith(
             4,
             expect.objectContaining({ maximumInputFixed: 250n, isPartial: true }),
+        );
+        expect(simulatorWithArgsSpy).toHaveBeenNthCalledWith(
+            5,
+            expect.objectContaining({ maximumInputFixed: 125n, isPartial: true }),
+        );
+        expect(simulatorWithArgsSpy).toHaveBeenNthCalledWith(
+            6,
+            expect.objectContaining({ maximumInputFixed: 62n, isPartial: true }),
         );
         // fallback sims never get a precomputed quote, their halved
         // sizes differ from the size the search probed
@@ -618,7 +628,8 @@ describe("Test findBestRouterTrade", () => {
         (trySimulateTradeSpy as Mock)
             .mockResolvedValueOnce(mockFullTradeError) // full size
             .mockResolvedValueOnce(mockViolationError) // partial size
-            .mockResolvedValueOnce(mockOtherError); // partialFallback1
+            .mockResolvedValueOnce(mockOtherError) // partialFallback1
+            .mockResolvedValue(mockViolationError); // remaining fallbacks
         (mockRainSolver.state.router.findLargestTradeSize as Mock).mockReturnValue({
             status: TradeSizeStatus.Found,
             size: 1000n,
@@ -635,10 +646,96 @@ describe("Test findBestRouterTrade", () => {
         );
 
         assert(result.isErr());
-        // 1 full + 1 partial + 1 fallback, stopped early
-        expect(trySimulateTradeSpy).toHaveBeenCalledTimes(3);
+        // all fallback steps run concurrently, a non retry error on one
+        // step does not stop the others anymore
+        expect(trySimulateTradeSpy).toHaveBeenCalledTimes(6);
         expect(result.error.spanAttributes["partialFallback1.error"]).toBe("some other revert");
-        expect(result.error.spanAttributes["partialFallback2.error"]).toBeUndefined();
+        expect(result.error.spanAttributes["partialFallback2.error"]).toContain(
+            "MinimalOutputBalanceViolation",
+        );
+        expect(result.error.spanAttributes["partialFallback4.error"]).toContain(
+            "MinimalOutputBalanceViolation",
+        );
+    });
+
+    it("should drop halved sizes that reach zero", async () => {
+        const mockFullTradeError = Result.err({
+            type: TradeType.RouteProcessor,
+            reason: SimulationHaltReason.OrderRatioGreaterThanMarketPrice,
+            spanAttributes: { error: "ratio too high" },
+            noneNodeError: "order ratio issue",
+        });
+        const mockViolationError = Result.err({
+            type: TradeType.RouteProcessor,
+            reason: SimulationHaltReason.NoOpportunity,
+            spanAttributes: {
+                error: "execution reverted: MinimalOutputBalanceViolation(0xtoken, 123)",
+            },
+        });
+
+        (trySimulateTradeSpy as Mock)
+            .mockResolvedValueOnce(mockFullTradeError) // full size
+            .mockResolvedValue(mockViolationError); // partial + all fallbacks
+        (mockRainSolver.state.router.findLargestTradeSize as Mock).mockReturnValue({
+            status: TradeSizeStatus.Found,
+            size: 8n, // tiny size, halves to 4, 2, 1 and then to zero
+        });
+
+        const result: SimulationResult = await findBestRouterTrade.call(
+            mockRainSolver,
+            orderDetails,
+            signer,
+            ethPrice,
+            toToken,
+            fromToken,
+            blockNumber,
+        );
+
+        assert(result.isErr());
+        // 1 full + 1 partial + only 3 fallbacks since the 4th halving hits zero
+        expect(trySimulateTradeSpy).toHaveBeenCalledTimes(5);
+        expect(simulatorWithArgsSpy).toHaveBeenLastCalledWith(
+            expect.objectContaining({ maximumInputFixed: 1n, isPartial: true }),
+        );
+        expect(result.error.spanAttributes["partialFallback3.error"]).toContain(
+            "MinimalOutputBalanceViolation",
+        );
+        expect(result.error.spanAttributes["partialFallback4.error"]).toBeUndefined();
+    });
+
+    it("should not run backoff when no trade size was found even for strict checked max owner", async () => {
+        mockRainSolver.appOptions.strictMaxOwnerProfilePartialTradeSizeCheck = true;
+        mockRainSolver.appOptions.ownerProfile = { "0xowner": Number.MAX_SAFE_INTEGER };
+        const mockFullTradeError = Result.err({
+            type: TradeType.Router,
+            reason: SimulationHaltReason.NoRoute,
+            spanAttributes: { error: "no route" },
+            noneNodeError: "no route available",
+        });
+
+        (trySimulateTradeSpy as Mock).mockResolvedValue(mockFullTradeError);
+        (mockRainSolver.state.router.findLargestTradeSize as Mock).mockReturnValue({
+            status: TradeSizeStatus.NoWay,
+        });
+
+        const result: SimulationResult = await findBestRouterTrade.call(
+            mockRainSolver,
+            orderDetails,
+            signer,
+            ethPrice,
+            toToken,
+            fromToken,
+            blockNumber,
+        );
+
+        // no way means no way, only the full size sim runs and the
+        // error returns directly without any partial or fallback sims
+        assert(result.isErr());
+        expect(trySimulateTradeSpy).toHaveBeenCalledTimes(1);
+        expect(result.error.spanAttributes["partial.error"]).toBe(
+            "found no route for any trade size",
+        );
+        expect(result.error.spanAttributes["partialFallback1.error"]).toBeUndefined();
     });
 
     it("should skip backoff when routerPartialFallback is disabled in config", async () => {
@@ -709,7 +806,8 @@ describe("Test findBestRouterTrade", () => {
         (trySimulateTradeSpy as Mock)
             .mockResolvedValueOnce(mockFullTradeError) // full size
             .mockResolvedValueOnce(mockPartialError) // partial size
-            .mockResolvedValueOnce(mockFallbackSuccess); // partialFallback1
+            .mockResolvedValueOnce(mockFallbackSuccess) // partialFallback1
+            .mockResolvedValue(mockPartialError); // remaining fallbacks
         (mockRainSolver.state.router.findLargestTradeSize as Mock).mockReturnValue({
             status: TradeSizeStatus.PriceMismatch,
             size: 1000n,
@@ -730,7 +828,7 @@ describe("Test findBestRouterTrade", () => {
         // since the owner has a max profile and strict check is on
         assert(result.isOk());
         expect(result.value.estimatedProfit).toBe(25n);
-        expect(trySimulateTradeSpy).toHaveBeenCalledTimes(3);
+        expect(trySimulateTradeSpy).toHaveBeenCalledTimes(6);
         expect(simulatorWithArgsSpy).toHaveBeenNthCalledWith(
             3,
             expect.objectContaining({ maximumInputFixed: 500n, isPartial: true }),

--- a/src/core/modes/router/index.test.ts
+++ b/src/core/modes/router/index.test.ts
@@ -53,7 +53,11 @@ describe("Test findBestRouterTrade", () => {
         };
         destination = "0xdestination";
         mockRainSolver = {
-            appOptions: { routerPartialFallback: true },
+            appOptions: {
+                routerPartialFallback: true,
+                routerPartialFallbackSteps: 4,
+                routerSecondaryRouteTry: "all",
+            },
             state: {
                 gasPrice: 100n,
                 client: {
@@ -530,6 +534,66 @@ describe("Test findBestRouterTrade", () => {
         expect(result.value.spanAttributes).toEqual({ foundOpp: true });
         expect(result.value.estimatedProfit).toBe(25n);
         expect(trySimulateTradeSpy).toHaveBeenCalledTimes(6);
+        // fallback sims lock the route to the already found quote and
+        // skip the offchain price match check to go straight to dryrun
+        const fallbackArgs = { isPartial: true, lockRoute: true, skipPriceMatchCheck: true };
+        expect(simulatorWithArgsSpy).toHaveBeenNthCalledWith(
+            3,
+            expect.objectContaining({ maximumInputFixed: 500n, ...fallbackArgs }),
+        );
+        expect(simulatorWithArgsSpy).toHaveBeenNthCalledWith(
+            4,
+            expect.objectContaining({ maximumInputFixed: 250n, ...fallbackArgs }),
+        );
+        expect(simulatorWithArgsSpy).toHaveBeenNthCalledWith(
+            5,
+            expect.objectContaining({ maximumInputFixed: 125n, ...fallbackArgs }),
+        );
+        expect(simulatorWithArgsSpy).toHaveBeenNthCalledWith(
+            6,
+            expect.objectContaining({ maximumInputFixed: 62n, ...fallbackArgs }),
+        );
+        // the full and partial sims never lock the route or skip the check
+        expect((simulatorWithArgsSpy as Mock).mock.calls[0][0].lockRoute).toBeUndefined();
+        expect((simulatorWithArgsSpy as Mock).mock.calls[1][0].lockRoute).toBeUndefined();
+        expect((simulatorWithArgsSpy as Mock).mock.calls[0][0].skipPriceMatchCheck).toBeUndefined();
+        expect((simulatorWithArgsSpy as Mock).mock.calls[1][0].skipPriceMatchCheck).toBeUndefined();
+    });
+
+    it("should run as many backoff steps as configured by routerPartialFallbackSteps", async () => {
+        mockRainSolver.appOptions.routerPartialFallbackSteps = 2;
+        const mockFullTradeError = Result.err({
+            type: TradeType.RouteProcessor,
+            reason: SimulationHaltReason.OrderRatioGreaterThanMarketPrice,
+            spanAttributes: { error: "ratio too high" },
+        });
+        const mockViolationError = Result.err({
+            type: TradeType.RouteProcessor,
+            reason: SimulationHaltReason.NoOpportunity,
+            spanAttributes: {
+                error: "execution reverted: MinimalOutputBalanceViolation(0xtoken, 123)",
+            },
+        });
+        (trySimulateTradeSpy as Mock).mockResolvedValueOnce(mockFullTradeError);
+        (trySimulateTradeSpy as Mock).mockResolvedValue(mockViolationError);
+        (mockRainSolver.state.router.findLargestTradeSize as Mock).mockReturnValue({
+            status: TradeSizeStatus.Found,
+            size: 1000n,
+        });
+
+        const result: SimulationResult = await findBestRouterTrade.call(
+            mockRainSolver,
+            orderDetails,
+            signer,
+            ethPrice,
+            toToken,
+            fromToken,
+            blockNumber,
+        );
+
+        // full, partial and only 2 fallback sims
+        assert(result.isErr());
+        expect(trySimulateTradeSpy).toHaveBeenCalledTimes(4);
         expect(simulatorWithArgsSpy).toHaveBeenNthCalledWith(
             3,
             expect.objectContaining({ maximumInputFixed: 500n, isPartial: true }),
@@ -538,18 +602,229 @@ describe("Test findBestRouterTrade", () => {
             4,
             expect.objectContaining({ maximumInputFixed: 250n, isPartial: true }),
         );
-        expect(simulatorWithArgsSpy).toHaveBeenNthCalledWith(
-            5,
-            expect.objectContaining({ maximumInputFixed: 125n, isPartial: true }),
+        expect(result.error.spanAttributes["partialFallback1.error"]).toContain(
+            "MinimalOutputBalanceViolation",
         );
-        expect(simulatorWithArgsSpy).toHaveBeenNthCalledWith(
-            6,
-            expect.objectContaining({ maximumInputFixed: 62n, isPartial: true }),
+        expect(result.error.spanAttributes["partialFallback2.error"]).toContain(
+            "MinimalOutputBalanceViolation",
         );
-        // fallback sims never get a precomputed quote, their halved
-        // sizes differ from the size the search probed
-        expect((simulatorWithArgsSpy as Mock).mock.calls[2][0].sushiQuote).toBeUndefined();
-        expect((simulatorWithArgsSpy as Mock).mock.calls[3][0].sushiQuote).toBeUndefined();
+        expect(result.error.spanAttributes["partialFallback3.error"]).toBeUndefined();
+    });
+
+    it("should pick the biggest passing fallback size, not the first one that resolves", async () => {
+        const mockFullTradeError = Result.err({
+            type: TradeType.RouteProcessor,
+            reason: SimulationHaltReason.OrderRatioGreaterThanMarketPrice,
+            spanAttributes: { error: "ratio too high" },
+        });
+        const mockViolationError = Result.err({
+            type: TradeType.RouteProcessor,
+            reason: SimulationHaltReason.NoOpportunity,
+            spanAttributes: {
+                error: "execution reverted: MinimalOutputBalanceViolation(0xtoken, 123)",
+            },
+        });
+        const mockBigSuccess = Result.ok({
+            type: TradeType.RouteProcessor,
+            spanAttributes: { size: "big" },
+            estimatedProfit: 50n,
+            oppBlockNumber: 123,
+        });
+        const mockSmallSuccess = Result.ok({
+            type: TradeType.RouteProcessor,
+            spanAttributes: { size: "small" },
+            estimatedProfit: 10n,
+            oppBlockNumber: 123,
+        });
+
+        // the 250n fallback passes but resolves after the 125n one
+        (trySimulateTradeSpy as Mock)
+            .mockResolvedValueOnce(mockFullTradeError) // full size
+            .mockResolvedValueOnce(mockViolationError) // partial size 1000n
+            .mockResolvedValueOnce(mockViolationError) // partialFallback1 500n
+            .mockImplementationOnce(
+                () => new Promise((resolve) => setTimeout(() => resolve(mockBigSuccess), 20)),
+            ) // partialFallback2 250n
+            .mockResolvedValueOnce(mockSmallSuccess) // partialFallback3 125n
+            .mockResolvedValue(mockViolationError); // partialFallback4 62n
+        (mockRainSolver.state.router.findLargestTradeSize as Mock).mockReturnValue({
+            status: TradeSizeStatus.Found,
+            size: 1000n,
+        });
+
+        const result: SimulationResult = await findBestRouterTrade.call(
+            mockRainSolver,
+            orderDetails,
+            signer,
+            ethPrice,
+            toToken,
+            fromToken,
+            blockNumber,
+        );
+
+        assert(result.isOk());
+        expect(result.value.spanAttributes).toEqual({ size: "big" });
+        expect(result.value.estimatedProfit).toBe(50n);
+        expect(trySimulateTradeSpy).toHaveBeenCalledTimes(6);
+    });
+
+    it("should reuse the partial sim sushi route for fallback sims, falling back to the full sim route", async () => {
+        const fullQuote = { route: { pcMap: new Map() }, tag: "full" } as any;
+        const partialQuote = { route: { pcMap: new Map() }, tag: "partial" } as any;
+        const balancerQuote = { price: 1n, tag: "balancer" } as any;
+        const mockFullTradeError = Result.err({
+            type: TradeType.RouteProcessor,
+            reason: SimulationHaltReason.OrderRatioGreaterThanMarketPrice,
+            spanAttributes: { error: "ratio too high" },
+        });
+        const mockViolationError = Result.err({
+            type: TradeType.RouteProcessor,
+            reason: SimulationHaltReason.NoOpportunity,
+            spanAttributes: {
+                error: "execution reverted: MinimalOutputBalanceViolation(0xtoken, 123)",
+            },
+        });
+        const mockFallbackSuccess = Result.ok({
+            type: TradeType.Balancer,
+            spanAttributes: { foundOpp: true },
+            estimatedProfit: 25n,
+            oppBlockNumber: 123,
+        });
+        (mockRainSolver.state.router.findLargestTradeSize as Mock).mockReturnValue({
+            status: TradeSizeStatus.Found,
+            size: 1000n,
+        });
+
+        // partial sim has its own quote, so fallback sims reuse it
+        (simulatorWithArgsSpy as Mock)
+            .mockReturnValueOnce({
+                quote: fullQuote,
+                trySimulateTrade: vi.fn().mockResolvedValue(mockFullTradeError),
+            })
+            .mockReturnValueOnce({
+                quote: partialQuote,
+                trySimulateTrade: vi.fn().mockResolvedValue(mockViolationError),
+            })
+            .mockReturnValue({
+                quote: partialQuote,
+                trySimulateTrade: vi.fn().mockResolvedValue(mockFallbackSuccess),
+            });
+        let result: SimulationResult = await findBestRouterTrade.call(
+            mockRainSolver,
+            orderDetails,
+            signer,
+            ethPrice,
+            toToken,
+            fromToken,
+            blockNumber,
+        );
+        assert(result.isOk());
+        expect(simulatorWithArgsSpy).toHaveBeenCalledTimes(6);
+        for (let i = 2; i < 6; i++) {
+            const args = (simulatorWithArgsSpy as Mock).mock.calls[i][0];
+            expect(args.sushiQuote).toBe(partialQuote);
+            expect(args.lockRoute).toBe(true);
+            expect(args.skipPriceMatchCheck).toBe(true);
+        }
+
+        // partial sim has no quote, so fallback sims reuse the full sim one
+        (simulatorWithArgsSpy as Mock).mockReset();
+        (simulatorWithArgsSpy as Mock)
+            .mockReturnValueOnce({
+                quote: fullQuote,
+                trySimulateTrade: vi.fn().mockResolvedValue(mockFullTradeError),
+            })
+            .mockReturnValueOnce({
+                quote: undefined,
+                trySimulateTrade: vi.fn().mockResolvedValue(mockViolationError),
+            })
+            .mockReturnValue({
+                quote: fullQuote,
+                trySimulateTrade: vi.fn().mockResolvedValue(mockFallbackSuccess),
+            });
+        result = await findBestRouterTrade.call(
+            mockRainSolver,
+            orderDetails,
+            signer,
+            ethPrice,
+            toToken,
+            fromToken,
+            blockNumber,
+        );
+        assert(result.isOk());
+        expect(simulatorWithArgsSpy).toHaveBeenCalledTimes(6);
+        for (let i = 2; i < 6; i++) {
+            const args = (simulatorWithArgsSpy as Mock).mock.calls[i][0];
+            expect(args.sushiQuote).toBe(fullQuote);
+            expect(args.lockRoute).toBe(true);
+        }
+
+        // partial sim quote is not a sushi one, so fallback sims skip it
+        // and reuse the full sim sushi quote instead
+        (simulatorWithArgsSpy as Mock).mockReset();
+        (simulatorWithArgsSpy as Mock)
+            .mockReturnValueOnce({
+                quote: fullQuote,
+                trySimulateTrade: vi.fn().mockResolvedValue(mockFullTradeError),
+            })
+            .mockReturnValueOnce({
+                quote: balancerQuote,
+                trySimulateTrade: vi.fn().mockResolvedValue(mockViolationError),
+            })
+            .mockReturnValue({
+                quote: fullQuote,
+                trySimulateTrade: vi.fn().mockResolvedValue(mockFallbackSuccess),
+            });
+        result = await findBestRouterTrade.call(
+            mockRainSolver,
+            orderDetails,
+            signer,
+            ethPrice,
+            toToken,
+            fromToken,
+            blockNumber,
+        );
+        assert(result.isOk());
+        expect(simulatorWithArgsSpy).toHaveBeenCalledTimes(6);
+        for (let i = 2; i < 6; i++) {
+            const args = (simulatorWithArgsSpy as Mock).mock.calls[i][0];
+            expect(args.sushiQuote).toBe(fullQuote);
+            expect(args.lockRoute).toBe(true);
+        }
+
+        // neither sim has a sushi quote, so fallback sims carry no quote to
+        // lock to and get quoted normally
+        (simulatorWithArgsSpy as Mock).mockReset();
+        (simulatorWithArgsSpy as Mock)
+            .mockReturnValueOnce({
+                quote: balancerQuote,
+                trySimulateTrade: vi.fn().mockResolvedValue(mockFullTradeError),
+            })
+            .mockReturnValueOnce({
+                quote: balancerQuote,
+                trySimulateTrade: vi.fn().mockResolvedValue(mockViolationError),
+            })
+            .mockReturnValue({
+                quote: balancerQuote,
+                trySimulateTrade: vi.fn().mockResolvedValue(mockFallbackSuccess),
+            });
+        result = await findBestRouterTrade.call(
+            mockRainSolver,
+            orderDetails,
+            signer,
+            ethPrice,
+            toToken,
+            fromToken,
+            blockNumber,
+        );
+        assert(result.isOk());
+        expect(simulatorWithArgsSpy).toHaveBeenCalledTimes(6);
+        for (let i = 2; i < 6; i++) {
+            expect((simulatorWithArgsSpy as Mock).mock.calls[i][0].sushiQuote).toBeUndefined();
+        }
+
+        // drop the persistent mock impl so it doesnt leak into other tests
+        (simulatorWithArgsSpy as Mock).mockRestore();
     });
 
     it("should return error with MinimalOutputBalanceViolation reason when all backoff steps fail", async () => {
@@ -913,6 +1188,177 @@ describe("Test findBestRouterTrade", () => {
         expect(result.error.spanAttributes["partialFallback1.error"]).toBeUndefined();
     });
 
+    describe("full trade size backoff", () => {
+        // a sushi quote with no route legs, so the dex exclusion retry stays out
+        const fullQuote = { route: { route: { legs: [] }, pcMap: new Map() }, tag: "full" } as any;
+        const mockViolationError = Result.err({
+            type: TradeType.RouteProcessor,
+            reason: SimulationHaltReason.NoOpportunity,
+            spanAttributes: {
+                error: "execution reverted: MinimalOutputBalanceViolation(0xtoken, 123)",
+            },
+            noneNodeError: "full violation",
+        });
+        const mockFallbackSuccess = Result.ok({
+            type: TradeType.RouteProcessor,
+            spanAttributes: { foundOpp: true },
+            estimatedProfit: 25n,
+            oppBlockNumber: 123,
+        });
+
+        it("should backoff from full size with the full route locked when full dryrun fails with MinimalOutputBalanceViolation", async () => {
+            (simulatorWithArgsSpy as Mock)
+                .mockReturnValueOnce({
+                    quote: fullQuote,
+                    trySimulateTrade: vi.fn().mockResolvedValue(mockViolationError),
+                })
+                .mockReturnValueOnce({
+                    quote: fullQuote,
+                    trySimulateTrade: vi.fn().mockResolvedValue(mockViolationError),
+                })
+                .mockReturnValue({
+                    quote: fullQuote,
+                    trySimulateTrade: vi.fn().mockResolvedValue(mockFallbackSuccess),
+                });
+
+            const result: SimulationResult = await findBestRouterTrade.call(
+                mockRainSolver,
+                orderDetails,
+                signer,
+                ethPrice,
+                toToken,
+                fromToken,
+                blockNumber,
+            );
+
+            // the size finder is skipped and the 4 halved sizes of the
+            // full size run straight away with the full route locked in
+            assert(result.isOk());
+            expect(result.value.spanAttributes).toEqual({ foundOpp: true });
+            expect(mockRainSolver.state.router.findLargestTradeSize).not.toHaveBeenCalled();
+            expect(simulatorWithArgsSpy).toHaveBeenCalledTimes(5);
+            expect(simulatorWithArgsSpy).toHaveBeenNthCalledWith(
+                1,
+                expect.objectContaining({ maximumInputFixed: 1000n, isPartial: false }),
+            );
+            const fallbackArgs = {
+                isPartial: true,
+                sushiQuote: fullQuote,
+                lockRoute: true,
+                skipPriceMatchCheck: true,
+            };
+            expect(simulatorWithArgsSpy).toHaveBeenNthCalledWith(
+                2,
+                expect.objectContaining({ maximumInputFixed: 500n, ...fallbackArgs }),
+            );
+            expect(simulatorWithArgsSpy).toHaveBeenNthCalledWith(
+                3,
+                expect.objectContaining({ maximumInputFixed: 250n, ...fallbackArgs }),
+            );
+            expect(simulatorWithArgsSpy).toHaveBeenNthCalledWith(
+                4,
+                expect.objectContaining({ maximumInputFixed: 125n, ...fallbackArgs }),
+            );
+            expect(simulatorWithArgsSpy).toHaveBeenNthCalledWith(
+                5,
+                expect.objectContaining({ maximumInputFixed: 62n, ...fallbackArgs }),
+            );
+            expect((simulatorWithArgsSpy as Mock).mock.calls[0][0].lockRoute).toBeUndefined();
+
+            (simulatorWithArgsSpy as Mock).mockRestore();
+        });
+
+        it("should return the full error with fallback attributes when all full size backoff steps fail", async () => {
+            (simulatorWithArgsSpy as Mock).mockReturnValue({
+                quote: fullQuote,
+                trySimulateTrade: vi.fn().mockResolvedValue(mockViolationError),
+            });
+
+            const result: SimulationResult = await findBestRouterTrade.call(
+                mockRainSolver,
+                orderDetails,
+                signer,
+                ethPrice,
+                toToken,
+                fromToken,
+                blockNumber,
+            );
+
+            assert(result.isErr());
+            expect(result.error.reason).toBe(SimulationHaltReason.NoOpportunity);
+            expect(result.error.noneNodeError).toBe("full violation");
+            expect(result.error.spanAttributes["full.error"]).toContain(
+                "MinimalOutputBalanceViolation",
+            );
+            for (let i = 1; i <= 4; i++) {
+                expect(result.error.spanAttributes[`partialFallback${i}.error`]).toContain(
+                    "MinimalOutputBalanceViolation",
+                );
+            }
+            expect(result.error.spanAttributes["partial.error"]).toBeUndefined();
+            expect(mockRainSolver.state.router.findLargestTradeSize).not.toHaveBeenCalled();
+            expect(simulatorWithArgsSpy).toHaveBeenCalledTimes(5);
+
+            (simulatorWithArgsSpy as Mock).mockRestore();
+        });
+
+        it("should not backoff from full size when routerPartialFallback is disabled", async () => {
+            mockRainSolver.appOptions.routerPartialFallback = false;
+            (simulatorWithArgsSpy as Mock).mockReturnValue({
+                quote: fullQuote,
+                trySimulateTrade: vi.fn().mockResolvedValue(mockViolationError),
+            });
+
+            const result: SimulationResult = await findBestRouterTrade.call(
+                mockRainSolver,
+                orderDetails,
+                signer,
+                ethPrice,
+                toToken,
+                fromToken,
+                blockNumber,
+            );
+
+            assert(result.isErr());
+            expect(result.error.reason).toBe(SimulationHaltReason.NoOpportunity);
+            expect(result.error.spanAttributes["partialFallback1.error"]).toBeUndefined();
+            expect(mockRainSolver.state.router.findLargestTradeSize).not.toHaveBeenCalled();
+            expect(simulatorWithArgsSpy).toHaveBeenCalledTimes(1);
+
+            (simulatorWithArgsSpy as Mock).mockRestore();
+        });
+
+        it("should not backoff from full size when full dryrun fails with a non retry error", async () => {
+            const mockOtherError = Result.err({
+                type: TradeType.RouteProcessor,
+                reason: SimulationHaltReason.NoOpportunity,
+                spanAttributes: { error: "execution reverted: SomeOtherError()" },
+            });
+            (simulatorWithArgsSpy as Mock).mockReturnValue({
+                quote: fullQuote,
+                trySimulateTrade: vi.fn().mockResolvedValue(mockOtherError),
+            });
+
+            const result: SimulationResult = await findBestRouterTrade.call(
+                mockRainSolver,
+                orderDetails,
+                signer,
+                ethPrice,
+                toToken,
+                fromToken,
+                blockNumber,
+            );
+
+            assert(result.isErr());
+            expect(result.error.reason).toBe(SimulationHaltReason.NoOpportunity);
+            expect(result.error.spanAttributes["partialFallback1.error"]).toBeUndefined();
+            expect(mockRainSolver.state.router.findLargestTradeSize).not.toHaveBeenCalled();
+            expect(simulatorWithArgsSpy).toHaveBeenCalledTimes(1);
+
+            (simulatorWithArgsSpy as Mock).mockRestore();
+        });
+    });
+
     it("should retry with the failing route dexes excluded when full trade dryrun fails", async () => {
         const sushiQuote = {
             route: {
@@ -969,6 +1415,81 @@ describe("Test findBestRouterTrade", () => {
             excludeDexes: new Set(["Hydrex"]),
         });
         expect(mockRainSolver.state.router.findLargestTradeSize).not.toHaveBeenCalled();
+    });
+
+    describe("routerSecondaryRouteTry config", () => {
+        const sushiQuote = {
+            route: {
+                pcMap: new Map([["pool1", { liquidityProvider: "Hydrex" }]]),
+                route: { legs: [{ uniqueId: "pool1" }] },
+            },
+        } as any;
+        const mockFullTradeError = Result.err({
+            type: TradeType.RouteProcessor,
+            reason: SimulationHaltReason.NoOpportunity,
+            spanAttributes: { error: "dryrun failed" },
+        });
+        const mockRetrySuccess = Result.ok({
+            type: TradeType.RouteProcessor,
+            spanAttributes: { foundOpp: true },
+            estimatedProfit: 50n,
+            oppBlockNumber: 123,
+        });
+        const runWithMode = async (mode: string, ownerProfile?: Record<string, number>) => {
+            mockRainSolver.appOptions.routerSecondaryRouteTry = mode;
+            mockRainSolver.appOptions.ownerProfile = ownerProfile;
+            (simulatorWithArgsSpy as Mock)
+                .mockReturnValueOnce({
+                    quote: sushiQuote,
+                    trySimulateTrade: vi.fn().mockResolvedValue(mockFullTradeError),
+                })
+                .mockReturnValueOnce({
+                    quote: sushiQuote,
+                    trySimulateTrade: vi.fn().mockResolvedValue(mockRetrySuccess),
+                });
+            return findBestRouterTrade.call(
+                mockRainSolver,
+                orderDetails,
+                signer,
+                ethPrice,
+                toToken,
+                fromToken,
+                blockNumber,
+            );
+        };
+
+        it("should retry for every order when set to all", async () => {
+            const result = await runWithMode("all");
+            assert(result.isOk());
+            expect(simulatorWithArgsSpy).toHaveBeenCalledTimes(2);
+            expect(simulatorWithArgsSpy).toHaveBeenLastCalledWith(
+                expect.objectContaining({ excludeDexes: new Set(["Hydrex"]) }),
+            );
+        });
+
+        it("should retry only for max profile owners when set to max", async () => {
+            // non max owner, no retry
+            let result = await runWithMode("max", { "0xother": Number.MAX_SAFE_INTEGER });
+            assert(result.isErr());
+            expect(result.error.spanAttributes["secondary.full.error"]).toBeUndefined();
+            expect(simulatorWithArgsSpy).toHaveBeenCalledTimes(1);
+
+            // max owner, retry
+            (simulatorWithArgsSpy as Mock).mockReset();
+            result = await runWithMode("max", { "0xowner": Number.MAX_SAFE_INTEGER });
+            assert(result.isOk());
+            expect(simulatorWithArgsSpy).toHaveBeenCalledTimes(2);
+            expect(simulatorWithArgsSpy).toHaveBeenLastCalledWith(
+                expect.objectContaining({ excludeDexes: new Set(["Hydrex"]) }),
+            );
+        });
+
+        it("should never retry when set to off", async () => {
+            const result = await runWithMode("off", { "0xowner": Number.MAX_SAFE_INTEGER });
+            assert(result.isErr());
+            expect(result.error.spanAttributes["secondary.full.error"]).toBeUndefined();
+            expect(simulatorWithArgsSpy).toHaveBeenCalledTimes(1);
+        });
     });
 
     it("should return error when retry attempt also fails", async () => {

--- a/src/core/modes/router/index.ts
+++ b/src/core/modes/router/index.ts
@@ -9,7 +9,7 @@ import { RouterTradeSimulator } from "./simulate";
 import { SimulationHaltReason } from "../simulator";
 import { SushiRouterQuote, TradeSizeStatus } from "../../../router";
 import { SimulationResult, TradeType } from "../../types";
-import { Result, extendObjectWithHeader } from "../../../common";
+import { Result, raceFirstOk, extendObjectWithHeader } from "../../../common";
 
 /** Represents the result of a router trade attempt paired with its full trade size quote */
 export type RouterTradeAttempt = {
@@ -238,12 +238,11 @@ export async function tryFindBestRouterTrade(
 
     // if the partial trade size sim got rejected onchain with MinimalOutputBalanceViolation,
     // it means the offchain pool data overestimated the output for the found partial trade
-    // size, so backoff by halving the trade size at each step validated against onchain
-    // dryrun and accept the first size that passes, the backoff stops early if a step fails
-    // with any other error, the backoff only runs when enabled by config, and for orders
-    // of max profile owners with strictMaxOwnerProfilePartialTradeSizeCheck config enabled,
-    // it runs on ANY partial sim failure, so smaller sizes get probed against the real
-    // chain even when the offchain quotes show no price match
+    // size, so backoff with halved trade sizes validated against onchain dryrun and accept
+    // the first size that passes, the backoff only runs when enabled by config, and for
+    // orders of max profile owners with strictMaxOwnerProfilePartialTradeSizeCheck config
+    // enabled, it runs on ANY partial sim failure, so smaller sizes get probed against
+    // the real chain even when the offchain quotes show no price match
     const reason = partialTradeSizeSimResult.error.reason;
     if (
         this.appOptions.routerPartialFallback &&
@@ -254,40 +253,50 @@ export async function tryFindBestRouterTrade(
                     this.appOptions.ownerProfile,
                 )))
     ) {
+        // build the halved trade sizes, dropping zero or negative entries
+        const fallbackTradeSizes: bigint[] = [];
         let fallbackTradeSize = partialTradeSize;
         for (let i = 1; i <= 4; i++) {
             fallbackTradeSize /= 2n;
             if (fallbackTradeSize <= 0n) break;
-            const partialFallbackSimulator = RouterTradeSimulator.withArgs({
+            fallbackTradeSizes.push(fallbackTradeSize);
+        }
+
+        // launch all fallback sims concurrently and take the first success,
+        // instead of stepping through the halved sizes sequentially, the sims
+        // that lose the race keep running but their outcome is discarded
+        const fallbackSims = fallbackTradeSizes.map((size) =>
+            RouterTradeSimulator.withArgs({
                 type: TradeType.Router,
                 solver: this,
                 orderDetails,
                 fromToken,
                 toToken,
                 signer,
-                maximumInputFixed: fallbackTradeSize,
+                maximumInputFixed: size,
                 ethPrice,
                 isPartial: true,
                 blockNumber,
                 excludeDexes,
-            });
-            const partialFallbackSimResult = await partialFallbackSimulator.trySimulateTrade();
-            if (partialFallbackSimResult.isOk()) {
-                return { result: partialFallbackSimResult, quote };
-            }
-            extendObjectWithHeader(
-                spanAttributes,
-                partialFallbackSimResult.error.spanAttributes,
-                `partialFallback${i}`,
-            );
-            if (
-                !SimulationHaltReason.needsRetry(
-                    partialFallbackSimResult.error.spanAttributes["error"],
-                )
-            ) {
-                break;
-            }
+            }).trySimulateTrade(),
+        );
+        const fallbackPick = await raceFirstOk(fallbackSims);
+        if (fallbackPick?.isOk()) {
+            return { result: fallbackPick, quote };
         }
+
+        // all fallback sims have already settled with error at this point,
+        // merge their attributes indexed by size order, not completion order
+        const fallbackResults = await Promise.all(fallbackSims);
+        fallbackResults.forEach((fallbackResult, i) => {
+            if (fallbackResult.isErr()) {
+                extendObjectWithHeader(
+                    spanAttributes,
+                    fallbackResult.error.spanAttributes,
+                    `partialFallback${i + 1}`,
+                );
+            }
+        });
     }
     return {
         result: Result.err({

--- a/src/core/modes/router/index.ts
+++ b/src/core/modes/router/index.ts
@@ -9,7 +9,7 @@ import { RouterTradeSimulator } from "./simulate";
 import { SimulationHaltReason } from "../simulator";
 import { SushiRouterQuote, TradeSizeStatus } from "../../../router";
 import { SimulationResult, TradeType } from "../../types";
-import { Result, raceFirstOk, extendObjectWithHeader } from "../../../common";
+import { Result, extendObjectWithHeader } from "../../../common";
 
 /** Represents the result of a router trade attempt paired with its full trade size quote */
 export type RouterTradeAttempt = {
@@ -26,7 +26,8 @@ export type RouterTradeAttempt = {
  * route's dexes excluded, so the next best route is tried, this is because the
  * sushi router lib pool models can be inaccurate for some dexes leading to false
  * positive quotes that dont hold up onchain and also shadow other good routes as
- * long as they wrongly quote the best amount out
+ * long as they wrongly quote the best amount out, the routerSecondaryRouteTry config
+ * sets which orders get the secondary try, all orders, max profile owners only, or none
  * @param this - RainSolver instance
  * @param orderDetails - The details of the order to be processed
  * @param signer - The signer to be used for the trade
@@ -58,12 +59,21 @@ export async function findBestRouterTrade(
         return primary.result;
     }
 
-    // retry once more with the primary attempt's failing route dexes
-    // excluded if it was rejected onchain during dryrun
+    // retry once more with the primary attempt's failing route dexes excluded
+    // if it was rejected onchain during dryrun and the config allows it for this order
+    const secondaryRouteTry = this.appOptions.routerSecondaryRouteTry;
+    const isSecondaryRouteTryEnabled =
+        secondaryRouteTry === "all" ||
+        (secondaryRouteTry === "max" &&
+            AppOptions.isMaxOwnerProfile(
+                orderDetails.takeOrder.struct.order.owner,
+                this.appOptions.ownerProfile,
+            ));
     const excludeDexes = SushiRouterQuote.is(primary.quote)
         ? SushiRouterQuote.getRouteDexes(primary.quote)
         : new Set<LiquidityProviders>();
     if (
+        isSecondaryRouteTryEnabled &&
         primary.result.error.reason === SimulationHaltReason.NoOpportunity &&
         excludeDexes.size == 1
     ) {
@@ -162,8 +172,7 @@ export async function tryFindBestRouterTrade(
     }
     extendObjectWithHeader(spanAttributes, fullTradeSizeSimResult.error.spanAttributes, "full");
 
-    // return early if dryrun failed
-    // in other words only try partial trade size if the full trade size failed due
+    // only run the partial trade size finder if the full trade size failed due
     // to order ratio being greater than market price or there was no route for full
     // trade size, that's because if for example for a pair there is only 1 pool and that
     // pool has certain amount of reserves that cant cover the full trade size but can
@@ -173,6 +182,32 @@ export async function tryFindBestRouterTrade(
         fullTradeSizeSimResult.error.reason !==
             SimulationHaltReason.OrderRatioGreaterThanMarketPrice
     ) {
+        // if the full trade size got rejected onchain with MinimalOutputBalanceViolation,
+        // the offchain pool data overestimated the output for the full size, the found
+        // route already clears the order ratio offchain, so the size finder adds nothing
+        // and the halved sizes are dryrun straight away with that route locked in
+        if (
+            this.appOptions.routerPartialFallback &&
+            fullTradeSizeSimResult.error.reason === SimulationHaltReason.NoOpportunity &&
+            SimulationHaltReason.needsRetry(fullTradeSizeSimResult.error.spanAttributes["error"])
+        ) {
+            const fallbackPick = await simulateFallbackTradeSizes.call(
+                this,
+                orderDetails,
+                signer,
+                ethPrice,
+                toToken,
+                fromToken,
+                blockNumber,
+                maximumInput,
+                spanAttributes,
+                [quote],
+                excludeDexes,
+            );
+            if (fallbackPick) {
+                return { result: fallbackPick, quote };
+            }
+        }
         return {
             result: Result.err({
                 type: fullTradeSizeSimResult.error.type,
@@ -253,50 +288,24 @@ export async function tryFindBestRouterTrade(
                     this.appOptions.ownerProfile,
                 )))
     ) {
-        // build the halved trade sizes, dropping zero or negative entries
-        const fallbackTradeSizes: bigint[] = [];
-        let fallbackTradeSize = partialTradeSize;
-        for (let i = 1; i <= 4; i++) {
-            fallbackTradeSize /= 2n;
-            if (fallbackTradeSize <= 0n) break;
-            fallbackTradeSizes.push(fallbackTradeSize);
-        }
-
-        // launch all fallback sims concurrently and take the first success,
-        // instead of stepping through the halved sizes sequentially, the sims
-        // that lose the race keep running but their outcome is discarded
-        const fallbackSims = fallbackTradeSizes.map((size) =>
-            RouterTradeSimulator.withArgs({
-                type: TradeType.Router,
-                solver: this,
-                orderDetails,
-                fromToken,
-                toToken,
-                signer,
-                maximumInputFixed: size,
-                ethPrice,
-                isPartial: true,
-                blockNumber,
-                excludeDexes,
-            }).trySimulateTrade(),
+        // the fallback sims reuse the sushi route already found by the partial
+        // sim, or by the full sim when the partial had none
+        const fallbackPick = await simulateFallbackTradeSizes.call(
+            this,
+            orderDetails,
+            signer,
+            ethPrice,
+            toToken,
+            fromToken,
+            blockNumber,
+            partialTradeSize,
+            spanAttributes,
+            [partialTradeSimulator.quote, fullTradeSimulator.quote],
+            excludeDexes,
         );
-        const fallbackPick = await raceFirstOk(fallbackSims);
-        if (fallbackPick?.isOk()) {
+        if (fallbackPick) {
             return { result: fallbackPick, quote };
         }
-
-        // all fallback sims have already settled with error at this point,
-        // merge their attributes indexed by size order, not completion order
-        const fallbackResults = await Promise.all(fallbackSims);
-        fallbackResults.forEach((fallbackResult, i) => {
-            if (fallbackResult.isErr()) {
-                extendObjectWithHeader(
-                    spanAttributes,
-                    fallbackResult.error.spanAttributes,
-                    `partialFallback${i + 1}`,
-                );
-            }
-        });
     }
     return {
         result: Result.err({
@@ -309,4 +318,88 @@ export async function tryFindBestRouterTrade(
         }),
         quote,
     };
+}
+
+/**
+ * Backs off from the given trade size with halved sizes (as many as the configured
+ * routerPartialFallbackSteps) validated against onchain dryrun and returns the biggest
+ * size that passes, the halved sims all launch concurrently
+ * and are all awaited, the sims reuse the first sushi route among the given quotes (in order of
+ * priority) instead of quoting again and skip the offchain price match check to go straight
+ * to dryrun, since the route already cleared the order ratio offchain for a bigger size,
+ * when none of the halved sizes pass, their span attributes get merged into the given
+ * attributes indexed by size order and undefined is returned
+ * @param this - RainSolver instance
+ * @param orderDetails - The details of the order to be processed
+ * @param signer - The signer to be used for the trade
+ * @param ethPrice - The current ETH price
+ * @param toToken - The token to trade to
+ * @param fromToken - The token to trade from
+ * @param blockNumber - The current block number
+ * @param startSize - The trade size to back off from, the halved sizes start at half of it
+ * @param spanAttributes - The attributes to merge the failed fallback sims attributes into
+ * @param quotes - The candidate quotes to reuse the route of, in order of priority
+ * @param excludeDexes - (optional) Liquidity providers (dexes) to exclude from route finding
+ */
+export async function simulateFallbackTradeSizes(
+    this: RainSolver,
+    orderDetails: Pair,
+    signer: RainSolverSigner,
+    ethPrice: string,
+    toToken: Token,
+    fromToken: Token,
+    blockNumber: bigint,
+    startSize: bigint,
+    spanAttributes: Attributes,
+    quotes: (RouterTradeSimulator["quote"] | undefined)[],
+    excludeDexes?: Set<LiquidityProviders>,
+): Promise<SimulationResult | undefined> {
+    // build the halved trade sizes, dropping zero or negative entries
+    const fallbackTradeSizes: bigint[] = [];
+    let fallbackTradeSize = startSize;
+    for (let i = 1; i <= this.appOptions.routerPartialFallbackSteps; i++) {
+        fallbackTradeSize /= 2n;
+        if (fallbackTradeSize <= 0n) break;
+        fallbackTradeSizes.push(fallbackTradeSize);
+    }
+
+    const sushiQuote = quotes.find(SushiRouterQuote.is);
+    const fallbackSims = fallbackTradeSizes.map((size) =>
+        RouterTradeSimulator.withArgs({
+            type: TradeType.Router,
+            solver: this,
+            orderDetails,
+            fromToken,
+            toToken,
+            signer,
+            maximumInputFixed: size,
+            ethPrice,
+            isPartial: true,
+            blockNumber,
+            excludeDexes,
+            sushiQuote,
+            lockRoute: true,
+            skipPriceMatchCheck: true,
+        }).trySimulateTrade(),
+    );
+    // wait for all sims and take the biggest size that passed, not the first
+    // one that resolved, the sims run concurrently so this only costs the
+    // slowest sim's latency, which is paid anyway when all of them fail
+    const fallbackResults = await Promise.all(fallbackSims);
+    const fallbackPick = fallbackResults.find((fallbackResult) => fallbackResult.isOk());
+    if (fallbackPick) {
+        return fallbackPick;
+    }
+
+    // merge the failed sims attributes indexed by size order
+    fallbackResults.forEach((fallbackResult, i) => {
+        if (fallbackResult.isErr()) {
+            extendObjectWithHeader(
+                spanAttributes,
+                fallbackResult.error.spanAttributes,
+                `partialFallback${i + 1}`,
+            );
+        }
+    });
+    return undefined;
 }

--- a/src/core/modes/router/simulate.test.ts
+++ b/src/core/modes/router/simulate.test.ts
@@ -260,6 +260,83 @@ describe("Test RouterTradeSimulator", () => {
             expect(mockSolver.state.contracts.getAddressesForTrade).not.toHaveBeenCalled();
         });
 
+        it("should skip the price match check when skipPriceMatchCheck is set", async () => {
+            const params = {
+                type: RouterType.Sushi,
+                quote: {
+                    type: RouterType.Sushi,
+                    status: "Success",
+                    price: ONE18 / 2n,
+                    route: {
+                        route: {},
+                        pcMap: new Map(),
+                    },
+                    amountOut: ONE18 / 2n,
+                },
+                routeVisual: ["some route"],
+                takeOrdersConfigStruct: {} as any,
+            };
+            (mockSolver.state.router.getTradeParams as Mock).mockResolvedValueOnce(
+                Result.ok(params),
+            );
+            simulator = new RouterTradeSimulator({ ...tradeArgs, skipPriceMatchCheck: true });
+
+            // the market price is lower than the order ratio, but the
+            // check is skipped so the params get built for dryrun
+            const result = await simulator.prepareTradeParams();
+            assert(result.isOk());
+            expect(result.value.type).toBe(TradeType.RouteProcessor);
+            expect(result.value.price).toBe(params.quote.price);
+            expect(simulator.spanAttributes["error"]).toBeUndefined();
+            expect(simulator.spanAttributes["routeReused"]).toBeUndefined();
+            expect(mockSolver.state.contracts.getAddressesForTrade).toHaveBeenCalledWith(
+                tradeArgs.orderDetails,
+                TradeType.RouteProcessor,
+            );
+        });
+
+        it("should pass lockRoute through and flag the reused route when locked to a sushi quote", async () => {
+            const mockSushiQuote = { route: { pcMap: new Map() }, price: 1n } as any;
+            const params = {
+                type: RouterType.Sushi,
+                quote: {
+                    type: RouterType.Sushi,
+                    status: "Success",
+                    price: 1234n * ONE18,
+                    route: {
+                        route: {},
+                        pcMap: new Map(),
+                    },
+                    amountOut: 1234n * ONE18,
+                },
+                routeVisual: ["some route"],
+                takeOrdersConfigStruct: {} as any,
+            };
+            (mockSolver.state.router.getTradeParams as Mock).mockResolvedValueOnce(
+                Result.ok(params),
+            );
+            simulator = new RouterTradeSimulator({
+                ...tradeArgs,
+                sushiQuote: mockSushiQuote,
+                lockRoute: true,
+            });
+
+            const result = await simulator.prepareTradeParams();
+            assert(result.isOk());
+            expect(simulator.spanAttributes["routeReused"]).toBe(true);
+            expect(mockSolver.state.router.getTradeParams).toHaveBeenCalledWith(
+                expect.objectContaining({ sushiQuote: mockSushiQuote, lockRoute: true }),
+            );
+
+            // lockRoute without a sushi quote does not flag the route as reused
+            (mockSolver.state.router.getTradeParams as Mock).mockResolvedValueOnce(
+                Result.ok(params),
+            );
+            simulator = new RouterTradeSimulator({ ...tradeArgs, lockRoute: true });
+            await simulator.prepareTradeParams();
+            expect(simulator.spanAttributes["routeReused"]).toBeUndefined();
+        });
+
         it("should return success", async () => {
             const params = {
                 type: RouterType.Balancer,

--- a/src/core/modes/router/simulate.ts
+++ b/src/core/modes/router/simulate.ts
@@ -47,6 +47,10 @@ export type SimulateRouterTradeArgs = {
     excludeDexes?: Set<LiquidityProviders>;
     /** Optional precomputed sushi quote for the given maximum input, avoids recomputing the same route */
     sushiQuote?: SushiRouterQuote;
+    /** Locks the trade to the route of the given `sushiQuote`, only the sushi router builds the trade params, no re-quoting */
+    lockRoute?: boolean;
+    /** Skips the offchain order ratio vs market price check and goes straight to dryrun */
+    skipPriceMatchCheck?: boolean;
 };
 
 /** Arguments for preparing router trade type parameters required for simulation and building tx object */
@@ -114,6 +118,7 @@ export class RouterTradeSimulator extends TradeSimulatorBase {
             isPartial,
             excludeDexes: this.tradeArgs.excludeDexes,
             sushiQuote: this.tradeArgs.sushiQuote,
+            lockRoute: this.tradeArgs.lockRoute,
         });
         if (tradeParamsResult.isErr()) {
             const result = {
@@ -161,9 +166,18 @@ export class RouterTradeSimulator extends TradeSimulatorBase {
         this.spanAttributes["amountOut"] = formatUnits(quote.amountOut, toToken.decimals);
         this.spanAttributes["marketPrice"] = formatUnits(quote.price, 18);
         this.spanAttributes["route"] = routeVisual;
+        if (this.tradeArgs.lockRoute && this.tradeArgs.sushiQuote) {
+            // the locked route quote belongs to a different amount, so the
+            // amountOut and marketPrice attributes above are not for this size
+            this.spanAttributes["routeReused"] = true;
+        }
 
-        // exit early if market price is lower than order quote ratio
-        if (quote.price < orderDetails.takeOrder.quote!.ratio) {
+        // exit early if market price is lower than order quote ratio, unless
+        // the check is skipped, in which case it goes straight to dryrun
+        if (
+            !this.tradeArgs.skipPriceMatchCheck &&
+            quote.price < orderDetails.takeOrder.quote!.ratio
+        ) {
             this.spanAttributes["error"] = "Order's ratio greater than market price";
             const result = {
                 type,

--- a/src/router/router.test.ts
+++ b/src/router/router.test.ts
@@ -908,6 +908,127 @@ describe("RainSolverRouter", () => {
             balancerSpy.mockRestore();
             sushiSpy.mockRestore();
         });
+
+        describe("locked route", () => {
+            const sushiQuote = {
+                type: RouterType.Sushi,
+                status: RouteStatus.Success,
+                price: 3000n * ONE18,
+                amountOut: 2500000000n,
+                route: { route: {}, pcMap: new Map() },
+            } as any;
+            const lockedArgs: GetTradeParamsArgs = { ...mockArgs, sushiQuote, lockRoute: true };
+
+            it("should only call sushi getTradeParams when locked to a sushi quote", async () => {
+                const sushiResult = Result.ok({
+                    type: RouterType.Sushi,
+                    quote: sushiQuote,
+                    routeVisual: [],
+                    takeOrdersConfigStruct: {} as any,
+                }) as any;
+                const sushiSpy = vi.spyOn(mockSushiRouter, "getTradeParams");
+                sushiSpy.mockResolvedValue(sushiResult);
+                const balancerSpy = vi.spyOn(mockBalancerRouter, "getTradeParams");
+                const stabullSpy = vi.spyOn(mockStabullRouter, "getTradeParams");
+
+                const result = await router.getTradeParams(lockedArgs);
+
+                assert(result.isOk());
+                expect(result.value.type).toBe(RouterType.Sushi);
+                expect(result.value.quote).toBe(sushiQuote);
+                expect(sushiSpy).toHaveBeenCalledWith(lockedArgs);
+                expect(balancerSpy).not.toHaveBeenCalled();
+                expect(stabullSpy).not.toHaveBeenCalled();
+
+                sushiSpy.mockRestore();
+                balancerSpy.mockRestore();
+                stabullSpy.mockRestore();
+            });
+
+            it("should return error when locked sushi getTradeParams fails", async () => {
+                const sushiSpy = vi.spyOn(mockSushiRouter, "getTradeParams");
+                sushiSpy.mockResolvedValue(
+                    Result.err(
+                        new SushiRouterError("sushi error", SushiRouterErrorType.NoRouteFound),
+                    ) as any,
+                );
+                const balancerSpy = vi.spyOn(mockBalancerRouter, "getTradeParams");
+                const stabullSpy = vi.spyOn(mockStabullRouter, "getTradeParams");
+
+                const result = await router.getTradeParams(lockedArgs);
+
+                assert(result.isErr());
+                expect(result.error.message).toContain("Failed to reuse trade route");
+                expect(result.error.typ).toBe(RainSolverRouterErrorType.NoRouteFound);
+                expect(balancerSpy).not.toHaveBeenCalled();
+                expect(stabullSpy).not.toHaveBeenCalled();
+
+                sushiSpy.mockRestore();
+                balancerSpy.mockRestore();
+                stabullSpy.mockRestore();
+            });
+
+            it("should return error when sushi router is not available", async () => {
+                (router.sushi as any) = undefined;
+                const balancerSpy = vi.spyOn(mockBalancerRouter, "getTradeParams");
+                const stabullSpy = vi.spyOn(mockStabullRouter, "getTradeParams");
+
+                const result = await router.getTradeParams(lockedArgs);
+
+                assert(result.isErr());
+                expect(result.error.message).toContain("sushi router is not available");
+                expect(result.error.typ).toBe(RainSolverRouterErrorType.NoRouteFound);
+                expect(balancerSpy).not.toHaveBeenCalled();
+                expect(stabullSpy).not.toHaveBeenCalled();
+
+                balancerSpy.mockRestore();
+                stabullSpy.mockRestore();
+            });
+
+            it("should quote all routers when lockRoute is set without a sushi quote", async () => {
+                const balancerResult = Result.ok({
+                    type: RouterType.Balancer,
+                    quote: {
+                        type: RouterType.Balancer as const,
+                        status: RouteStatus.Success,
+                        price: 3000n * ONE18,
+                        amountOut: 3000000000n,
+                    },
+                    routeVisual: [],
+                    takeOrdersConfigStruct: {} as any,
+                }) as any;
+                const sushiSpy = vi.spyOn(mockSushiRouter, "getTradeParams");
+                sushiSpy.mockResolvedValue(
+                    Result.err(
+                        new SushiRouterError("sushi error", SushiRouterErrorType.NoRouteFound),
+                    ) as any,
+                );
+                const balancerSpy = vi.spyOn(mockBalancerRouter, "getTradeParams");
+                balancerSpy.mockResolvedValue(balancerResult);
+                const stabullSpy = vi.spyOn(mockStabullRouter, "getTradeParams");
+                stabullSpy.mockResolvedValue(
+                    Result.err(
+                        new StabullRouterError(
+                            "stabull error",
+                            StabullRouterErrorType.NoRouteFound,
+                        ),
+                    ) as any,
+                );
+
+                const args: GetTradeParamsArgs = { ...mockArgs, lockRoute: true };
+                const result = await router.getTradeParams(args);
+
+                assert(result.isOk());
+                expect(result.value.type).toBe(RouterType.Balancer);
+                expect(sushiSpy).toHaveBeenCalledWith(args);
+                expect(balancerSpy).toHaveBeenCalledWith(args);
+                expect(stabullSpy).toHaveBeenCalledWith(args);
+
+                sushiSpy.mockRestore();
+                balancerSpy.mockRestore();
+                stabullSpy.mockRestore();
+            });
+        });
     });
 
     describe("test findLargestTradeSize method", () => {

--- a/src/router/router.ts
+++ b/src/router/router.ts
@@ -262,6 +262,26 @@ export class RainSolverRouter extends RainSolverRouterBase {
         } else {
             this.cache.set(key, 1);
         }
+
+        // when the route is locked to the given sushi quote, only the sushi
+        // router builds the trade params from it and no other router gets
+        // quoted, so the given route is reused as is
+        if (args.lockRoute && args.sushiQuote) {
+            if (!this.sushi) {
+                return Result.err(
+                    new RainSolverRouterError(
+                        "Cannot reuse sushi route as the sushi router is not available",
+                        RainSolverRouterErrorType.NoRouteFound,
+                    ),
+                );
+            }
+            const result = await this.sushi.getTradeParams(args);
+            if (result.isErr()) {
+                return Result.err(getError("Failed to reuse trade route", [result]));
+            }
+            return Result.ok(result.value);
+        }
+
         const promises = [
             this.sushi?.getTradeParams(args),
             this.balancer?.getTradeParams(args),

--- a/src/router/types.ts
+++ b/src/router/types.ts
@@ -104,6 +104,14 @@ export type GetTradeParamsArgs = {
      * other routers ignore it
      */
     sushiQuote?: SushiRouterQuote;
+    /**
+     * Locks the trade to the route of the given `sushiQuote`, when set only the
+     * sushi router builds the trade params from it and no other router gets quoted,
+     * the quote may have been found for a different amount, so its price and amount
+     * out do not correspond to the given maximum input and only the route itself
+     * is meant to be used, has no effect without `sushiQuote`
+     */
+    lockRoute?: boolean;
 };
 
 /** Represents the trade params for a RainSolverRouter route */


### PR DESCRIPTION
<!-- Thanks for your Pull Request, please read the contributing guidelines before submitting. -->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## Checks
<!-- It's important you've done these, or your PR will not be considered for review -->
By submitting this for review, I'm confirming I've done the following:
- [x] made this PR as small as possible
- [x] unit-tested any new functionality
- [ ] linked any relevant issues or PRs
- [ ] included screenshots (if this involves a front-end change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added configurable router fallback steps, defaulting to four concurrent halving attempts.
  - Added secondary route retry modes: `all`, `max` (default), or `off`.
  - Router retries can reuse successful route quotes and exclude routes that failed onchain.
  - Added improved route-locking behavior for fallback simulations.

- **Bug Fixes**
  - Router fallback now selects the largest successfully simulated trade size.
  - Retry handling continues appropriately after eligible simulation failures while stopping for non-retryable errors.

- **Documentation**
  - Documented the new router configuration options and defaults.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->